### PR TITLE
🎨 Palette: Add visual label to Output Directory field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@ Format: `## YYYY-MM-DD - [Title]`
 ## 2024-10-18 - WPF Default Text Contrast
 **Learning:** The default `Gray` color in WPF (and many UI frameworks) often fails WCAG AA contrast guidelines on light backgrounds (approx 3.95:1). For status text or hints, use a darker shade like `#555555` to ensure readability for all users while maintaining visual hierarchy.
 **Action:** Always verify color contrast ratios for "subtle" text colors using a contrast checker.
+
+## 2024-10-24 - Explicit Labeling and Mnemonics in WPF
+**Learning:** Sighted keyboard users often rely on visual labels to understand the purpose of input fields. While `AutomationProperties.Name` serves screen readers, it's essential to pair it with a visual `<Label>` that sets `Target="{Binding ElementName=...}"`. Furthermore, when assigning access keys (mnemonics like `_D`), it is crucial to audit adjacent buttons and fields (e.g., `_Browse...` and `_Open Folder`) to avoid conflicting access keys.
+**Action:** Always provide explicit visible labels for input fields unless visually redundant, and double-check mnemonic uniqueness within the form context.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -95,10 +95,13 @@ $xaml = @"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
                  ToolTip="Enter one or more URLs (one per line)"/>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal">
-            <TextBox Name="OutBox" Width="340" FontSize="14" AutomationProperties.Name="Output Directory" ToolTip="Directory where files will be saved"/>
-            <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-            <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+        <StackPanel Grid.Row="2" Orientation="Vertical">
+            <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBox Name="OutBox" Width="340" FontSize="14" AutomationProperties.Name="Output Directory" ToolTip="Directory where files will be saved"/>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+            </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"


### PR DESCRIPTION
💡 What: Added a visual `<Label>` (`Output _Directory:`) above the Output Directory `TextBox` and bound it to the input field using `Target="{Binding ElementName=OutBox}"`.
🎯 Why: The Output Directory input field lacked a visual label, forcing sighted users to infer its purpose from the default path or adjacent buttons. Keyboard users also lacked a direct shortcut to focus the field.
📸 Before/After: N/A (WPF application)
♿ Accessibility: Improved keyboard navigation with the `Alt+D` mnemonic and provided visual context for the `OutBox` element.
📝 Journaled: Added an entry to `.jules/palette.md` explaining the discovery of mnemonic conflicts and the importance of checking existing mnemonics when adding new labels in WPF.

---
*PR created automatically by Jules for task [4255268247666777100](https://jules.google.com/task/4255268247666777100) started by @badMade*