### PR TITLE
🎨 Palette: Enable tooltips on disabled buttons and improve Clear button state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Enable tooltips on disabled elements in WPF]
+**Learning:** WPF disables ToolTips on disabled controls by default. This is an anti-pattern for UX/accessibility because it hides helpful guidance (like why a button is disabled) from the user exactly when they need it most.
+**Action:** When disabling buttons (e.g. `IsEnabled="False"`), always add `ToolTipService.ShowOnDisabled="True"` to ensure the explanation tooltip remains visible to users.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -87,7 +87,7 @@ $xaml = @"
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" IsEnabled="False" ToolTipService.ShowOnDisabled="True" ToolTip="Clear URL list"/>
             </StackPanel>
         </Grid>
 
@@ -111,6 +111,7 @@ $xaml = @"
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
+                ToolTipService.ShowOnDisabled="True"
                 ToolTip="Please enter at least one URL to enable conversion"
                 />
 
@@ -255,9 +256,13 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
+        $ClearBtn.ToolTip = "No URLs to clear"
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
+        $ClearBtn.ToolTip = "Clear URL list"
     }
 })
 


### PR DESCRIPTION
💡 **What:** Added `ToolTipService.ShowOnDisabled="True"` to the Convert and Clear buttons in the WPF GUI. Also updated the Clear button's state to be disabled when the URL text box is empty, matching the Convert button's logic.
🎯 **Why:** WPF disables ToolTips on disabled controls by default, which hides helpful guidance (like why a button is disabled) from the user exactly when they need it most. This change provides clear, immediate feedback.
♿ **Accessibility:** Users relying on screen magnifiers or those who are confused by disabled states now get context via tooltips even when the action cannot be performed.

---
*PR created automatically by Jules for task [15117311729658660976](https://jules.google.com/task/15117311729658660976) started by @badMade*