### PR TITLE
Add `actions: read` permission and upgrade CodeQL actions to v4 in workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -7,13 +7,14 @@ on:
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   code-review:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Motivation
- Fix the CodeQL failure `Resource not accessible by integration` by granting the workflow token access to Actions metadata. 
- Avoid future breakage from CodeQL Action v3 deprecation by moving to the supported v4 releases.

### Description
- Updated `.github/workflows/gemini-code-assist.yml` to add `actions: read` under the `permissions` block (after `security-events: write`).
- Upgraded `github/codeql-action/init@v3` to `github/codeql-action/init@v4` and `github/codeql-action/analyze@v3` to `github/codeql-action/analyze@v4` in the workflow steps.
- Changes were saved and committed to the branch containing the workflow file.

### Testing
- Verified the patch with `git diff -- .github/workflows/gemini-code-assist.yml` and inspected the file with `nl -ba .github/workflows/gemini-code-assist.yml`.
- Confirmed repository state with `git status --short` and created a commit using `git add` and `git commit`, which completed successfully.
- All local validation commands executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e2bbe7c083208227c963df08d6bf)