### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS via Memory Exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Prevent DoS from Large Remote Payloads
+**Vulnerability:** When fetching external URLs for conversion (e.g., using `requests.get()`), the application read the entire response into memory at once without bounds checking or streaming. This introduces a Denial of Service (DoS) vulnerability via memory exhaustion, where a malicious server could provide an extremely large file or infinite stream.
+**Learning:** For a CLI that ingests data from external networks, the risk of a "bomb" file is high, and robust streaming + chunked reading are required to handle content safely.
+**Prevention:** Always use `stream=True` in HTTP requests when fetching arbitrary user-specified URLs. Read the data in chunks using `iter_content`, enforcing a strict maximum size (e.g., 10MB), and abort the fetch if the payload exceeds this limit. Also check the `Content-Length` header beforehand as a fast fail-safe.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -70,11 +70,39 @@ def main(argv=None):
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                # Fetch in stream mode to prevent loading massive payloads into memory (DoS risk)
+                response = session.get(target_url, timeout=30, stream=True)
                 response.raise_for_status()
 
+                # Limit payload size to 10MB to prevent memory exhaustion
+                MAX_SIZE = 10 * 1024 * 1024
+                content_length = response.headers.get("Content-Length")
+                if content_length and int(content_length) > MAX_SIZE:
+                    print(f"Error: Content length ({content_length} bytes) exceeds maximum allowed size.", file=sys.stderr)
+                    return
+
+                content = b""
+                # response.iter_content might not be iterable on mocked MagicMock responses in tests.
+                # Adding a fallback check or making sure it decodes safely
+                if hasattr(response, "iter_content"):
+                    for chunk in response.iter_content(chunk_size=8192):
+                        content += chunk
+                        if len(content) > MAX_SIZE:
+                            print(f"Error: Downloaded content exceeds maximum allowed size.", file=sys.stderr)
+                            return
+                else:
+                    content = response.content
+                    if len(content) > MAX_SIZE:
+                        print(f"Error: Downloaded content exceeds maximum allowed size.", file=sys.stderr)
+                        return
+
+                enc = response.encoding
+                if not isinstance(enc, str):
+                    enc = "utf-8"
+                text = content.decode(enc, errors="replace")
+
                 print("Converting to Markdown...")
-                md_content = md(response.text, heading_style="ATX")
+                md_content = md(text, heading_style="ATX")
 
                 if args.outdir:
                     if not os.path.exists(args.outdir):

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -59,7 +59,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        with patch('html2md.cli.open', create=True) as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -51,3 +51,39 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+@patch("requests.Session.get")
+def test_large_response_content_length_rejected(mock_get, capsys):
+    """Test that responses with a Content-Length exceeding the limit are rejected."""
+    response = MagicMock()
+    response.headers = {"Content-Length": str(10 * 1024 * 1024 + 1)}
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://example.com/large"])
+    outerr = capsys.readouterr()
+
+    assert "Error: Content length" in outerr.err
+    assert "exceeds maximum allowed size" in outerr.err
+
+
+@patch("requests.Session.get")
+def test_large_response_streaming_rejected(mock_get, capsys):
+    """Test that streaming responses exceeding the limit are rejected."""
+    response = MagicMock()
+    response.headers = {}
+    response.raise_for_status.return_value = None
+
+    # Mock iter_content to yield chunks that eventually exceed the limit
+    def fake_iter_content(chunk_size):
+        yield b"a" * (5 * 1024 * 1024)
+        yield b"b" * (6 * 1024 * 1024)
+
+    response.iter_content = fake_iter_content
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://example.com/stream"])
+    outerr = capsys.readouterr()
+
+    assert "Error: Downloaded content exceeds maximum allowed size" in outerr.err


### PR DESCRIPTION
This PR fixes a DoS vulnerability caused by unbounded memory consumption when downloading files from external URLs. The CLI now streams the HTTP response in chunks and aborts if the payload size exceeds a strict 10MB limit. Both the `Content-Length` header (for early exit) and the actual streamed content size are validated. Covered by tests.

---
*PR created automatically by Jules for task [8298895853542038252](https://jules.google.com/task/8298895853542038252) started by @badMade*