### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure default host binding in Flask app

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [Secure Default Host Binding]
+**Vulnerability:** The Flask application in `app.py` was defaulting to binding on `0.0.0.0` (all interfaces) if the `HOST` environment variable was not set.
+**Learning:** Defaulting to `0.0.0.0` can unintentionally expose local development servers or internal services to the network, increasing the attack surface.
+**Prevention:** Always default network services to bind to `127.0.0.1` (localhost) unless explicitly configured otherwise via environment variables or configuration files. This enforces a secure-by-default posture.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -30,7 +30,9 @@ def get_host_port():
         )
         port_value = DEFAULT_PORT
 
-    hostname = os.environ.get('HOST', '0.0.0.0')
+    # Default to 127.0.0.1 (localhost) to prevent unintended network exposure.
+    # Users must explicitly set HOST=0.0.0.0 if public exposure is required.
+    hostname = os.environ.get('HOST', '127.0.0.1')
     return hostname, port_value
 
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure default host binding in Flask app

🚨 Severity: MEDIUM
💡 Vulnerability: The Flask app was defaulting to bind to `0.0.0.0` (all network interfaces), potentially exposing the local server to the external network unintentionally.
🎯 Impact: Unauthorized users on the same network could access endpoints (e.g. `/health`), expanding the attack surface unnecessarily.
🔧 Fix: Changed the default host to `127.0.0.1` (localhost). Users who need external access must now explicitly set `HOST=0.0.0.0`.
✅ Verification: Review the code to confirm the fallback in `os.environ.get('HOST', '127.0.0.1')` is correct. Tested that the app still functions.

---
*PR created automatically by Jules for task [9701849349507077466](https://jules.google.com/task/9701849349507077466) started by @badMade*