### PR TITLE
🎨 Palette: Improve screen reader labels in GUI inputs

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -91,14 +91,14 @@ $xaml = @"
             </StackPanel>
         </Grid>
 
-        <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
+        <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True" AutomationProperties.Name="URL Input"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
                  ToolTip="Enter one or more URLs (one per line)"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved" AutomationProperties.Name="Output Directory"/>
                 <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
                 <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
             </StackPanel>


### PR DESCRIPTION
💡 What: Added accessible names (`AutomationProperties.Name`) to the primary inputs (`UrlBox` and `OutBox`) in the GUI script.
🎯 Why: While the `<Label>` elements point to these text boxes using `Target`, explicitly defining an AutomationName ensures screen readers read clear, descriptive labels ("URL Input" and "Output Directory") rather than relying on parsing the visible label text (e.g., "_Paste URL(s):").
♿ Accessibility: Improved screen reader announcements for the two main text fields.

---
*PR created automatically by Jules for task [15106098808210535748](https://jules.google.com/task/15106098808210535748) started by @badMade*