### PR TITLE
🎨 Palette: Replace blocking validation MessageBox with non-blocking status updates

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Replace blocking MessageBox validation with inline status updates]
+**Learning:** Using `[System.Windows.MessageBox]::Show` for form validation in a WPF/PowerShell script creates a jarring, blocking user experience. It interrupts the user flow and can cause the UI to feel clunky. Furthermore, failing to reset loading indicators (like a `ProgressBar`'s `IsIndeterminate` state) on validation errors leaves the UI in a confusing "stuck" state.
+**Action:** When implementing form validation or error handling in UI scripts, prefer non-blocking inline feedback (e.g., updating a `StatusBar`'s `TextBlock`) over modal popups. Always ensure that loading states are explicitly reset on all error or early-return paths.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -273,25 +273,34 @@ $ConvertBtn.Add_Click({
     if ($urlList.Count -eq 0) {
         $StatusText.Text = "Please enter a URL."
         $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # --- Security Validation ---
-    try {
-        $uriObj = [System.Uri]$url
-        if ($uriObj.Scheme -notmatch '^https?$') {
-            throw "Invalid scheme"
+    $validUrls = @()
+    foreach ($u in $urlList) {
+        try {
+            $uriObj = [System.Uri]$u
+            if ($uriObj.Scheme -notmatch '^https?$') {
+                throw "Invalid scheme"
+            }
+            # AbsoluteUri is properly percent-encoded, preventing quote-based injection
+            $validUrls += $uriObj.AbsoluteUri
+        } catch {
+            $StatusText.Text = "Invalid HTTP/HTTPS URL detected."
+            $StatusText.Foreground = "Red"
+            $ProgressBar.IsIndeterminate = $false
+            return
         }
-        # AbsoluteUri is properly percent-encoded, preventing quote-based injection
-        $url = $uriObj.AbsoluteUri
-    } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
-        return
     }
+    $urlList = $validUrls
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------


### PR DESCRIPTION
💡 What: Replaced blocking `MessageBox` popups for validation errors with inline non-blocking updates in the GUI's `StatusText`. Additionally, properly resets the `ProgressBar` indeterminate state upon validation failure, preventing a stuck loading visual state. Fixed URL validation to iterate over the input array.
🎯 Why: `MessageBox` popups create a jarring and intrusive UX by blocking user flow and obscuring the UI. A stuck loading indicator leads to user confusion. This change ensures smoother, non-intrusive feedback.
♿ Accessibility: Ensures that status updates are read politely by screen readers via the existing `AutomationProperties.LiveSetting` on the `StatusText` block.

---
*PR created automatically by Jules for task [343370649193495536](https://jules.google.com/task/343370649193495536) started by @badMade*