### PR TITLE
🛡️ Sentinel: [MEDIUM] Multiple security and robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+.venv/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2024-03-10 - Uninitialized variable leading to command execution errors
+**Vulnerability:** In `gui-url-convert.ps1`, the PowerShell `$bat` variable was used in an executed `cmd.exe` command line string (`$psi.Arguments = "/c ""$bat" ..."`) but `$bat` was never initialized.
+**Learning:** Shell-wrapping with uninitialized variables can result in unexpected and potentially dangerous command interpretation (though here it likely resulted in command failure). PowerShell's default behavior allows referencing undefined variables.
+**Prevention:** Strictly run PowerShell with strict mode (`Set-StrictMode`) or thoroughly verify variable definitions via linters before using them in execution contexts.
+
+## 2024-03-10 - Pre-emptive SSRF Protection in URL parsing tools
+**Vulnerability:** The CLI `process_url` accepted URLs pointing to localhost and internal loopbacks.
+**Learning:** CLI tools handling user URLs are often deployed in server environments where internal network access via SSRF is a critical risk. Validating scheme (`http/https`) alone is not sufficient; checking the resolved IP address using `socket` and `ipaddress` against private IP ranges provides stronger defense.
+**Prevention:** Always implement IP-level restrictions alongside scheme and input validation when performing automated outbound requests.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -322,6 +322,7 @@ $ConvertBtn.Add_Click({
     # 2. Use the "double-quote wrapper" for cmd /c (i.e., /c ""command" args")
     #    to ensure all internal quotes are preserved and arguments are correctly delimited.
     # 3. Explicitly quote each argument to prevent metacharacters like & from being interpreted.
+    $bat = "run-html2md.bat"
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = "cmd.exe"
     $psi.Arguments = "/c `"`"$bat`" --url `"$url`" --outdir `"$outdir`" --all-formats`""

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,15 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -117,10 +117,9 @@ def main(argv=None):
                               file=sys.stderr)
                         return
 
-                    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
                     # Open with restrictive permissions (read/write for owner only)
-                    fd = os.open(out_path, flags, 0o600)
-                    with open(fd, 'w', encoding='utf-8') as f:
+                    with open(out_path, 'w', encoding='utf-8') as f:
+                        os.chmod(out_path, 0o600)
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -117,9 +117,10 @@ def main(argv=None):
                               file=sys.stderr)
                         return
 
+                    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
                     # Open with restrictive permissions (read/write for owner only)
-                    with open(out_path, 'w', encoding='utf-8') as f:
-                        os.chmod(out_path, 0o600)
+                    fd = os.open(out_path, flags, 0o600)
+                    with open(fd, 'w', encoding='utf-8') as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 import argparse
+import ipaddress
 import os
+import socket
 import sys
 from urllib.parse import urlparse, unquote
 
@@ -66,6 +68,21 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return
 
+            # SSRF Protection: Block localhost and internal IPs
+            if parsed.hostname:
+                try:
+                    ip = socket.gethostbyname(parsed.hostname)
+                    ip_obj = ipaddress.ip_address(ip)
+                    if ip_obj.is_private or ip_obj.is_loopback:
+                        print(f"Error: Access to internal IP or localhost is blocked "
+                              f"for security reasons.", file=sys.stderr)
+                        return
+                except socket.gaierror:
+                    # Ignore resolution errors here; requests will fail naturally
+                    pass
+                except ValueError:
+                    pass
+
             print(f"Processing URL: {target_url}")
 
             try:
@@ -99,7 +116,11 @@ def main(argv=None):
                         print("Error: Output path escapes output directory.",
                               file=sys.stderr)
                         return
-                    with open(out_path, 'w', encoding='utf-8') as f:
+
+                    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+                    # Open with restrictive permissions (read/write for owner only)
+                    fd = os.open(out_path, flags, 0o600)
+                    with open(fd, 'w', encoding='utf-8') as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -36,16 +36,17 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
-                             try:
-                                 main(['--url', 'http://example.com', '--outdir', 'dummy'])
-                             except Exception as e:
-                                 self.fail(f"main raised exception {e}")
+                        with patch('os.open', side_effect=OSError("Permission denied")):
+                            with patch('builtins.open'):
+                                 try:
+                                     main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                                 except Exception as e:
+                                     self.fail(f"main raised exception {e}")
 
-                             output = captured_stderr.getvalue()
-                             # Expect "File error: Permission denied"
-                             self.assertIn("File error", output)
-                             self.assertIn("Permission denied", output)
+                                 output = captured_stderr.getvalue()
+                                 # Expect "File error: Permission denied"
+                                 self.assertIn("File error", output)
+                                 self.assertIn("Permission denied", output)
 
     def test_outdir_containment_uses_path_aware_check(self):
         """Test that output containment check rejects prefix-matching escapes."""
@@ -59,7 +60,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        with patch('os.open') as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'


### PR DESCRIPTION
As part of an ongoing security audit, I have implemented four enhancements across the `html2md` toolchain:

1. **Uninitialized Variable (`gui-url-convert.ps1`)**: Discovered and fixed a bug where the `$bat` variable was used without initialization, causing `cmd.exe` to fail correctly launching `run-html2md.bat`.
2. **SSRF Mitigation (`cli.py`)**: Added validation to block URL scheme inputs resolving to localhost or private IPs.
3. **File Permission Hardening (`cli.py`)**: Output markdown files are now created with strict `0o600` permissions via `os.open`, preventing broader access if downloaded to a shared environment.
4. **Flask Security Headers (`app.py`)**: Applied standard security headers including HSTS, `X-Frame-Options: DENY`, and `X-Content-Type-Options: nosniff`.

---
*PR created automatically by Jules for task [9520810057407992157](https://jules.google.com/task/9520810057407992157) started by @badMade*