### PR TITLE
🔒 [Security Fix] Validate URL scheme in CLI

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -3,6 +3,59 @@
 from __future__ import annotations
 import argparse
 import os
+from urllib.parse import urlparse
+
+def process_url(target_url: str, session, outdir: str | None = None) -> None:
+    """Process a single URL."""
+    try:
+        from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        # Should be caught by main before calling this, but for safety
+        print("Error: Missing dependency markdownify.")
+        return
+
+    # Fix common URL typo: trailing slash before query parameters
+    if '/?' in target_url:
+        target_url = target_url.replace('/?', '?')
+
+    # Security check: Only allow http and https schemes
+    parsed = urlparse(target_url)
+    if parsed.scheme not in ('http', 'https'):
+        print(f"Warning: Invalid URL scheme '{parsed.scheme}' for '{target_url}'. Only 'http' and 'https' are supported.")
+        return
+
+    print(f"Processing URL: {target_url}")
+
+    try:
+        print("Fetching content...")
+        response = session.get(target_url, timeout=30)
+        response.raise_for_status()
+
+        print("Converting to Markdown...")
+        md_content = md(response.text, heading_style="ATX")
+
+        if outdir:
+            if not os.path.exists(outdir):
+                os.makedirs(outdir)
+
+            # Create a simple filename based on the URL
+            filename = "conversion_result.md"
+            url_path = target_url.split('?')[0].rstrip('/')
+            if url_path:
+                base = os.path.basename(url_path)
+                if base:
+                    filename = f"{base}.md"
+
+            out_path = os.path.join(outdir, filename)
+            with open(out_path, 'w', encoding='utf-8') as f:
+                f.write(md_content)
+            print(f"Success! Saved to: {out_path}")
+        else:
+            print(md_content)
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Conversion failed: {e}")
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -24,7 +77,8 @@ def main(argv=None):
     if args.url or args.batch:
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
-            from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            # Verify markdownify is present
+            import markdownify  # pylint: disable=unused-import,import-outside-toplevel
         except ImportError as e:
             print(f"Error: Missing dependency {e.name}."
                   "Please run: pip install requests markdownify")
@@ -52,46 +106,8 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def process_url(target_url: str) -> None:
-            """Process a single URL."""
-            # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
-
-            print(f"Processing URL: {target_url}")
-
-            try:
-                print("Fetching content...")
-                response = session.get(target_url, timeout=30)
-                response.raise_for_status()
-
-                print("Converting to Markdown...")
-                md_content = md(response.text, heading_style="ATX")
-
-                if args.outdir:
-                    if not os.path.exists(args.outdir):
-                        os.makedirs(args.outdir)
-
-                    # Create a simple filename based on the URL
-                    filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
-                    if url_path:
-                        base = os.path.basename(url_path)
-                        if base:
-                            filename = f"{base}.md"
-
-                    out_path = os.path.join(args.outdir, filename)
-                    with open(out_path, 'w', encoding='utf-8') as f:
-                        f.write(md_content)
-                    print(f"Success! Saved to: {out_path}")
-                else:
-                    print(md_content)
-
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}")
-
         if args.url:
-            process_url(args.url)
+            process_url(args.url, session, args.outdir)
 
         if args.batch:
             if not os.path.exists(args.batch):
@@ -101,7 +117,7 @@ def main(argv=None):
                 for line in f:
                     u = line.strip()
                     if u:
-                        process_url(u)
+                        process_url(u, session, args.outdir)
 
         return 0
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,0 +1,104 @@
+"""Security tests for CLI URL validation."""
+
+import sys
+import unittest
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+# Mock dependencies before importing the module under test
+sys.modules['requests'] = MagicMock()
+sys.modules['markdownify'] = MagicMock()
+
+from html2md.cli import process_url, main
+
+class TestCliSecurity(unittest.TestCase):
+    def setUp(self):
+        self.session = MagicMock()
+        self.session.headers = {}
+
+        # Reset the mock for markdownify before each test
+        sys.modules['markdownify'].markdownify = MagicMock(return_value="# Mock Markdown")
+
+    def test_valid_https_url(self):
+        """Test that a valid HTTPS URL is processed."""
+        url = "https://example.com"
+        process_url(url, self.session)
+        self.session.get.assert_called_once_with(url, timeout=30)
+
+    def test_valid_http_url(self):
+        """Test that a valid HTTP URL is processed."""
+        url = "http://example.com"
+        process_url(url, self.session)
+        self.session.get.assert_called_once_with(url, timeout=30)
+
+    def test_invalid_scheme_file(self):
+        """Test that file:// scheme is rejected."""
+        url = "file:///etc/passwd"
+        with patch('builtins.print') as mock_print:
+            process_url(url, self.session)
+
+            # verify session.get was NOT called
+            self.session.get.assert_not_called()
+
+            # verify warning was printed
+            found_warning = False
+            for call in mock_print.call_args_list:
+                args, _ = call
+                if "Warning: Invalid URL scheme" in args[0] and "'file'" in args[0]:
+                    found_warning = True
+                    break
+            self.assertTrue(found_warning, "Warning message not printed for file scheme")
+
+    def test_invalid_scheme_ftp(self):
+        """Test that ftp:// scheme is rejected."""
+        url = "ftp://example.com"
+        with patch('builtins.print') as mock_print:
+            process_url(url, self.session)
+            self.session.get.assert_not_called()
+
+            found_warning = False
+            for call in mock_print.call_args_list:
+                args, _ = call
+                if "Warning: Invalid URL scheme" in args[0] and "'ftp'" in args[0]:
+                    found_warning = True
+                    break
+            self.assertTrue(found_warning, "Warning message not printed for ftp scheme")
+
+    def test_no_scheme(self):
+        """Test that URL without scheme is rejected."""
+        url = "example.com"
+        with patch('builtins.print') as mock_print:
+            process_url(url, self.session)
+            self.session.get.assert_not_called()
+
+            found_warning = False
+            for call in mock_print.call_args_list:
+                args, _ = call
+                if "Warning: Invalid URL scheme" in args[0]:
+                    found_warning = True
+                    break
+            self.assertTrue(found_warning, "Warning message not printed for missing scheme")
+
+    def test_batch_flow(self):
+        """Test batch flow invokes process_url for each line."""
+        # Create a real temp file
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("https://good.com\nfile:///bad\nhttp://also-good.com")
+            batch_path = f.name
+
+        try:
+            # We assume main calls process_url, so we mock process_url to check calls
+            with patch('html2md.cli.process_url') as mock_process_url,                  patch('requests.Session', return_value=self.session):
+
+                main(['--batch', batch_path])
+
+                self.assertEqual(mock_process_url.call_count, 3)
+                mock_process_url.assert_any_call("https://good.com", self.session, None)
+                mock_process_url.assert_any_call("file:///bad", self.session, None)
+                mock_process_url.assert_any_call("http://also-good.com", self.session, None)
+        finally:
+            os.remove(batch_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What:** Refactored `process_url` to a module-level function and added validation to only allow `http` and `https` schemes.
**Risk:** Previously, any URL scheme supported by `requests` (or potentially `file://` if the library supported it) could be processed. This fix mitigates potential SSRF or local file inclusion risks if the underlying library were to support them.
**Solution:** Added a check using `urllib.parse.urlparse` to verify the scheme is `http` or `https`. Invalid schemes are logged as warnings and skipped.
**Tests:** Added `tests/test_cli_security.py` to verify valid/invalid schemes and batch processing. Verified existing smoke tests pass.

---
*PR created automatically by Jules for task [10956256675293725531](https://jules.google.com/task/10956256675293725531) started by @badMade*