### PR TITLE
🧹 [code health] Replace bare except with specific JSONDecodeError and…

### DIFF
--- a/src/html2md/log_export.py
+++ b/src/html2md/log_export.py
@@ -9,15 +9,24 @@ def main(argv=None):
     ap.add_argument('--fields', default='ts,input,output,status,reason')
     args = ap.parse_args(argv)
     fields = [f.strip() for f in args.fields.split(',') if f.strip()]
-    inp = Path(args.inp); out = Path(args.out)
+    inp = Path(args.inp)
+    out = Path(args.out)
     with inp.open('r', encoding='utf-8') as fi, out.open('w', newline='', encoding='utf-8') as fo:
-        w = csv.DictWriter(fo, fieldnames=fields); w.writeheader()
+        w = csv.DictWriter(fo, fieldnames=fields)
+        w.writeheader()
         for line in fi:
-            line=line.strip();
-            if not line: continue
-            try: rec=json.loads(line)
-            except: continue
-            w.writerow({k:rec.get(k,'') for k in fields})
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if not isinstance(rec, dict):
+                continue
+
+            w.writerow({k: rec.get(k, '') for k in fields})
     return 0
 
 if __name__=='__main__':

--- a/tests/test_log_export.py
+++ b/tests/test_log_export.py
@@ -1,0 +1,38 @@
+
+import json
+import csv
+from pathlib import Path
+from html2md.log_export import main
+
+def test_log_export(tmp_path):
+    log_file = tmp_path / "test.jsonl"
+    out_file = tmp_path / "test.csv"
+
+    log_content = [
+        {"ts": "2023-01-01 00:00:00", "input": "http://example.com", "output": "example.md", "status": "ok", "reason": ""},
+        "invalid json",
+        "[]",
+        "null",
+        "123",
+        "\"string\"",
+        {"ts": "2023-01-01 00:01:00", "input": "http://example.org", "output": "example_org.md", "status": "ok", "reason": ""}
+    ]
+
+    with log_file.open("w", encoding="utf-8") as f:
+        for item in log_content:
+            if isinstance(item, dict):
+                f.write(json.dumps(item) + "\n")
+            else:
+                f.write(item + "\n")
+
+    main(["--in", str(log_file), "--out", str(out_file)])
+
+    assert out_file.exists()
+
+    with out_file.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 2
+    assert rows[0]["input"] == "http://example.com"
+    assert rows[1]["input"] == "http://example.org"


### PR DESCRIPTION
… improve robustness

- Replaced bare `except:` with `except json.JSONDecodeError:` in `src/html2md/log_export.py`.
- Added a type check `isinstance(rec, dict)` to ensure `rec` is a dictionary before calling `.get()`, preserving original robustness.
- Improved code readability by removing semicolons and following PEP 8.
- Added a comprehensive test `tests/test_log_export.py` covering various edge cases.