### PR TITLE
🎨 Palette: Add keyboard shortcuts to ToolTips and AutomationProperties to TextBoxes

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,27 +86,27 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard (Alt+T)"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list (Alt+R)"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 ToolTip="Enter one or more URLs (one per line)" AutomationProperties.Name="URL List"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved" AutomationProperties.Name="Output Directory"/>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder (Alt+B)">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder (Alt+O)">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
+                  ToolTip="If checked, includes headers and footers. Default is main content only. (Alt+W)"/>
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"


### PR DESCRIPTION
🎨 Palette: Add keyboard shortcuts to ToolTips and AutomationProperties to TextBoxes

💡 What:
- Added `AutomationProperties.Name` ("URL List" and "Output Directory") to the main text boxes in the `gui-url-convert.ps1` WPF UI.
- Appended keyboard shortcut hints (e.g., `(Alt+T)`, `(Alt+B)`) to the `ToolTip` properties for the main buttons and the Whole Page checkbox.

🎯 Why:
- Input fields in XAML need `AutomationProperties.Name` for robust screen reader accessibility, even when a `<Label>` with a `Target` binding is present.
- Keyboard accelerators (using `_` like `_Browse...`) exist but are often hidden until the user presses Alt. Adding the explicit shortcut to the tooltip significantly improves discoverability for keyboard users.

♿ Accessibility:
- Improves screen reader announcements for the core input fields.
- Makes keyboard navigation much more obvious to all users.

---
*PR created automatically by Jules for task [393659138767175061](https://jules.google.com/task/393659138767175061) started by @badMade*