### PR TITLE
Enhance GUI Accessibility with Keyboard Accelerators and Tooltips

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -80,19 +80,21 @@ $xaml = @"
         </Grid.RowDefinitions>
 
         <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14"/>
-        <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Height="80"/>
+        <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Height="80"
+                 ToolTip="Enter one or more URLs (one per line)."/>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal">
-            <TextBox Name="OutBox" Width="340" FontSize="14" AutomationProperties.Name="Output Directory"/>
-            <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">Browse...</Button>
-            <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">Open Folder</Button>
+            <TextBox Name="OutBox" Width="340" FontSize="14" AutomationProperties.Name="Output Directory"
+                     ToolTip="Destination folder for converted files."/>
+            <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
+            <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
                   ToolTip="If checked, includes headers and footers. Default is main content only."/>
 
-        <Button Name="ConvertBtn" Grid.Row="3" Content="Convert (All Formats)"
+        <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 ToolTip="Start conversion process"
                 />


### PR DESCRIPTION
Added keyboard accelerators (mnemonics) to the main action buttons in `gui-url-convert.ps1` (`Browse...` -> `_Browse...`, `Open Folder` -> `_Open Folder`, `Convert` -> `_Convert`).
Added helpful tooltips to the `UrlBox` and `OutBox` text fields to guide users on expected input formats and purposes.
Verified changes by code inspection and existing test suite execution (log export tests passed, cli smoke test failed due to environment but verified manually).

---
*PR created automatically by Jules for task [541428572047672968](https://jules.google.com/task/541428572047672968) started by @badMade*