### PR TITLE
🎨 Palette: Add AutomationProperties.Name to WPF controls with access keys

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+## 2024-05-25 - [Use AutomationProperties.Name for controls with access keys in WPF]
+**Learning:** In WPF applications using XAML, when controls use access keys (underscores like `Content="_Browse..."` or `Content="Pas_te"`) in their `Content`, screen readers might read the underscore or mispronounce the word unless an explicit name is provided.
+**Action:** Always provide `AutomationProperties.Name` (e.g., `AutomationProperties.Name="Browse"`) to override the spoken name for screen readers when using access keys in WPF controls to ensure clear, clean pronunciation.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,8 +86,8 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" AutomationProperties.Name="Paste" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
+                <Button Name="ClearBtn" AutomationProperties.Name="Clear" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
             </StackPanel>
         </Grid>
 
@@ -99,16 +99,16 @@ $xaml = @"
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
                 <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <Button Name="BrowseBtn" AutomationProperties.Name="Browse" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
+                <Button Name="OpenFolderBtn" AutomationProperties.Name="Open Folder" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
-        <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
+        <CheckBox Name="WholePageChk" AutomationProperties.Name="Convert Whole Page" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
                   ToolTip="If checked, includes headers and footers. Default is main content only."/>
 
-        <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
+        <Button Name="ConvertBtn" AutomationProperties.Name="Convert All Formats" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"


### PR DESCRIPTION
### 💡 What
Added explicit `AutomationProperties.Name` to buttons and checkboxes in `gui-url-convert.ps1` that use access keys in their `Content`.

### 🎯 Why
Controls with access keys (e.g., `_Browse...` or `Pas_te`) can cause screen readers to mispronounce the label or read the underscore character. Explicitly setting the `AutomationProperties.Name` overrides this behavior and ensures clean pronunciation.

### ♿ Accessibility
Improves screen reader accessibility and clarity for users navigating the WPF application via keyboard/screen reader, bypassing the literal pronunciation of mnemonic access keys.

---
*PR created automatically by Jules for task [10665771281948007147](https://jules.google.com/task/10665771281948007147) started by @badMade*