### PR TITLE
🔒 Fix Terminal Injection in CLI exception output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@ This journal records CRITICAL security learnings, vulnerabilities, and patterns 
 **Vulnerability:** `gui-url-convert.ps1` constructs a command string using unescaped user input (`$url` and `$outdir`) inside a single-quoted string context passed to `powershell -Command`. A malicious URL containing a single quote `'` allows arbitrary PowerShell code execution.
 **Learning:** String concatenation for command construction is dangerous, even in PowerShell. Using `Start-Process -ArgumentList` with an array of arguments is safer than building a command string.
 **Prevention:** Avoid `Invoke-Expression` or `powershell -Command "..."`. Use `& $exe $args` where `$args` is an array, or `Start-Process` with `ArgumentList`.
+
+## 2024-10-24 - Terminal Injection in CLI
+**Vulnerability:** The `cli.py` script directly printed exception messages using `print(f"Conversion failed: {e}")`. If the exception message contained terminal control characters (e.g., ANSI escape sequences `\x1b` or Bell `\x07`), it could allow an attacker to execute terminal injection attacks or manipulate the console output.
+**Learning:** Terminal output from untrusted sources (including external HTTP responses that cause exceptions) must be sanitized before being displayed to the user.
+**Prevention:** Sanitize exception messages or any untrusted output by filtering out non-printable characters, except for necessary whitespace like newlines and tabs. Example: `"".join(c for c in str(e) if c.isprintable() or c in "\n\t\r")`.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 import argparse
 import os
 
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
-        prog='html2md',
-        description='Convert HTML URL to Markdown.'
+        prog="html2md", description="Convert HTML URL to Markdown."
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    ap.add_argument("--help-only", action="store_true", help=argparse.SUPPRESS)
+    ap.add_argument("--url", help="Input URL to convert")
+    ap.add_argument("--batch", help="File containing URLs to process (one per line)")
+    ap.add_argument("--outdir", help="Output directory to save the file")
 
     args = ap.parse_args(argv)
 
@@ -24,39 +24,45 @@ def main(argv=None):
     if args.url or args.batch:
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
-            from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from markdownify import (
+                markdownify as md,
+            )  # pylint: disable=import-outside-toplevel
         except ImportError as e:
-            print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify")
+            print(
+                f"Error: Missing dependency {e.name}."
+                "Please run: pip install requests markdownify"
+            )
             return 1
 
         session = requests.Session()
-        session.headers.update({
-            'User-Agent': (
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/120.0.0.0 Safari/537.36'
-            ),
-            'Accept': (
-                'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                'image/avif,image/webp,image/apng,*/*;q=0.8'
-            ),
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://www.google.com/',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'cross-site',
-            'Sec-Fetch-User': '?1',
-        })
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,image/apng,*/*;q=0.8"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Referer": "https://www.google.com/",
+                "Connection": "keep-alive",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "cross-site",
+                "Sec-Fetch-User": "?1",
+            }
+        )
 
         def process_url(target_url: str) -> None:
             """Process a single URL."""
             # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
+            if "/?" in target_url:
+                target_url = target_url.replace("/?", "?")
 
             print(f"Processing URL: {target_url}")
 
@@ -74,21 +80,24 @@ def main(argv=None):
 
                     # Create a simple filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
+                    url_path = target_url.split("?")[0].rstrip("/")
                     if url_path:
                         base = os.path.basename(url_path)
                         if base:
                             filename = f"{base}.md"
 
                     out_path = os.path.join(args.outdir, filename)
-                    with open(out_path, 'w', encoding='utf-8') as f:
+                    with open(out_path, "w", encoding="utf-8") as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
                     print(md_content)
 
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}")
+                safe_msg = "".join(
+                    c for c in str(e) if c.isprintable() or c in "\n\t\r"
+                )
+                print(f"Conversion failed: {safe_msg}")
 
         if args.url:
             process_url(args.url)
@@ -97,7 +106,7 @@ def main(argv=None):
             if not os.path.exists(args.batch):
                 print(f"Error: Batch file not found: {args.batch}")
                 return 1
-            with open(args.batch, 'r', encoding='utf-8') as f:
+            with open(args.batch, "r", encoding="utf-8") as f:
                 for line in f:
                     u = line.strip()
                     if u:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,0 +1,37 @@
+"""Security tests for CLI."""
+
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+from html2md.cli import main
+
+
+def test_exception_output_sanitization():
+    """Test that terminal control characters in exceptions are sanitized."""
+    # Since requests is imported lazily inside `main`, we need to mock it in sys.modules
+    # or patch the specific variable inside html2md.cli (but it's imported as a local variable).
+    # The easiest way is to mock sys.modules for requests and markdownify.
+
+    mock_requests = MagicMock()
+    mock_session = MagicMock()
+    mock_requests.Session.return_value = mock_session
+
+    # Exception message with ANSI escape sequence (ESC) and Bell (BEL)
+    vuln_msg = "Error: \x1b[31mRed Text\x1b[0m and \x07 bell\n\t."
+    mock_session.get.side_effect = Exception(vuln_msg)
+
+    mock_markdownify = MagicMock()
+
+    with patch.dict(
+        "sys.modules", {"requests": mock_requests, "markdownify": mock_markdownify}
+    ):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main(["--url", "http://example.com"])
+
+            output = mock_stdout.getvalue()
+
+            assert "\x1b" not in output, "Output should not contain ESC characters"
+            assert "\x07" not in output, "Output should not contain BEL characters"
+            assert (
+                "Error: [31mRed Text[0m and  bell\n\t." in output
+            ), "Sanitized output should be printed"


### PR DESCRIPTION
🎯 **What:** The CLI directly printed unhandled exceptions resulting from `requests.get()` without sanitization. An attacker controlling a target server could return a response that triggered an exception containing terminal control characters (ANSI escapes, Bell characters, etc.).
⚠️ **Risk:** If a user attempted to convert a malicious URL, the output exception would be printed to their console, causing a Terminal Injection vulnerability. This could be used to clear the user's terminal, hide malicious output, or inject control characters that manipulate terminal settings.
🛡️ **Solution:** The `str(e)` exception message is now sanitized before being passed to `print()`. A list comprehension iterates through the message and drops any character that is not printable (`c.isprintable()`) or a standard whitespace formatting character (`\n`, `\t`, `\r`). A test suite has been added to `tests/test_cli_security.py` to ensure this specific scenario operates as intended and cleanly filters out control characters without impacting standard text output.

---
*PR created automatically by Jules for task [3415919705679688334](https://jules.google.com/task/3415919705679688334) started by @badMade*