### PR TITLE
feat(gui): add Clear button to URL input for better UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@ This journal records CRITICAL UX/accessibility learnings.
 Format: `## YYYY-MM-DD - [Title]`
 **Learning:** [UX/a11y insight]
 **Action:** [How to apply next time]
+
+## 2024-05-22 - [The Value of Reset Actions]
+**Learning:** In text-heavy input fields (like batch URL lists), users often make mistakes or want to restart. A simple "Clear" button reduces the friction of manually selecting and deleting text, providing a "delightful" micro-interaction that feels responsive to user intent.
+**Action:** Look for other multi-line text inputs or complex form sections where a "Reset" or "Clear" action would simplify the error recovery flow.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -79,7 +79,14 @@ $xaml = @"
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14"/>
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <Button Name="ClearBtn" Content="C_lear" Grid.Column="1" Width="60" Height="22" Margin="0,0,0,2" VerticalAlignment="Bottom" ToolTip="Clear URL input"/>
+        </Grid>
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Height="80"/>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal">
@@ -120,6 +127,7 @@ $window = [Windows.Markup.XamlReader]::Load($reader)
 
 # --- Get controls ---
 $UrlBox = $window.FindName("UrlBox")
+$ClearBtn = $window.FindName("ClearBtn")
 $OutBox = $window.FindName("OutBox")
 $BrowseBtn = $window.FindName("BrowseBtn")
 $OpenFolderBtn = $window.FindName("OpenFolderBtn")
@@ -131,6 +139,12 @@ $LogBox = $window.FindName("LogBox")
 
 # Set default output to Downloads
 $OutBox.Text = "$env:USERPROFILE\Downloads"
+
+# --- Clear button logic ---
+$ClearBtn.Add_Click({
+    $UrlBox.Clear()
+    $UrlBox.Focus()
+})
 
 # --- Browse button logic ---
 $BrowseBtn.Add_Click({


### PR DESCRIPTION
Added a 'Clear' button to the URL input field in the `gui-url-convert.ps1` WPF GUI to improve user experience when managing batch URLs. This allows users to easily clear the input field with a single click or keyboard shortcut (Alt+L). Also updated the UX journal in `.jules/palette.md`.

---
*PR created automatically by Jules for task [12658156694356837460](https://jules.google.com/task/12658156694356837460) started by @badMade*