### PR TITLE
🎨 Palette: Replace blocking message boxes with inline status messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2024-06-12 - [Replace Blocking Message Boxes with Non-Blocking Status Bar Messages]
+**Learning:** For WPF applications using XAML to define UI, modal dialogs like `MessageBox` block the main interface and disrupt the user's flow, especially for common validation tasks like invalid URLs or invalid characters in file paths. In applications with an established non-blocking status bar pattern, it provides a much more intuitive and pleasant experience to use the status bar instead of modal popup dialogues for validation feedback.
+**Action:** When performing validation in UI scripts, prefer using a non-blocking `StatusText` element (along with resetting any loading states like `ProgressBar.IsIndeterminate`) rather than raising a modal `MessageBox`, thereby keeping the user in their workflow.
+
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -285,13 +285,17 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
+        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------


### PR DESCRIPTION
**What:** The UX enhancement replaced modal message boxes for invalid URLs and output directories in `gui-url-convert.ps1` with non-blocking inline status messages on the `StatusText` element.
**Why:** Modal dialogs disrupt the user flow, forcing them to physically dismiss the message before returning to correct their input. Inline validation provides immediate, non-blocking feedback and is a better UX pattern.
**Accessibility:** Setting the status message directly utilizes the existing WPF status bar which, based on prior journal entries, already has `AutomationProperties.LiveSetting="Polite"` for screen readers to announce updates seamlessly.

---
*PR created automatically by Jules for task [6655620040585429305](https://jules.google.com/task/6655620040585429305) started by @badMade*