### PR TITLE
🧹 Unify Duplicate Default Port Constant

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -19,14 +19,13 @@ def health():
 
 def get_host_port():
     """Get host and port from environment variables."""
-    default_port = 10000
     port_str = os.environ.get('PORT')
     try:
         port_value = int(port_str) if port_str is not None else DEFAULT_PORT
     except ValueError:
         print(
             f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
         )
         port_value = DEFAULT_PORT
 


### PR DESCRIPTION
## 🎯 What
Removed the redundant `default_port` local variable in `get_host_port` function within `src/html2md/app.py`.

## 💡 Why
The local `default_port` variable was a duplicate of the global `DEFAULT_PORT` constant. By using the global constant directly, we ensure consistency and reduce potential for confusion or maintenance errors where the local value might diverge from the actual default used in logic.

## ✅ Verification
Ran `pytest tests/test_app.py` to verify that the default port behavior and error handling remain correct. All tests passed.

## ✨ Result
Cleaner code with a single source of truth for the default port value.

---
*PR created automatically by Jules for task [10936027060898717597](https://jules.google.com/task/10936027060898717597) started by @badMade*