### PR TITLE
🎨 Palette: Improve GUI validation feedback UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-24 - [Replace Blocking MessageBox with StatusBar Feedback in WPF GUI]
+**Learning:** Using `[System.Windows.MessageBox]::Show` for basic form validation errors (like invalid URLs or bad characters) is disruptive and can feel jarring to users compared to inline feedback. Also, if a process starts a visual loading indicator (like `$ProgressBar.IsIndeterminate = $true`) before validation, any early exit must reset that indicator, or the app will appear to be hanging indefinitely.
+**Action:** Replace blocking modal alerts with unobtrusive updates to status elements (e.g., `$StatusText.Text` with a "Red" foreground). Always ensure that early `return` statements on validation failures also reset any active loading states to prevent misleading the user.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -273,6 +273,7 @@ $ConvertBtn.Add_Click({
     if ($urlList.Count -eq 0) {
         $StatusText.Text = "Please enter a URL."
         $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
@@ -285,13 +286,17 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
+        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------


### PR DESCRIPTION
💡 What: Replaced blocking modal `MessageBox` popups for validation errors with inline `StatusText` updates, and ensured that `$ProgressBar.IsIndeterminate` is set to `$false` if an early validation error occurs before conversion begins.
🎯 Why: To make the interface more pleasant to use by avoiding disruptive popups, and to prevent confusing user experiences where the progress bar spins indefinitely after a failed validation attempt.
📸 Before/After: Visual changes apply to the main Window status bar (which now dynamically updates with red error text) and the progress bar (which now appropriately stops spinning).
♿ Accessibility: Provides validation feedback in a non-disruptive, polite manner, integrating well with existing screen reader setups in the application.

## AI Usage
AI-generated edits primarily targeting `gui-url-convert.ps1`'s convert button click handler and `.jules/palette.md` for journal learning additions.

## Assumptions & Validation
- Assuming users prefer inline validation over system pop-ups for minor data entry errors (validated by existing `StatusText` implementation in `gui-url-convert.ps1`).
- Assumed it is safe to set `$ProgressBar.IsIndeterminate = $false` on an early exit since no background process has started yet.

## Design Rationale
- Using existing variables/controls (`StatusText`, `ProgressBar`) instead of introducing new feedback mechanisms.
- Retaining existing text validation feedback color logic (`"Red"`).

## Testing
- Modified script run and observed in isolated environment. Tests for the core `html2md` library pass as these are UI changes to the WPF interface script.

## Risk & Rollback
- Blast radius is limited to the single `.ps1` GUI script. Rollback would be a quick revert.

## Tech Debt
- None. These changes align directly with existing patterns without new abstractions.

---
*PR created automatically by Jules for task [17940787059106523547](https://jules.google.com/task/17940787059106523547) started by @badMade*