### PR TITLE
🎨 Palette: Improve error text color contrast & fix typos

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-10-25 - [Ensure Accessible Error Colors in WPF]
+**Learning:** Using the default "Red" (`#FF0000`) for error text in WPF status bars/labels fails WCAG AA contrast ratio requirements (4.5:1) against standard gray/white backgrounds (actual contrast is ~3.5:1 to 3.9:1).
+**Action:** Use a darker red like `#D32F2F` or `DarkRed` (`#8B0000`) for error states to maintain accessibility and readability while providing clear visual feedback.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -172,7 +172,7 @@ $OpenFolderBtn.Add_Click({
         Invoke-Item -LiteralPath $path
     } else {
         $StatusText.Text = "Output folder does not exist."
-        $StatusText.Foreground = "Red"
+        $StatusText.Foreground = "DarkRed"
     }
 })
 
@@ -237,8 +237,7 @@ $PasteBtn.Add_Click({
         }
     } catch {
         $StatusText.Text = "Error pasting from clipboard."
-        $StatusText.Foreground = "Red"
-        $StatusText.Foreground = "Red"
+        $StatusText.Foreground = "DarkRed"
     }
 })
 
@@ -272,7 +271,7 @@ $ConvertBtn.Add_Click({
 
     if ($urlList.Count -eq 0) {
         $StatusText.Text = "Please enter a URL."
-        $StatusText.Foreground = "Red"
+        $StatusText.Foreground = "DarkRed"
         return
     }
 
@@ -319,7 +318,7 @@ $ConvertBtn.Add_Click({
         if (Get-Command "python3" -ErrorAction SilentlyContinue) { $pyCmd = "python3" }
         else {
             $StatusText.Text = "Error: Python not found in PATH."
-            $StatusText.Foreground = "Red"
+            $StatusText.Foreground = "DarkRed"
             $LogBox.AppendText("ERROR: 'python' command not found. Please install Python.`r`n")
             $ProgressBar.IsIndeterminate = $false
             return
@@ -376,7 +375,7 @@ $ConvertBtn.Add_Click({
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."
-            $StatusText.Foreground = "Red"
+            $StatusText.Foreground = "DarkRed"
             $LogBox.AppendText("ERROR: Could not find .venv\Scripts\html2md.exe or html2md.py in $scriptDir`r`n")
             $LogBox.AppendText("Have you run setup-html2md.ps1?`r`n")
             $ProgressBar.IsIndeterminate = $false

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -28,7 +28,7 @@ def main(argv=None):
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
             from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
         except ImportError as e:
-            print(f"Error: Missing dependency {e.name}."
+            print(f"Error: Missing dependency {e.name}. "
                   "Please run: pip install requests markdownify", file=sys.stderr)
             return 1
 


### PR DESCRIPTION
💡 **What:**
- Replaced the default `"Red"` color for error messages in the `gui-url-convert.ps1` WPF UI with `"DarkRed"`.
- Removed a duplicate line setting the foreground color.
- Added a missing space in a CLI error message string in `src/html2md/cli.py`.
- Added a new entry to the `.jules/palette.md` journal documenting the contrast ratio issue.

🎯 **Why:**
Using the default "Red" (`#FF0000`) on standard light gray/white backgrounds (like `#F0F0F0`) has a contrast ratio of roughly 3.5:1 to 3.9:1, which fails WCAG AA guidelines for normal text (requires 4.5:1). Switching to "DarkRed" (`#8B0000`) provides a contrast ratio of over 9:1, guaranteeing excellent readability and AAA accessibility compliance for error messages. The CLI typo fix improves readability of the terminal output.

♿ **Accessibility:**
- Improved color contrast for all error state feedback in the GUI, ensuring users with visual impairments can easily read failure notifications.

---
*PR created automatically by Jules for task [1248872625603220684](https://jules.google.com/task/1248872625603220684) started by @badMade*