### PR TITLE
🎨 Palette: Improve Error Color Contrast and Clear Button State

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-28 - [WCAG Color Contrast & Disabled Button States in WPF]
+**Learning:** Default system colors in WPF (like "Red", which is `#FF0000`) often fail WCAG AA contrast requirements against standard gray backgrounds (like the WPF StatusBar background, resulting in ~3.5:1). A darker shade like `#D32F2F` is required to achieve >4.5:1 contrast for accessibility. Additionally, contextual disabled states for buttons (e.g. disabling a "Clear" button when an input is already empty) provides better visual feedback and prevents dead clicks.
+**Action:** Always verify color contrast when manually setting foreground text colors. Use context-sensitive `.IsEnabled` properties on WPF buttons to communicate valid actions visually to the user.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -87,7 +87,7 @@ $xaml = @"
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list" IsEnabled="False"/>
             </StackPanel>
         </Grid>
 
@@ -172,7 +172,7 @@ $OpenFolderBtn.Add_Click({
         Invoke-Item -LiteralPath $path
     } else {
         $StatusText.Text = "Output folder does not exist."
-        $StatusText.Foreground = "Red"
+        $StatusText.Foreground = "#D32F2F"
     }
 })
 
@@ -237,8 +237,7 @@ $PasteBtn.Add_Click({
         }
     } catch {
         $StatusText.Text = "Error pasting from clipboard."
-        $StatusText.Foreground = "Red"
-        $StatusText.Foreground = "Red"
+        $StatusText.Foreground = "#D32F2F"
     }
 })
 
@@ -255,9 +254,11 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
     }
 })
 
@@ -272,7 +273,7 @@ $ConvertBtn.Add_Click({
 
     if ($urlList.Count -eq 0) {
         $StatusText.Text = "Please enter a URL."
-        $StatusText.Foreground = "Red"
+        $StatusText.Foreground = "#D32F2F"
         return
     }
 
@@ -319,7 +320,7 @@ $ConvertBtn.Add_Click({
         if (Get-Command "python3" -ErrorAction SilentlyContinue) { $pyCmd = "python3" }
         else {
             $StatusText.Text = "Error: Python not found in PATH."
-            $StatusText.Foreground = "Red"
+            $StatusText.Foreground = "#D32F2F"
             $LogBox.AppendText("ERROR: 'python' command not found. Please install Python.`r`n")
             $ProgressBar.IsIndeterminate = $false
             return
@@ -376,7 +377,7 @@ $ConvertBtn.Add_Click({
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."
-            $StatusText.Foreground = "Red"
+            $StatusText.Foreground = "#D32F2F"
             $LogBox.AppendText("ERROR: Could not find .venv\Scripts\html2md.exe or html2md.py in $scriptDir`r`n")
             $LogBox.AppendText("Have you run setup-html2md.ps1?`r`n")
             $ProgressBar.IsIndeterminate = $false


### PR DESCRIPTION
🎨 Palette: Improve Error Color Contrast and Clear Button State

💡 What:
- Updated the red error text color in the StatusBar from standard "Red" (#FF0000) to a darker shade (#D32F2F).
- Added contextual disabled states to the "Clear" button, preventing clicks when the input is empty.
- Removed a duplicate error color assignment.
- Appended learning to `.jules/palette.md`.

🎯 Why:
- The default "Red" on a typical WPF StatusBar gray background fails WCAG AA contrast requirements. A darker red improves readability for visually impaired users.
- Disabling the "Clear" button when the `UrlBox` is empty provides clear visual feedback of the system's state and prevents "dead clicks," making the interface feel more responsive and polished.

♿ Accessibility:
- WCAG AA compliant text contrast for error states.
- Contextual control states improve keyboard/screen reader navigation clarity.

---
*PR created automatically by Jules for task [3912549075246609271](https://jules.google.com/task/3912549075246609271) started by @badMade*