### PR TITLE
Add pytest coverage for CLI URL scheme validation and path-traversal defenses

### DIFF
--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,22 +1,25 @@
 """Security-focused tests for CLI URL and output path handling."""
 
 from unittest.mock import MagicMock, patch
+import pytest
 
 from html2md import cli
 
 
-@patch("requests.Session.get")
-def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path):
-    """Unsupported schemes are rejected before any network call."""
-    for url, scheme in [
+@pytest.mark.parametrize(
+    "url, scheme",
+    [
         ("file:///etc/passwd", "file"),
         ("ftp://example.com/data.txt", "ftp"),
         ("example.com/data.txt", ""),
-    ]:
-        cli.main(["--url", url, "--outdir", str(tmp_path)])
-        outerr = capsys.readouterr()
-        assert f"Error: Unsupported URL scheme '{scheme}'." in outerr.err
-
+    ],
+)
+@patch("requests.Session.get")
+def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme):
+    """Unsupported schemes are rejected before any network call."""
+    cli.main(["--url", url, "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+    assert f"Error: Unsupported URL scheme '{scheme}'." in outerr.err
     mock_get.assert_not_called()
 
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,0 +1,50 @@
+"""Security-focused tests for CLI URL and output path handling."""
+
+from unittest.mock import MagicMock, patch
+
+from html2md import cli
+
+
+@patch("requests.Session.get")
+def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path):
+    """Unsupported schemes are rejected before any network call."""
+    for url, scheme in [
+        ("file:///etc/passwd", "file"),
+        ("ftp://example.com/data.txt", "ftp"),
+        ("example.com/data.txt", ""),
+    ]:
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
+        outerr = capsys.readouterr()
+        assert f"Error: Unsupported URL scheme '{scheme}'." in outerr.err
+
+    mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
+    """Traversal-like URL paths must never write outside of --outdir."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("secret content", encoding="utf-8")
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    urls = [
+        "http://example.com/foo/../..%2Fsecret.txt",
+        "http://example.com/foo/%2E%2E%2F%2E%2E%2Fsecret.txt",
+    ]
+
+    for url in urls:
+        cli.main(["--url", url, "--outdir", str(outdir)])
+        outerr = capsys.readouterr()
+        assert "Success!" in outerr.out
+
+    # Ensure any output files are contained under --outdir.
+    assert all(path.is_file() for path in outdir.rglob("*.md"))
+    assert secret_file.read_text(encoding="utf-8") == "secret content"
+    assert not (tmp_path / "secret.txt.md").exists()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -45,6 +45,6 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
-    assert all(path.is_file() for path in outdir.rglob("*.md"))
+    assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()


### PR DESCRIPTION
### Motivation
- Add automated tests to cover the URL scheme rejection (non-HTTP/HTTPS) and output-path traversal defenses recently implemented in the CLI so regressions in these security boundaries are caught. 

### Description
- Added a new test module `tests/test_cli_security.py` that exercises `cli.main` for unsupported schemes and traversal-like URL paths. 
- `test_process_url_unsupported_scheme` patches `requests.Session.get` and asserts `file://`, `ftp://`, and no-scheme inputs produce the expected error and do not trigger network calls. 
- `test_traversal_like_paths_stay_within_outdir` creates an `--outdir`, writes a sentinel `secret.txt`, mocks a successful HTTP response, invokes `cli.main` on encoded/mixed traversal-like URLs, and asserts outputs are only created under `--outdir` and the sentinel file is unchanged. 

### Testing
- Ran a bytecode/compile check with `python3 -m compileall -q src tests` which completed successfully. 
- Attempted to run `PYTHONPATH=src python3 -m pytest -q tests/test_cli_security.py` but `pytest` is not available in this environment, so the test run could not be executed here. 
- Attempts to install `pytest` (`python3 -m pip install pytest`) failed because `pip` is not available in the configured toolchain, so CI/test execution should be performed in the project CI or a developer environment where `pytest`/`pip` are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8cb651988320b62d7c118aefac55)