### PR TITLE
🎨 Palette: Improve screen reader accessibility for WPF GUI inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-06-19 - [Add explicit AutomationProperties to all inputs and buttons in WPF GUI]
+**Learning:** While tooltips provide visual context for hover, screen readers often need explicit `AutomationProperties.Name` and `AutomationProperties.HelpText` directly on WPF interactive controls (like `Button`, `TextBox`, and `CheckBox`) to ensure full keyboard navigation support and auditory context when focus changes.
+**Action:** Always complement `ToolTip` attributes in XAML with `AutomationProperties.Name` and `AutomationProperties.HelpText` to ensure parity between visual helpers and screen reader announcements.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,32 +86,32 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard" AutomationProperties.Name="Paste URL" AutomationProperties.HelpText="Paste URL from Clipboard"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list" AutomationProperties.Name="Clear URLs" AutomationProperties.HelpText="Clear URL list"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 ToolTip="Enter one or more URLs (one per line)" AutomationProperties.Name="URLs to convert" AutomationProperties.HelpText="Enter one or more URLs (one per line)"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved" AutomationProperties.Name="Output Directory" AutomationProperties.HelpText="Directory where files will be saved"/>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder" AutomationProperties.Name="Browse for Output Directory" AutomationProperties.HelpText="Select output folder">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder" AutomationProperties.Name="Open Output Directory" AutomationProperties.HelpText="Open output folder">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
+                  ToolTip="If checked, includes headers and footers. Default is main content only." AutomationProperties.Name="Convert Whole Page" AutomationProperties.HelpText="If checked, includes headers and footers. Default is main content only."/>
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
-                ToolTip="Please enter at least one URL to enable conversion"
+                ToolTip="Please enter at least one URL to enable conversion" AutomationProperties.Name="Convert" AutomationProperties.HelpText="Convert URLs to all formats"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
💡 What: The UX enhancement added
Added `AutomationProperties.Name` and `AutomationProperties.HelpText` to the primary interactive controls (`TextBox`es, `Button`s, `CheckBox`) in the WPF XAML within `gui-url-convert.ps1`.

🎯 Why: The user problem it solves
Screen readers often rely on explicit AutomationProperties to properly announce control names and helper text, especially when controls use visual-only helpers like `ToolTip`s or access keys (e.g., "Pas_te"). This change ensures that keyboard users and screen reader users get clear, auditory context for every interactive element in the main GUI.

♿ Accessibility: Any a11y improvements made
Full screen reader support and keyboard context for all input fields and action buttons in the GUI, bridging the gap between visual ToolTips and accessibility APIs. Documented the learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [18138747089032788031](https://jules.google.com/task/18138747089032788031) started by @badMade*