### PR TITLE
Force tests to use local package to avoid CI flakiness

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Ensure tests import the in-repo package (src-layout) instead of any globally
+# installed package named "html2md".
+REPO_SRC = Path(__file__).resolve().parents[1] / 'src'
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,9 +1,15 @@
-
+import os
 import subprocess
+from pathlib import Path
+
 
 def run(cmd):
-    return subprocess.run(cmd, capture_output=True, text=True, shell=True)
+    env = os.environ.copy()
+    repo_src = Path(__file__).resolve().parents[1] / 'src'
+    env['PYTHONPATH'] = str(repo_src) + os.pathsep + env.get('PYTHONPATH', '')
+    return subprocess.run(cmd, capture_output=True, text=True, shell=True, env=env)
+
 
 def test_help_runs():
-    r = run("html2md --help")
+    r = run("python -m html2md --help")
     assert r.returncode == 0, r.stderr


### PR DESCRIPTION
### Motivation
- Tests were resolving a globally installed `html2md` package instead of the repository `src/` package, producing mismatched `/health` payloads and host defaults and causing CI failures. Confidence: high; assumption: I could not inspect the remote CI environment so this diagnosis is inferred from the failure pattern. 

### Description
- Add `tests/conftest.py` to prepend the repository `src/` directory to `sys.path` so test imports resolve the in-repo package. 
- Update `tests/test_cli_smoke.py` to run `python -m html2md --help` and set `PYTHONPATH` in the subprocess environment so the CLI invocation uses the local package. 
- This is a minimal, targeted change aimed at stabilizing test resolution without changing application behavior. 

### Testing
- Ran `pytest -q` after changes and the test suite completed with all tests passing. 
- Installed `flask` (`pip install flask`) in the test environment to satisfy test dependencies and verified tests still pass after installation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff13321988320b318dd9d237b4fcc)