### PR TITLE
fix: secure Flask development server by restricting default host to 1…

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -2,19 +2,32 @@
 
 import os
 
-from flask import Flask, jsonify
+try:
+    from flask import Flask, jsonify
+except ImportError:
+    # Flask is an optional dependency
+    Flask = None
+    jsonify = None
 
 from html2md import __version__
 
 DEFAULT_PORT = 10000
 
-app = Flask(__name__)
+app = Flask(__name__) if Flask is not None else None
 
 
-@app.route('/health')
-def health():
-    """Return health status of the application."""
-    return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
+def create_routes(application):
+    """Create routes for the application."""
+    if application is None:
+        return
+
+    @application.route('/health')
+    def health():
+        """Return health status of the application."""
+        return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
+
+
+create_routes(app)
 
 
 def get_host_port():
@@ -30,10 +43,23 @@ def get_host_port():
         )
         port_value = DEFAULT_PORT
 
-    hostname = os.environ.get('HOST', '0.0.0.0')
+    hostname = os.environ.get('HOST', '127.0.0.1')
+    if hostname == '0.0.0.0':
+        print(
+            'Security Warning: Host is set to 0.0.0.0, making the server '
+            'accessible from any network interface. Use with caution.'
+        )
     return hostname, port_value
 
 
 if __name__ == '__main__':
+    if app is None:
+        print('Error: Flask is not installed. Cannot start the development server.')
+        exit(1)
+
     host, port = get_host_port()
+    print(
+        'WARNING: This is a development server. Do not use it in a production '
+        'deployment. Use a production WSGI server instead.'
+    )
     app.run(host=host, port=port)

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -1,6 +1,7 @@
 """Flask application for html2md."""
 
 import os
+import sys
 
 try:
     from flask import Flask, jsonify
@@ -25,14 +26,14 @@ if app:
 
 def get_host_port():
     """Get host and port from environment variables."""
-    default_port = 10000
     port_str = os.environ.get('PORT')
     try:
         port_value = int(port_str) if port_str is not None else DEFAULT_PORT
     except ValueError:
         print(
             f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.',
+            file=sys.stderr,
         )
         port_value = DEFAULT_PORT
 
@@ -40,19 +41,21 @@ def get_host_port():
     if hostname == '0.0.0.0':
         print(
             'Security Warning: Host is set to 0.0.0.0, making the server '
-            'accessible from any network interface. Use with caution.'
+            'accessible from any network interface. Use with caution.',
+            file=sys.stderr,
         )
     return hostname, port_value
 
 
 if __name__ == '__main__':
     if app is None:
-        print('Error: Flask is not installed. Cannot start the development server.')
-        exit(1)
+        print('Error: Flask is not installed. Cannot start the development server.', file=sys.stderr)
+        raise SystemExit(1)
 
     host, port = get_host_port()
     print(
         'WARNING: This is a development server. Do not use it in a production '
-        'deployment. Use a production WSGI server instead.'
+        'deployment. Use a production WSGI server instead.',
+        file=sys.stderr,
     )
     app.run(host=host, port=port)

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -16,18 +16,11 @@ DEFAULT_PORT = 10000
 app = Flask(__name__) if Flask is not None else None
 
 
-def create_routes(application):
-    """Create routes for the application."""
-    if application is None:
-        return
-
-    @application.route('/health')
+if app:
+    @app.route('/health')
     def health():
         """Return health status of the application."""
         return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
-
-
-create_routes(app)
 
 
 def get_host_port():

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -1,0 +1,39 @@
+"""Security tests for the Flask application defaults."""
+
+import os
+from unittest.mock import patch
+from html2md.app import get_host_port, DEFAULT_PORT
+
+
+def test_get_host_port_defaults():
+    """Verify default host and port when no environment variables are set."""
+    with patch.dict(os.environ, {}, clear=True):
+        host, port = get_host_port()
+        assert host == '127.0.0.1'
+        assert port == DEFAULT_PORT
+
+
+def test_get_host_port_from_env():
+    """Verify host and port are correctly read from environment variables."""
+    with patch.dict(os.environ, {'HOST': '10.0.0.1', 'PORT': '8080'}):
+        host, port = get_host_port()
+        assert host == '10.0.0.1'
+        assert port == 8080
+
+
+def test_get_host_port_security_warning_0000(capsys):
+    """Verify security warning when binding to 0.0.0.0."""
+    with patch.dict(os.environ, {'HOST': '0.0.0.0'}):
+        host, port = get_host_port()
+        assert host == '0.0.0.0'
+        captured = capsys.readouterr()
+        assert 'Security Warning: Host is set to 0.0.0.0' in captured.out
+
+
+def test_get_host_port_invalid_port(capsys):
+    """Verify fallback when an invalid port is provided."""
+    with patch.dict(os.environ, {'PORT': 'invalid'}):
+        _, port = get_host_port()
+        assert port == DEFAULT_PORT
+        captured = capsys.readouterr()
+        assert 'Warning: Invalid PORT environment variable value' in captured.out

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -27,7 +27,7 @@ def test_get_host_port_security_warning_0000(capsys):
         host, port = get_host_port()
         assert host == '0.0.0.0'
         captured = capsys.readouterr()
-        assert 'Security Warning: Host is set to 0.0.0.0' in captured.out
+        assert 'Security Warning: Host is set to 0.0.0.0' in captured.err
 
 
 def test_get_host_port_invalid_port(capsys):
@@ -36,4 +36,4 @@ def test_get_host_port_invalid_port(capsys):
         _, port = get_host_port()
         assert port == DEFAULT_PORT
         captured = capsys.readouterr()
-        assert 'Warning: Invalid PORT environment variable value' in captured.out
+        assert 'Warning: Invalid PORT environment variable value' in captured.err


### PR DESCRIPTION
…27.0.0.1

- Change default host to 127.0.0.1
- Add security warnings for 0.0.0.0 binding and development server usage
- Add unit tests for host/port resolution logic
- Improve robustness when flask is not installed