### PR TITLE
🎨 Palette: Enable tooltip on disabled convert button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Enable Tooltips on Disabled WPF Buttons]
+**Learning:** In WPF applications using XAML, tooltips on disabled elements (like buttons) do not display by default. This creates an accessibility and UX issue because users cannot see the explanation of why the control is disabled (e.g. "Please enter at least one URL to enable conversion").
+**Action:** When working on WPF UI files, ensure disabled buttons that provide helpful context have `ToolTipService.ShowOnDisabled="True"` explicitly set so that screen readers and hover interactions can surface the tooltip text.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -111,6 +111,7 @@ $xaml = @"
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
+                ToolTipService.ShowOnDisabled="True"
                 ToolTip="Please enter at least one URL to enable conversion"
                 />
 


### PR DESCRIPTION
🎨 Palette: Enable tooltip on disabled convert button

💡 What: Added `ToolTipService.ShowOnDisabled="True"` to the `ConvertBtn` control in `gui-url-convert.ps1`.
🎯 Why: In WPF, tooltips on disabled elements are hidden by default. The button already had a helpful tooltip explaining why it was disabled ("Please enter at least one URL to enable conversion"), but users couldn't see it until this change.
♿ Accessibility: Improves accessibility by ensuring screen readers and hover interactions can surface the contextual explanation for the disabled state.
📝 Journal: Added this WPF-specific accessibility pattern to `.jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [4133330736814456302](https://jules.google.com/task/4133330736814456302) started by @badMade*