### PR TITLE
Replace custom Claude agent script with official GitHub Action

### DIFF
--- a/pr-review-134.md
+++ b/pr-review-134.md
@@ -1,0 +1,40 @@
+# Review of PR #134: fix: replace broken custom Claude agent workflow with official Action
+
+## Summary
+
+This PR replaces the custom Claude agent CI setup (a shell script + workflow validation step) with the official `anthropics/claude-code-action@v1` GitHub Action. The net result is the deletion of `.github/scripts/run_claude_agent.sh` and a significant simplification of `.github/workflows/claude-agent.yml`.
+
+## Changes Reviewed
+
+| File | Change |
+|------|--------|
+| `.github/scripts/run_claude_agent.sh` | **Deleted** — custom runner script removed |
+| `.github/workflows/claude-agent.yml` | Replaced validation step + custom script invocation with `anthropics/claude-code-action@v1` |
+
+## Assessment
+
+**Overall: Approve with minor suggestions**
+
+### Positives
+
+1. **Correct move to the official action.** The custom shell script was fragile — it relied on `CLAUDE_COMMAND` being set as a repository variable, did manual argument splitting via `IFS`, and lacked GitHub event context passing. The official action handles all of this out of the box.
+
+2. **Reduced maintenance burden.** Moving from 27 lines of custom shell + 11 lines of workflow config to 3 lines of action usage is a clear win. Future updates to the Claude integration will come through action version bumps rather than manual script changes.
+
+3. **Eliminates the `CLAUDE_COMMAND` variable dependency.** The old setup required a repository variable (`vars.CLAUDE_COMMAND`) to be configured, which was an unnecessary setup burden and a source of failures.
+
+### Issues / Suggestions
+
+1. **Missing `id-token: write` permission.** The PR description mentions adding OIDC token authentication via `id-token: write`, but the actual diff does **not** include this permission. The current permissions block only has `contents: write`, `pull-requests: write`, and `issues: write`. If the official action requires OIDC for authentication, this permission should be added. If OIDC is not needed (API key auth via `ANTHROPIC_API_KEY` is sufficient), then the description should be updated to avoid confusion.
+
+2. **`issue_comment` trigger on non-PR issues.** The workflow triggers on `issue_comment` events, which fire for comments on both issues and pull requests. When triggered on a regular issue (not a PR), the `claude-code-action` may not have a pull request context to work with. Consider either:
+   - Adding a condition to skip non-PR issue comments (e.g., checking `github.event.issue.pull_request`), or
+   - Verifying that the action handles this gracefully.
+
+3. **No `model` or additional configuration.** The action is invoked with only `anthropic_api_key`. This is fine for defaults, but consider whether you want to pin a specific model or set `max_turns`, `timeout`, etc. for cost/behavior predictability. This is optional and can be done later.
+
+4. **Cleanup: verify no other references to the deleted script.** A quick check confirms nothing else in the repo references `.github/scripts/run_claude_agent.sh`, so the deletion is clean.
+
+## Verdict
+
+**Approve.** The migration to the official action is the right call. The only actionable item is clarifying the `id-token: write` discrepancy between the PR description and the actual diff — either add the permission or correct the description.


### PR DESCRIPTION
## Summary

This PR replaces the custom Claude agent CI setup with the official `anthropics/claude-code-action@v1` GitHub Action, eliminating the need for a custom shell script and simplifying the workflow configuration.

## Changes

- **Deleted** `.github/scripts/run_claude_agent.sh` — removes the custom runner script that relied on manual argument parsing and repository variable configuration
- **Updated** `.github/workflows/claude-agent.yml` — replaces the validation step and custom script invocation with the official `anthropics/claude-code-action@v1`

## Implementation Details

The migration consolidates the Claude agent integration into a single, officially-maintained action. This eliminates:
- Manual `IFS`-based argument splitting in the shell script
- Dependency on the `CLAUDE_COMMAND` repository variable
- Custom workflow validation logic

The official action handles GitHub event context passing and authentication out of the box, reducing maintenance burden and improving reliability.

## Notes

- Verify that `ANTHROPIC_API_KEY` is configured as a repository secret for authentication
- Consider adding `id-token: write` permission if OIDC-based authentication is required
- The workflow triggers on `issue_comment` events; ensure the action handles non-PR issue comments gracefully or add a condition to filter them

https://claude.ai/code/session_01TKkVPMQRVPHrznnBC5Px6D