### PR TITLE
🧹 Refactor hardcoded default port to constant

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -6,32 +6,33 @@ from flask import Flask, jsonify
 
 from html2md import __version__
 
+DEFAULT_PORT = 10000
+
 app = Flask(__name__)
 
 
-@app.route('/health')
+@app.route("/health")
 def health():
     """Return health status of the application."""
-    return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
+    return jsonify({"status": "ok", "service": "html2md", "version": __version__})
 
 
 def get_host_port():
     """Get host and port from environment variables."""
-    default_port = 10000
-    port_str = os.environ.get('PORT')
+    port_str = os.environ.get("PORT")
     try:
-        port_value = int(port_str) if port_str is not None else default_port
+        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
     except ValueError:
         print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
+            f"Warning: Invalid PORT environment variable value "
+            f"{port_str!r}; falling back to default {DEFAULT_PORT}."
         )
-        port_value = default_port
+        port_value = DEFAULT_PORT
 
-    hostname = os.environ.get('HOST', '127.0.0.1')
+    hostname = os.environ.get("HOST", "127.0.0.1")
     return hostname, port_value
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     host, port = get_host_port()
     app.run(host=host, port=port)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,43 +4,43 @@ import importlib
 
 import pytest
 
-pytest.importorskip('flask')
+pytest.importorskip("flask")
 
 
 def test_health_endpoint():
     """Test the health check endpoint."""
-    flask_app_module = importlib.import_module('html2md.app')
+    flask_app_module = importlib.import_module("html2md.app")
     client = flask_app_module.app.test_client()
 
-    response = client.get('/health')
+    response = client.get("/health")
 
     assert response.status_code == 200
     json_response = response.get_json()
-    assert json_response['status'] == 'ok'
-    assert json_response['service'] == 'html2md'
-    assert json_response['version'] == flask_app_module.__version__
+    assert json_response["status"] == "ok"
+    assert json_response["service"] == "html2md"
+    assert json_response["version"] == flask_app_module.__version__
 
 
 def test_get_host_port_defaults(monkeypatch):
     """Test getting host and port with defaults."""
-    monkeypatch.delenv('HOST', raising=False)
-    monkeypatch.delenv('PORT', raising=False)
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
 
-    flask_app_module = importlib.import_module('html2md.app')
+    flask_app_module = importlib.import_module("html2md.app")
     host, port = flask_app_module.get_host_port()
 
-    assert host == '127.0.0.1'
-    assert port == 10000
+    assert host == "127.0.0.1"
+    assert port == flask_app_module.DEFAULT_PORT
 
 
 def test_get_host_port_invalid_port(monkeypatch, capsys):
     """Test getting host and port with invalid port environment variable."""
-    monkeypatch.setenv('HOST', '0.0.0.0')
-    monkeypatch.setenv('PORT', 'invalid')
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    monkeypatch.setenv("PORT", "invalid")
 
-    flask_app_module = importlib.import_module('html2md.app')
+    flask_app_module = importlib.import_module("html2md.app")
     host, port = flask_app_module.get_host_port()
 
-    assert host == '0.0.0.0'
-    assert port == 10000
-    assert 'Invalid PORT environment variable value' in capsys.readouterr().out
+    assert host == "0.0.0.0"
+    assert port == flask_app_module.DEFAULT_PORT
+    assert "Invalid PORT environment variable value" in capsys.readouterr().out


### PR DESCRIPTION
Move the hardcoded default port (10000) in src/html2md/app.py to a module-level constant DEFAULT_PORT.
Update get_host_port() to use this constant.
Update tests/test_app.py to reference the constant in assertions, ensuring tests stay synchronized with the default value.

This improves maintainability and code readability.

---
*PR created automatically by Jules for task [9313411310116928447](https://jules.google.com/task/9313411310116928447) started by @badMade*