### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via Unbounded HTTP Client Response Size

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - DoS via Unbounded HTTP Client Response Parsing
+**Vulnerability:** The HTTP client in `html2md` downloaded entire remote files blindly into memory using `requests.get()` without setting `stream=True` and enforcing a maximum limit, making the application vulnerable to DoS attacks via extremely large URLs.
+**Learning:** `requests.get()` loads the entire file into memory unless `stream=True` is provided. If `stream=True` is specified, we must iterate over the content using `iter_content` to fetch it chunk by chunk, tracking the total size to prevent memory exhaustion and DoS when handling unverified remote user input.
+**Prevention:** Whenever downloading data from external sources, enforce size limits. Use streaming APIs (like `requests.get(..., stream=True)`) and incrementally build the output while checking against a defined maximum length (e.g., `MAX_CONTENT_SIZE`). Fail securely if the limit is exceeded.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,9 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
+MAX_CONTENT_SIZE = 10 * 1024 * 1024  # 10 MB limit to prevent DoS
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -70,8 +73,21 @@ def main(argv=None):
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                # Stream the response to enforce size limits and prevent DoS attacks
+                response = session.get(target_url, timeout=30, stream=True)
                 response.raise_for_status()
+
+                # Read the response in chunks to enforce MAX_CONTENT_SIZE
+                content_bytes = bytearray()
+                for chunk in response.iter_content(chunk_size=8192):
+                    content_bytes.extend(chunk)
+                    if len(content_bytes) > MAX_CONTENT_SIZE:
+                        print(f"Error: URL content exceeds maximum size of {MAX_CONTENT_SIZE} bytes.",
+                              file=sys.stderr)
+                        return
+
+                # Assign the accumulated bytes to _content so response.text works normally
+                response._content = bytes(content_bytes)
 
                 print("Converting to Markdown...")
                 md_content = md(response.text, heading_style="ATX")

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -66,6 +66,9 @@ class TestCliExceptions(unittest.TestCase):
                                 return '/tmp/out'
 
                             with patch('os.path.realpath', side_effect=fake_realpath):
+                                # Avoid argparse gettext trying to use the mocked open() by forcing english
+                                import os as _os
+                                _os.environ['LC_ALL'] = 'C'
                                 main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
 
                             output = captured_stderr.getvalue()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `html2md` CLI fetched remote URLs directly into memory using `requests.Session.get()` without defining a maximum content size. A malicious user could cause the application to crash via out-of-memory (OOM) errors by passing URLs that serve extremely large files or infinite data streams.
🎯 Impact: Exploitation could cause Denial of Service (DoS) by exhausting the system's memory, halting other processes, or crashing the container running the CLI.
🔧 Fix: Modifies the `requests.get()` call to use `stream=True` and reads the response iteratively using `iter_content`, enforcing a hard `MAX_CONTENT_SIZE` limit of 10 MB. If the response exceeds 10 MB, the CLI bails out gracefully. The accumulated bytes are re-assigned to `response._content` to allow `markdownify` to function as usual on the `response.text`.
✅ Verification: Ran `PYTHONPATH=src python -m pytest tests/` which all successfully complete. Verified streaming chunks behavior.
📚 Journaled: Added an entry into `.jules/sentinel.md` to document the lack of boundaries while downloading remote files and its prevention.

---
*PR created automatically by Jules for task [17518186501441669677](https://jules.google.com/task/17518186501441669677) started by @badMade*