### PR TITLE
🎨 Palette: Improve GUI feedback and button states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-24 - [Enhance quantitative feedback and dynamic button states in GUI]
+**Learning:** Real-time quantitative feedback on multi-item inputs (e.g., "$count URLs detected") provides much better user confidence than static success messages (e.g. "Pasted from clipboard"). Additionally, secondary action buttons (like 'Clear') should be disabled when they are not applicable to prevent confusion.
+**Action:** When designing interfaces with bulk inputs, dynamically update status text to reflect the actual parsed state of the input rather than just acknowledging the input action. Ensure related action buttons accurately reflect whether their action is currently valid.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -87,7 +87,7 @@ $xaml = @"
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" IsEnabled="False" ToolTip="Clear URL list"/>
             </StackPanel>
         </Grid>
 
@@ -225,8 +225,6 @@ $PasteBtn.Add_Click({
                 $UrlBox.AppendText($text)
                 $UrlBox.Focus()
                 $UrlBox.ScrollToEnd()
-                $StatusText.Text = "Pasted from clipboard."
-                $StatusText.ClearValue([System.Windows.Controls.TextBlock]::ForegroundProperty)
             } else {
                 $StatusText.Text = "Clipboard is empty or whitespace."
                 $StatusText.ClearValue([System.Windows.Controls.TextBlock]::ForegroundProperty)
@@ -238,7 +236,6 @@ $PasteBtn.Add_Click({
     } catch {
         $StatusText.Text = "Error pasting from clipboard."
         $StatusText.Foreground = "Red"
-        $StatusText.Foreground = "Red"
     }
 })
 
@@ -246,8 +243,6 @@ $PasteBtn.Add_Click({
 $ClearBtn.Add_Click({
     $UrlBox.Clear()
     $UrlBox.Focus()
-    $StatusText.Text = "Cleared."
-    $StatusText.ClearValue([System.Windows.Controls.TextBlock]::ForegroundProperty)
 })
 
 # --- Dynamic Convert button state ---
@@ -255,9 +250,24 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
+        $StatusText.Text = "Ready"
+        $StatusText.ClearValue([System.Windows.Controls.TextBlock]::ForegroundProperty)
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
+        $StatusText.ClearValue([System.Windows.Controls.TextBlock]::ForegroundProperty)
+
+        $lines = @($UrlBox.Text -split "`r`n|`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $count = $lines.Count
+        if ($count -eq 1) {
+            $StatusText.Text = "1 URL detected."
+        } elseif ($count -gt 1) {
+            $StatusText.Text = "$count URLs detected."
+        } else {
+            $StatusText.Text = "Ready"
+        }
     }
 })
 


### PR DESCRIPTION
💡 **What:** 
- The `Clear` button is now dynamically enabled/disabled depending on whether the URL input box has content.
- The status bar now displays a real-time count of detected URLs (e.g., "3 URLs detected.") instead of static messages like "Pasted from clipboard." or "Ready."
- Handlers for the `Paste` and `Clear` buttons were simplified by removing redundant, hardcoded status updates since the `TextChanged` event naturally handles state reporting now.

🎯 **Why:** 
- Disabling the 'Clear' button when the list is empty prevents user confusion by indicating clearly that the action is not currently available.
- Real-time quantitative feedback on multi-item inputs provides immediate reassurance to users, especially when pasting large batches of URLs, confirming exactly how many items the application recognized.

📸 **Before/After:** 
- *Before*: The Clear button was always clickable even if the box was empty. Status messages would say "Pasted from clipboard." but not indicate how many URLs were pasted.
- *After*: The Clear button disables correctly. Status dynamically updates to e.g., "5 URLs detected."

♿ **Accessibility:**
- Improved state clarity ensures users relying on screen readers (and visual users alike) receive more accurate, context-aware feedback about the current state of their input list.

---
*PR created automatically by Jules for task [5190748423567438165](https://jules.google.com/task/5190748423567438165) started by @badMade*