### PR TITLE
🎨 Palette: [UX improvement] Dynamic Convert Button and Keyboard Nav

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@ Format: `## YYYY-MM-DD - [Title]`
 ## 2026-03-08 - Missing Visible Label for Output Directory Input
 **Learning:** Found an input field (`OutBox`) that had `AutomationProperties.Name` and a `ToolTip` but no visible `<Label>`. While this was technically accessible to screen readers, sighted users lacked visual context for what the input was for. `Target="{Binding ElementName=...}"` provides both visual context and an expanded clickable area (especially when combined with mnemonics like `_T` in `Save _To:`).
 **Action:** Always ensure important input fields have visible, associated `<Label>` controls, not just automation properties, to improve usability for all users and provide keyboard mnemonics (Alt+T).
+
+## 2026-03-08 - Keyboard Accelerators & Dynamic Button State
+**Learning:** In WPF/PowerShell XAML, multiple controls can accidentally share the same keyboard accelerator (e.g., Alt+T for "Paste" and "Save To" using `_`). Additionally, primary action buttons should ideally communicate *why* they are disabled when required input is missing.
+**Action:** Always verify that keyboard mnemonics (using `_` in Content/Label) are unique across the UI. Use dynamic `ToolTip` and `IsEnabled` properties on primary buttons, tied to `TextChanged` events of required inputs, to guide users rather than letting them click and fail.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -127,7 +127,7 @@ $xaml = @"
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Height="80"/>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal">
-            <Label Content="Save _To:" Target="{Binding ElementName=OutBox}" FontSize="14" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <Label Content="_Save To:" Target="{Binding ElementName=OutBox}" FontSize="14" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <TextBox Name="OutBox" Width="265" FontSize="14" ToolTip="Directory where files will be saved" VerticalContentAlignment="Center"/>
             <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
             <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
@@ -143,7 +143,7 @@ $xaml = @"
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
-                ToolTip="Start conversion process" IsDefault="True"
+                ToolTip="Please enter at least one URL to enable conversion" IsDefault="True" IsEnabled="False"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>
@@ -183,6 +183,17 @@ $LogBox = $window.FindName("LogBox")
 
 # Set default output to Downloads
 $OutBox.Text = "$env:USERPROFILE\Downloads"
+
+# --- URL Box text changed logic ---
+$UrlBox.Add_TextChanged({
+    if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
+        $ConvertBtn.IsEnabled = $false
+        $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+    } else {
+        $ConvertBtn.IsEnabled = $true
+        $ConvertBtn.ToolTip = "Start conversion process"
+    }
+})
 
 # --- Browse button logic ---
 $BrowseBtn.Add_Click({


### PR DESCRIPTION
🎨 Palette: [UX improvement] Dynamic Convert Button and Keyboard Nav

💡 What: 
- Changed `Save _To:` label to `_Save To:` to resolve a keyboard accelerator conflict (Alt+T was assigned to both Paste and Save To).
- Disabled the `Convert` button by default when the URL input is empty.
- Added a dynamic `ToolTip` to the `Convert` button that explains *why* it is disabled, and updates to "Start conversion process" when text is entered.

🎯 Why: 
Users could previously click the "Convert" button with an empty input field, resulting in an error message. By disabling the button and providing a clear tooltip, we guide the user to provide necessary input first, preventing the error state entirely. Fixing the overlapping Alt+T shortcut also improves keyboard navigation for power users.

♿ Accessibility: 
- Keyboard shortcut conflict resolved (Alt+S for Save To, Alt+T for Paste).
- Improved contextual feedback via dynamic ToolTips on the primary action button.

---
*PR created automatically by Jules for task [14129125404306521870](https://jules.google.com/task/14129125404306521870) started by @badMade*