### PR TITLE
🎨 Palette: [UX improvement] Responsive Output Directory row in GUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@ Format: `## YYYY-MM-DD - [Title]`
 ## 2024-10-18 - WPF Default Text Contrast
 **Learning:** The default `Gray` color in WPF (and many UI frameworks) often fails WCAG AA contrast guidelines on light backgrounds (approx 3.95:1). For status text or hints, use a darker shade like `#555555` to ensure readability for all users while maintaining visual hierarchy.
 **Action:** Always verify color contrast ratios for "subtle" text colors using a contrast checker.
+
+## 2024-11-20 - WPF Layouts: StackPanel vs Grid
+**Learning:** Hardcoding sizes in a `StackPanel` (e.g., setting a fixed width for a `TextBox`) results in poor responsive behavior when resizing a window. A `Grid` with `*` and `Auto` sizing creates a fluid interface. In addition, providing a visible `<Label>` with an explicit `Target` binding (using `ElementName`) is critical for screen readers and providing keyboard mnemonics, whereas `AutomationProperties.Name` on the input only helps screen readers but leaves visual and keyboard users without cues.
+**Action:** Always use a `Grid` for forms where inputs should stretch alongside fixed-size buttons. Always pair inputs with a visible `<Label>` that has a mnemonic and a `Target` binding.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -95,11 +95,18 @@ $xaml = @"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
                  ToolTip="Enter one or more URLs (one per line)"/>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal">
-            <TextBox Name="OutBox" Width="340" FontSize="14" AutomationProperties.Name="Output Directory" ToolTip="Directory where files will be saved"/>
-            <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-            <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
-        </StackPanel>
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Label Content="_Save To:" Target="{Binding ElementName=OutBox}" FontSize="14" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <TextBox Name="OutBox" Grid.Column="1" Height="28" VerticalContentAlignment="Center" FontSize="14" AutomationProperties.Name="Output Directory" ToolTip="Directory where files will be saved"/>
+            <Button Name="BrowseBtn" Grid.Column="2" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
+            <Button Name="OpenFolderBtn" Grid.Column="3" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+        </Grid>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"


### PR DESCRIPTION
Replaced the StackPanel for the output directory row with a responsive Grid layout in `gui-url-convert.ps1`. This ensures the input stretches properly when the window is resized. Also added an explicit `Label` with a mnemonic (`Alt+S`) and a `Target` binding to improve accessibility for keyboard users and screen readers. Additionally, documented the UX insights in `.jules/palette.md`.

---
*PR created automatically by Jules for task [4069976761720367401](https://jules.google.com/task/4069976761720367401) started by @badMade*