### PR TITLE
🎨 Palette: Replace modal dialogs with inline status feedback in GUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2026-03-18 - [Replace modal dialogs with inline status feedback in GUI]
+**Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), modal dialogs (`MessageBox`) can be jarring and interruptive to the user experience. By replacing blocking `MessageBox` calls with inline non-blocking feedback through elements like `StatusText` with `AutomationProperties.LiveSetting="Polite"`, we provide a smoother and more accessible experience, especially for error and validation messaging.
+**Action:** Prefer non-blocking status feedback updates (e.g., updating a StatusBar TextBlock with appropriate colors and ARIA settings) instead of modal dialogs (`MessageBox`) for validation and operational feedback.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -285,16 +285,22 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
+        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------
+
+    $StatusText.ClearValue([System.Windows.Controls.TextBlock]::ForegroundProperty)
 
     if (-not (Test-Path $outdir)) {
         try { New-Item -ItemType Directory -Path $outdir -Force | Out-Null }


### PR DESCRIPTION
💡 **What:** Replaced the blocking `MessageBox` popups used for URL and Output Directory validation in `gui-url-convert.ps1` with inline status feedback using the `StatusText` element.
🎯 **Why:** Modal dialogs are jarring and interrupt the user's workflow. Updating the status bar text and color is a smoother, more pleasant way to provide validation feedback without requiring an extra click to dismiss an error message.
📸 **Before/After:** Before: Users get a blocking popup on invalid URL or output dir characters. After: The status text updates to red with the error message, and the progress bar stops, allowing the user to immediately correct the input.
♿ **Accessibility:** The `StatusText` element is already configured with `AutomationProperties.LiveSetting="Polite"`, so screen readers will automatically announce the validation error without aggressively taking focus.

---
*PR created automatically by Jules for task [13304515857612673419](https://jules.google.com/task/13304515857612673419) started by @badMade*