### PR TITLE
Refactor: Extract User-Agent and default headers to constants

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import argparse
 import os
 
+from .constants import DEFAULT_REQUEST_HEADERS
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -31,26 +33,7 @@ def main(argv=None):
             return 1
 
         session = requests.Session()
-        session.headers.update({
-            'User-Agent': (
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/120.0.0.0 Safari/537.36'
-            ),
-            'Accept': (
-                'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                'image/avif,image/webp,image/apng,*/*;q=0.8'
-            ),
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://www.google.com/',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'cross-site',
-            'Sec-Fetch-User': '?1',
-        })
+        session.headers.update(DEFAULT_REQUEST_HEADERS)
 
         def process_url(target_url: str) -> None:
             """Process a single URL."""

--- a/src/html2md/constants.py
+++ b/src/html2md/constants.py
@@ -1,0 +1,26 @@
+"""Constants for html2md."""
+
+from __future__ import annotations
+
+USER_AGENT = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/120.0.0.0 Safari/537.36'
+)
+
+DEFAULT_REQUEST_HEADERS = {
+    'User-Agent': USER_AGENT,
+    'Accept': (
+        'text/html,application/xhtml+xml,application/xml;q=0.9,'
+        'image/avif,image/webp,image/apng,*/*;q=0.8'
+    ),
+    'Accept-Language': 'en-US,en;q=0.9',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Referer': 'https://www.google.com/',
+    'Connection': 'keep-alive',
+    'Upgrade-Insecure-Requests': '1',
+    'Sec-Fetch-Dest': 'document',
+    'Sec-Fetch-Mode': 'navigate',
+    'Sec-Fetch-Site': 'cross-site',
+    'Sec-Fetch-User': '?1',
+}

--- a/tests/test_cli_internals.py
+++ b/tests/test_cli_internals.py
@@ -1,0 +1,48 @@
+"""Tests for CLI internals."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+
+# Add src to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+# Use string import to avoid actual import if deps missing
+# But we need main to be imported. It doesn't import deps at top level so safe.
+from html2md.cli import main
+from html2md.constants import DEFAULT_REQUEST_HEADERS
+
+class TestCLIInternals(unittest.TestCase):
+    """Test CLI internals."""
+
+    def test_default_headers_are_used(self):
+        """Test that default headers are applied to the session."""
+
+        # Create mock modules
+        mock_requests = MagicMock()
+        mock_session = MagicMock()
+        mock_requests.Session.return_value = mock_session
+
+        mock_md_module = MagicMock()
+        mock_md_module.markdownify.return_value = "mocked markdown"
+
+        # Inject mocks into sys.modules so imports succeed
+        with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_md_module}):
+            # Setup response for get
+            mock_response = MagicMock()
+            mock_response.text = "<html></html>"
+            mock_session.get.return_value = mock_response
+
+            # Run main
+            # We pass a mocked url
+            exit_code = main(['--url', 'http://example.com'])
+
+            # Verify exit code
+            self.assertEqual(exit_code, 0)
+
+            # Verify update called with DEFAULT_REQUEST_HEADERS
+            mock_session.headers.update.assert_called_with(DEFAULT_REQUEST_HEADERS)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Moved hardcoded User-Agent and other request headers from `src/html2md/cli.py` to `src/html2md/constants.py`. Added unit test to verify headers are applied correctly.

---
*PR created automatically by Jules for task [11333449323338414420](https://jules.google.com/task/11333449323338414420) started by @badMade*