### PR TITLE
Refactor app.py to use global DEFAULT_PORT constant

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -19,14 +19,13 @@ def health():
 
 def get_host_port():
     """Get host and port from environment variables."""
-    default_port = 10000
     port_str = os.environ.get('PORT')
     try:
         port_value = int(port_str) if port_str is not None else DEFAULT_PORT
     except ValueError:
         print(
             f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
         )
         port_value = DEFAULT_PORT
 


### PR DESCRIPTION
Removed a redundant local `default_port` variable in `get_host_port` and replaced it with the global `DEFAULT_PORT` constant. This simplifies the code and ensures consistency.

Verified with mock tests simulating Flask environment.

---
*PR created automatically by Jules for task [5328153396050887638](https://jules.google.com/task/5328153396050887638) started by @badMade*