### PR TITLE
🎨 Palette: Improve accessibility and button state interaction in GUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2026-03-20 - [Dynamically disable Clear button and add AutomationProperties.Name to Input/Output fields]
+**Learning:** In WPF (PowerShell GUI), setting `AutomationProperties.Name` on input fields greatly improves screen reader experience, acting much like an ARIA label on the web. Additionally, dynamically disabling action buttons (like 'Clear') when they are irrelevant prevents user confusion and meaningless clicks.
+**Action:** Always consider initial control states and dynamically toggle `IsEnabled` and `ToolTip` properties based on user input to guide them effectively, and apply `AutomationProperties.Name` to input controls without visible labels or where context requires it.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -87,18 +87,18 @@ $xaml = @"
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Nothing to clear" IsEnabled="False"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 ToolTip="Enter one or more URLs (one per line)" AutomationProperties.Name="Input URLs"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved" AutomationProperties.Name="Output Directory"/>
                 <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
                 <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
             </StackPanel>
@@ -255,9 +255,13 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
+        $ClearBtn.ToolTip = "Nothing to clear"
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
+        $ClearBtn.ToolTip = "Clear URL list"
     }
 })
 


### PR DESCRIPTION
💡 What: 
- Added `AutomationProperties.Name` to URL and output directory `TextBox` controls.
- Set the initial `ClearBtn` state to `IsEnabled="False"` with a tooltip explaining there's nothing to clear.
- Dynamically toggle the `ClearBtn` `IsEnabled` and `ToolTip` properties based on user input in the `UrlBox`.

🎯 Why: 
To improve screen reader accessibility (acting like ARIA labels) and to make the user interface more intuitive by preventing irrelevant interactions (clicking clear when there is nothing to clear).

📸 Before/After: 
N/A (interaction/accessibility change, visually disabled button).

♿ Accessibility: 
Improved screen reader announcement for the primary input fields by providing explicit `AutomationProperties.Name` attributes.

---
*PR created automatically by Jules for task [8661206050338405670](https://jules.google.com/task/8661206050338405670) started by @badMade*