### PR TITLE
🎨 Palette: Show tooltip on disabled convert button

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -112,6 +112,7 @@ $xaml = @"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"
+                ToolTipService.ShowOnDisabled="True"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
💡 What: Added `ToolTipService.ShowOnDisabled="True"` to the `ConvertBtn` in the WPF GUI (`gui-url-convert.ps1`).
🎯 Why: The convert button was disabled by default and had a helpful tooltip ("Please enter at least one URL to enable conversion"), but because WPF doesn't show tooltips on disabled elements by default, users could never actually see this guidance. This change ensures the helpful explanation is visible when users hover over the disabled button.
♿ Accessibility: Improves interface clarity by ensuring feedback on disabled states is perceivable by all users.

---
*PR created automatically by Jules for task [3096051724821014880](https://jules.google.com/task/3096051724821014880) started by @badMade*