### PR TITLE
Restore DEFAULT_PORT and use Flask logger for invalid PORT handling

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -6,6 +6,8 @@ from flask import Flask, jsonify
 
 from html2md import __version__
 
+DEFAULT_PORT = 10000
+
 app = Flask(__name__)
 
 
@@ -17,16 +19,15 @@ def health():
 
 def get_host_port():
     """Get host and port from environment variables."""
-    default_port = 10000
     port_str = os.environ.get('PORT')
     try:
-        port_value = int(port_str) if port_str is not None else default_port
+        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
     except ValueError:
-        print(
+        app.logger.warning(
             f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
         )
-        port_value = default_port
+        port_value = DEFAULT_PORT
 
     hostname = os.environ.get('HOST', '127.0.0.1')
     return hostname, port_value

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 """Tests for the Flask application."""
 
 import importlib
+import logging
 
 import pytest
 
@@ -33,26 +34,15 @@ def test_get_host_port_defaults(monkeypatch):
     assert port == flask_app_module.DEFAULT_PORT
 
 
-def test_get_host_port_invalid_port(monkeypatch, capsys):
+def test_get_host_port_invalid_port(monkeypatch, caplog):
     """Test getting host and port with invalid port environment variable."""
     monkeypatch.setenv('HOST', '0.0.0.0')
     monkeypatch.setenv('PORT', 'invalid')
+    caplog.set_level(logging.WARNING)
 
     flask_app_module = importlib.import_module('html2md.app')
     host, port = flask_app_module.get_host_port()
 
     assert host == '0.0.0.0'
     assert port == flask_app_module.DEFAULT_PORT
-
-
-def test_get_host_port_invalid_port(monkeypatch, capsys):
-    """Test getting host and port with invalid port environment variable."""
-    monkeypatch.setenv('HOST', '0.0.0.0')
-    monkeypatch.setenv('PORT', 'invalid')
-
-    flask_app_module = importlib.import_module('html2md.app')
-    host, port = flask_app_module.get_host_port()
-
-    assert host == '0.0.0.0'
-    assert port == flask_app_module.DEFAULT_PORT
-    assert 'Invalid PORT environment variable value' in capsys.readouterr().err
+    assert 'Invalid PORT environment variable value' in caplog.text


### PR DESCRIPTION
### Motivation
- Fix an inconsistent state introduced during the revert where tests referenced a missing module-level default port and the invalid-`PORT` warning relied on `print()` semantics.
- Ensure the application and tests share a single source of truth for the default port and use Flask-style logging for warnings.

### Description
- Add a module-level `DEFAULT_PORT = 10000` to `src/html2md/app.py` and use it in `get_host_port()` for both normal and fallback paths.
- Replace `print(...)` in the `ValueError` branch with `app.logger.warning(...)` so warnings are emitted via Flask's logger.
- Update `tests/test_app.py` to remove a duplicate `test_get_host_port_invalid_port` and assert the warning via `caplog` (set to `logging.WARNING`) instead of capturing stdout/stderr.
- Keep health endpoint behavior unchanged and ensure tests assert `flask_app_module.__version__` and use `flask_app_module.DEFAULT_PORT` for port expectations.

### Testing
- Ran syntax validation with `python -m py_compile src/html2md/app.py tests/test_app.py`, which succeeded.
- Ran the modified test module with `PYTHONPATH=src pytest tests/test_app.py -vv`, which skipped execution in this environment because `flask` is not installed (tests themselves are updated to use `caplog`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998cb36b5a48320b32d189cd3d6d45f)