### PR TITLE
🛡️ Sentinel: [HIGH] Fix Server-Side Request Forgery (SSRF) in CLI

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 import argparse
+import ipaddress
 import os
+import socket
 import sys
 from urllib.parse import urlparse, unquote
+
+def is_internal_ip(ip_str: str) -> bool:
+    """Check if an IP address is internal/private."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved
+    except ValueError:
+        return False
 
 def main(argv=None):
     """Run the CLI."""
@@ -67,6 +77,25 @@ def main(argv=None):
                 return
 
             print(f"Processing URL: {target_url}")
+
+            try:
+                hostname = parsed.hostname
+                if not hostname:
+                    print("Error: Invalid URL hostname.", file=sys.stderr)
+                    return
+
+                try:
+                    ip_address = socket.gethostbyname(hostname)
+                except socket.gaierror:
+                    print(f"Error: Could not resolve hostname '{hostname}'.", file=sys.stderr)
+                    return
+
+                if is_internal_ip(ip_address):
+                    print(f"Error: Access to internal IP address '{ip_address}' is forbidden.", file=sys.stderr)
+                    return
+            except Exception as e:
+                print(f"Error validating hostname: {e}", file=sys.stderr)
+                return
 
             try:
                 print("Fetching content...")

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -59,7 +59,12 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        # Fix mock open breaking argparse translations by avoiding mocking builtins.open
+                        # during argparse initialization by setting autospec or wrapping.
+                        # We only need to ensure it's not called, or we can just patch it with a specific target.
+                        # Wait, the failure happens when argparse is initialized, which attempts to read translations using open.
+                        # We can mock `html2md.cli.open` instead of `builtins.open` to avoid breaking gettext.
+                        with patch('html2md.cli.open', create=True) as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) could allow users to craft URLs pointing to internal or private IP addresses via the `html2md` CLI command, potentially exposing internal networks.
🎯 Impact: Attackers could query localhost or internal services by providing malicious URLs, leading to information disclosure or service disruption.
🔧 Fix: Added a pre-fetch hostname resolution step and explicitly checked against private, loopback, link-local, and multicast IP address ranges using Python's `ipaddress` module, preventing the fetch if forbidden.
✅ Verification: Ensure the test suite passes, including tests that mock network failures. All tests currently pass.

---
*PR created automatically by Jules for task [9370020920466331451](https://jules.google.com/task/9370020920466331451) started by @badMade*