### PR TITLE
🎨 Palette: [Show tooltip on disabled Convert button]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Show Tooltip on Disabled WPF Controls]
+**Learning:** By default, WPF hides tooltips on disabled controls (like buttons). This prevents users from understanding *why* a control is disabled if the explanation is in the tooltip.
+**Action:** Add `ToolTipService.ShowOnDisabled="True"` to controls with a helpful `ToolTip` property when they can be in an `IsEnabled="False"` state.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -112,6 +112,7 @@ $xaml = @"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"
+                ToolTipService.ShowOnDisabled="True"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
💡 What: Added `ToolTipService.ShowOnDisabled="True"` to the Convert button in the WPF GUI (`gui-url-convert.ps1`) and recorded this learning in `.jules/palette.md`.
🎯 Why: By default, WPF hides tooltips when a control is disabled. The Convert button has a helpful tooltip ("Please enter at least one URL to enable conversion") explaining *why* it's disabled, but users couldn't see it. This makes the interface more intuitive and accessible.
♿ Accessibility: Ensures users reliant on tooltips to understand interface state have access to the information even when the control cannot be interacted with.

---
*PR created automatically by Jules for task [13330904685283002483](https://jules.google.com/task/13330904685283002483) started by @badMade*