### PR TITLE
🎨 Palette: Show tooltip on disabled Convert button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-30 - [Show tooltips on disabled buttons in WPF GUI]
+**Learning:** In WPF applications (like `gui-url-convert.ps1`), elements that are disabled (`IsEnabled="False"`) do not display their `ToolTip` by default. This hides important context (e.g., *why* the button is disabled) from the user.
+**Action:** Whenever using `IsEnabled="False"` on a button with an explanatory `ToolTip`, explicitly add `ToolTipService.ShowOnDisabled="True"` to ensure the tooltip is visible when hovering over the disabled control.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -112,6 +112,7 @@ $xaml = @"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"
+                ToolTipService.ShowOnDisabled="True"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
💡 **What**: Added `ToolTipService.ShowOnDisabled="True"` to the `ConvertBtn` in `gui-url-convert.ps1`.
🎯 **Why**: When users open the app, the Convert button is disabled. It has a helpful tooltip explaining *why* it's disabled ("Please enter at least one URL to enable conversion"), but in WPF, tooltips do not show on disabled elements by default. This makes that helpful context visible.
♿ **Accessibility**: Improves clarity for users relying on tooltips for context and prevents confusion on why the primary action is unavailable. Also updated the `.jules/palette.md` journal to capture this WPF-specific UX pattern.

---
*PR created automatically by Jules for task [3313208094138267225](https://jules.google.com/task/3313208094138267225) started by @badMade*