### PR TITLE
🎨 Palette: GUI UX and Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-28 - [Add explicit screen reader mapping and contextual button disabled states]
+**Learning:** Even when inputs have a `<Label>` bound via `Target`, multi-line text boxes and other complex inputs often benefit from an explicit `AutomationProperties.Name` attribute for reliable screen reader announcements. Additionally, contextual buttons like "Clear" or "Submit" should be dynamically disabled (`IsEnabled="False"`) when their action is not applicable (e.g., when the input is empty) to prevent confusing "no-op" interactions.
+**Action:** Always add `AutomationProperties.Name` to input fields in WPF XAML, and bind dynamic disabled states to the associated input fields' text-changed events for contextual actions.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -87,18 +87,19 @@ $xaml = @"
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list" IsEnabled="False"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 ToolTip="Enter one or more URLs (one per line)"
+                 AutomationProperties.Name="URLs to convert"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved" AutomationProperties.Name="Output Directory"/>
                 <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
                 <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
             </StackPanel>
@@ -255,9 +256,11 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
     }
 })
 


### PR DESCRIPTION
🎨 Palette: Add explicit screen reader labels and dynamic state to GUI inputs

💡 **What:** Added `AutomationProperties.Name` attributes to the multiline URL input box and Output directory box in `gui-url-convert.ps1`. Additionally, modified the "Clear" button to be disabled by default and dynamically toggle its `IsEnabled` state based on whether the URL input box has content. Added an entry to the `.jules/palette.md` journal to record the learnings regarding dynamic contextual buttons and the necessity of explicit Automation Properties for screen readers.

🎯 **Why:** To improve accessibility (specifically for screen readers interacting with multiline inputs) and prevent confusing interactions where a user might try to interact with a contextual button (Clear) when there is nothing to act upon.

📸 **Before/After:**
- **Before:** "Clear" button was always enabled, regardless of input state. Screen readers might announce multiline text box inputs unclearly.
- **After:** "Clear" button activates only when text is entered into the `UrlBox`. Screen readers announce the `UrlBox` as "URLs to convert" and `OutBox` as "Output Directory".

♿ **Accessibility:**
- Improved contextual state awareness by disabling unnecessary actions dynamically.
- Improved explicit object name mapping for assistive technologies via UI Automation Properties.

---
*PR created automatically by Jules for task [1426861241777422497](https://jules.google.com/task/1426861241777422497) started by @badMade*