### PR TITLE
Refactor cli.py for testability and add batch empty line test

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,66 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
+def process_url(target_url: str, session, args, md_func) -> None:
+    """Process a single URL."""
+    import requests  # type: ignore
+
+    # Fix common URL typo: trailing slash before query parameters
+    if '/?' in target_url:
+        target_url = target_url.replace('/?', '?')
+
+    parsed = urlparse(target_url)
+    if parsed.scheme not in ('http', 'https'):
+        print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
+              "Only http and https are allowed.", file=sys.stderr)
+        return
+
+    print(f"Processing URL: {target_url}")
+
+    try:
+        print("Fetching content...")
+        response = session.get(target_url, timeout=30)
+        response.raise_for_status()
+
+        print("Converting to Markdown...")
+        md_content = md_func(response.text, heading_style="ATX")
+
+        if args.outdir:
+            if not os.path.exists(args.outdir):
+                os.makedirs(args.outdir)
+
+            # Create a safe filename based on the URL
+            filename = "conversion_result.md"
+            url_path = target_url.split('?')[0].rstrip('/')
+            if url_path:
+                base = os.path.basename(unquote(url_path))
+                # Sanitize to prevent path traversal
+                base = base.replace('/', '_').replace('\\', '_')
+                base = base.strip('. ')
+                if base:
+                    filename = f"{base}.md"
+
+            out_path = os.path.join(args.outdir, filename)
+            # Final safety check: ensure output stays within outdir
+            real_outdir = os.path.realpath(args.outdir)
+            real_out_path = os.path.realpath(out_path)
+            if os.path.commonpath([real_outdir, real_out_path]) != real_outdir:
+                print("Error: Output path escapes output directory.",
+                      file=sys.stderr)
+                return
+            with open(out_path, 'w', encoding='utf-8') as f:
+                f.write(md_content)
+            print(f"Success! Saved to: {out_path}")
+        else:
+            print(md_content)
+
+    except requests.RequestException as e:
+        print(f"Network error: {e}", file=sys.stderr)
+    except OSError as e:
+        print(f"File error: {e}", file=sys.stderr)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Conversion failed: {e}", file=sys.stderr)
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -54,66 +114,8 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def process_url(target_url: str) -> None:
-            """Process a single URL."""
-            # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
-
-            parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
-                return
-
-            print(f"Processing URL: {target_url}")
-
-            try:
-                print("Fetching content...")
-                response = session.get(target_url, timeout=30)
-                response.raise_for_status()
-
-                print("Converting to Markdown...")
-                md_content = md(response.text, heading_style="ATX")
-
-                if args.outdir:
-                    if not os.path.exists(args.outdir):
-                        os.makedirs(args.outdir)
-
-                    # Create a safe filename based on the URL
-                    filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
-                    if url_path:
-                        base = os.path.basename(unquote(url_path))
-                        # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
-                        base = base.strip('. ')
-                        if base:
-                            filename = f"{base}.md"
-
-                    out_path = os.path.join(args.outdir, filename)
-                    # Final safety check: ensure output stays within outdir
-                    real_outdir = os.path.realpath(args.outdir)
-                    real_out_path = os.path.realpath(out_path)
-                    if os.path.commonpath([real_outdir, real_out_path]) != real_outdir:
-                        print("Error: Output path escapes output directory.",
-                              file=sys.stderr)
-                        return
-                    with open(out_path, 'w', encoding='utf-8') as f:
-                        f.write(md_content)
-                    print(f"Success! Saved to: {out_path}")
-                else:
-                    print(md_content)
-
-            except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
-            except OSError as e:
-                print(f"File error: {e}", file=sys.stderr)
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
-
         if args.url:
-            process_url(args.url)
+            process_url(args.url, session, args, md)
 
         if args.batch:
             if not os.path.exists(args.batch):
@@ -123,7 +125,7 @@ def main(argv=None):
                 for line in f:
                     u = line.strip()
                     if u:
-                        process_url(u)
+                        process_url(u, session, args, md)
 
         return 0
 

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import sys
+import os
+
+class TestCliBatch(unittest.TestCase):
+    @patch('html2md.cli.process_url')
+    @patch('os.path.exists')
+    def test_batch_empty_lines_skipped(self, mock_exists, mock_process_url):
+        """Test that empty lines and whitespace-only lines in batch file are skipped."""
+        from html2md.cli import main
+
+        # Mock dependencies modules to avoid ImportError
+        mock_requests = MagicMock()
+        mock_md = MagicMock()
+
+        # Batch file content with valid URLs, empty lines, and whitespace lines
+        batch_content = "http://example.com/valid1\n\n   \nhttp://example.com/valid2\n"
+
+        mock_exists.side_effect = lambda p: True if p == 'urls.txt' else False
+
+        with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_md}):
+            with patch('builtins.open', mock_open(read_data=batch_content)):
+                # Run the main function with --batch
+                main(['--batch', 'urls.txt'])
+
+        # Verify that process_url was only called for the non-empty lines
+        self.assertEqual(mock_process_url.call_count, 2)
+
+        # Check call arguments
+        calls = mock_process_url.call_args_list
+        self.assertEqual(calls[0][0][0], "http://example.com/valid1")
+        self.assertEqual(calls[1][0][0], "http://example.com/valid2")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Refactor `src/html2md/cli.py`: Move `process_url` to top level.
- Add `tests/test_cli_batch.py`: Test skipping of empty lines in batch files.
- Improve CLI testability by allowing direct mocking of URL processing.