### PR TITLE
🎨 Palette: Enhance GUI visual feedback and padding

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Micro-UX improvements in WPF GUI]
+**Learning:** Adding `Padding` to WPF input controls drastically improves visual appeal and text readability. Similarly, dynamically setting `IsEnabled` states for clear/reset buttons based on input availability provides immediate visual feedback, avoiding confusing "dead clicks". Setting a distinct background color (e.g., `#F8F9FA`) for read-only text fields clearly distinguishes them from editable inputs.
+**Action:** When designing or refactoring WPF/XAML interfaces, ensure interactive elements' enabled states reflect whether their action is actually possible, and add padding/background cues to clarify interactability and improve typography.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -84,21 +84,21 @@ $xaml = @"
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
+            <Label Content="_Paste URL(s) *:" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list" IsEnabled="False"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
-                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80" Padding="4"
+                 ToolTip="Required: Enter one or more URLs (one per line)"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
+                <TextBox Name="OutBox" Width="340" FontSize="14" Padding="4" ToolTip="Directory where files will be saved"/>
                 <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
                 <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
             </StackPanel>
@@ -117,7 +117,7 @@ $xaml = @"
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>
         
         <TextBox Name="LogBox" Grid.Row="5" Margin="0,10,0,0" FontFamily="Consolas" FontSize="12"
-                 TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
+                 TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" Padding="4" Background="#F8F9FA" AutomationProperties.Name="Log Output"/>
 
         <StatusBar Grid.Row="6" Margin="0,10,0,0">
             <TextBlock Name="StatusText" Text="Ready" AutomationProperties.LiveSetting="Polite">
@@ -252,12 +252,15 @@ $ClearBtn.Add_Click({
 
 # --- Dynamic Convert button state ---
 $UrlBox.Add_TextChanged({
-    if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
+    $isEmpty = [string]::IsNullOrWhiteSpace($UrlBox.Text)
+    if ($isEmpty) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
     }
 })
 


### PR DESCRIPTION
🎨 Palette: Enhance GUI visual feedback and padding

💡 What:
- Disabled the "Clear" button by default, dynamically enabling it only when URLs are present
- Added a `*` to the "Paste URL(s)" label and an explicit tooltip to indicate it's required
- Added 4px padding to all TextBox inputs (`UrlBox`, `OutBox`, `LogBox`) for visual breathing room
- Added a subtle grey background (`#F8F9FA`) to the read-only `LogBox`

🎯 Why:
- Provides immediate visual feedback to the user on what actions are possible (can't clear an empty list)
- Improves text readability and aesthetic polish by giving text breathing room from control borders
- Clearly distinguishes between editable and read-only text fields

♿ Accessibility:
- Avoids dead clicks on the "Clear" button by disabling it when there's nothing to clear
- Explicit required field indication improves form clarity

---
*PR created automatically by Jules for task [17215685205509005758](https://jules.google.com/task/17215685205509005758) started by @badMade*