### PR TITLE
feat(gui): add "Clear" button to URL input for better UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@ This journal records CRITICAL UX/accessibility learnings.
 Format: `## YYYY-MM-DD - [Title]`
 **Learning:** [UX/a11y insight]
 **Action:** [How to apply next time]
+
+## 2026-02-23 - Inline Reset Actions
+**Learning:** For repetitive input tasks like pasting URLs, users benefit significantly from inline "reset" actions (like a Clear button) to reduce friction compared to manual selection and deletion.
+**Action:** When designing input forms for batch operations, always evaluate if a quick "start over" mechanism is needed near the input field.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -79,7 +79,14 @@ $xaml = @"
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14"/>
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Label Grid.Column="0" Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14"/>
+            <Button Name="ClearBtn" Grid.Column="1" Content="C_lear" Width="60" Height="22" Margin="0,0,0,2" VerticalAlignment="Bottom" ToolTip="Clear URL input"/>
+        </Grid>
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Height="80"/>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal">
@@ -120,6 +127,7 @@ $window = [Windows.Markup.XamlReader]::Load($reader)
 
 # --- Get controls ---
 $UrlBox = $window.FindName("UrlBox")
+$ClearBtn = $window.FindName("ClearBtn")
 $OutBox = $window.FindName("OutBox")
 $BrowseBtn = $window.FindName("BrowseBtn")
 $OpenFolderBtn = $window.FindName("OpenFolderBtn")
@@ -131,6 +139,12 @@ $LogBox = $window.FindName("LogBox")
 
 # Set default output to Downloads
 $OutBox.Text = "$env:USERPROFILE\Downloads"
+
+# --- Clear button logic ---
+$ClearBtn.Add_Click({
+    $UrlBox.Clear()
+    $UrlBox.Focus()
+})
 
 # --- Browse button logic ---
 $BrowseBtn.Add_Click({


### PR DESCRIPTION
Added a "Clear" button next to the URL input field in the PowerShell GUI to allow users to quickly reset the form. This improves usability for batch processing tasks.

**Changes:**
- Modified `gui-url-convert.ps1` to include a "Clear" button in the XAML definition.
- Added PowerShell logic to handle the button click (clear text and focus input).
- Documented UX learning in `.jules/palette.md`.

**Why:**
- Users often paste multiple URLs and need a quick way to start over without manual selection/deletion.
- Improves keyboard accessibility by managing focus after clearing.

---
*PR created automatically by Jules for task [13932307122492183893](https://jules.google.com/task/13932307122492183893) started by @badMade*