### PR TITLE
🎨 Palette: Add keyboard shortcut hints to GUI tooltips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-03-19 - [Add keyboard shortcut hints to GUI tooltips]
+**Learning:** While access keys (using `_` in WPF Content attributes, triggering `Alt+Key` shortcuts) provide keyboard navigation, their discoverability is poor. Users typically have to probe by holding `Alt` to see them. Adding explicit shortcut hints to tooltips (e.g., `(Alt+C)`) makes these time-saving shortcuts discoverable and significantly improves power-user UX.
+**Action:** Always append the corresponding keyboard shortcut hint (e.g., `(Alt+C)`) to the ToolTip text of UI elements that have access keys defined.
+
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,8 +86,8 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard (Alt+T)"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list (Alt+R)"/>
             </StackPanel>
         </Grid>
 
@@ -99,19 +99,19 @@ $xaml = @"
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
                 <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder (Alt+B)">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder (Alt+O)">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
+                  ToolTip="If checked, includes headers and footers. Default is main content only. (Alt+W)"/>
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
-                ToolTip="Please enter at least one URL to enable conversion"
+                ToolTip="Please enter at least one URL to enable conversion (Alt+C)"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>
@@ -254,10 +254,10 @@ $ClearBtn.Add_Click({
 $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
-        $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion (Alt+C)"
     } else {
         $ConvertBtn.IsEnabled = $true
-        $ConvertBtn.ToolTip = "Start conversion process"
+        $ConvertBtn.ToolTip = "Start conversion process (Alt+C)"
     }
 })
 


### PR DESCRIPTION
💡 **What:** Added explicit keyboard shortcut hints (e.g., `(Alt+C)`) to the ToolTips of interactive elements in the `gui-url-convert.ps1` WPF application.
🎯 **Why:** While the GUI supports keyboard navigation via access keys (using `_` in WPF Content attributes, like `_Convert`), their discoverability is poor. Users typically have to probe by holding `Alt` to see them. Adding explicit shortcut hints to tooltips makes these time-saving shortcuts discoverable and significantly improves power-user UX.
♿ **Accessibility:** Improves discoverability for keyboard navigators and power users.

---
*PR created automatically by Jules for task [11312523796279713495](https://jules.google.com/task/11312523796279713495) started by @badMade*