### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-30 - Server-Side Request Forgery (SSRF) in URL Fetching
+**Vulnerability:** The CLI application allowed any `http` or `https` URL to be fetched without validation, exposing the local network, metadata services (e.g., `169.254.169.254`), and loopback interface (`localhost`, `127.0.0.1`) to SSRF attacks.
+**Learning:** This existed because the original implementation only validated the URL scheme and relied on the Python `requests` library to fetch the content. It failed to account for the fact that `requests` can follow local/private IPs and redirect traffic to internal networks.
+**Prevention:** Implement a check that resolves the hostname to an IP address (`socket.getaddrinfo`) and explicitly blocks the request if the IP matches any `is_private`, `is_loopback`, `is_link_local`, `is_multicast`, `is_unspecified`, or `is_reserved` conditions using the `ipaddress` library.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -2,9 +2,42 @@
 
 from __future__ import annotations
 import argparse
+import ipaddress
 import os
+import socket
 import sys
 from urllib.parse import urlparse, unquote
+
+
+def _is_safe_url(url: str) -> bool:
+    """Check if the URL resolves to a safe, public IP address."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+
+    try:
+        # Try resolving the hostname (works for both IP literals and domain names)
+        # We check all returned IP addresses for safety.
+        addr_infos = socket.getaddrinfo(hostname, None)
+        for addr_info in addr_infos:
+            ip_str = addr_info[4][0]
+            ip = ipaddress.ip_address(ip_str)
+            # Check against local, private, or reserved ranges
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_unspecified
+                or ip.is_reserved
+            ):
+                return False
+        return True
+    except (socket.gaierror, ValueError):
+        # If we cannot resolve the hostname or parse the IP, fail securely (deny access)
+        return False
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -64,6 +97,11 @@ def main(argv=None):
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
+                return
+
+            if not _is_safe_url(target_url):
+                print(f"Error: URL resolves to a local or private network address, "
+                      "which is not allowed for security reasons.", file=sys.stderr)
                 return
 
             print(f"Processing URL: {target_url}")

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
+import builtins
 import io
 import requests
 from html2md.cli import main
@@ -59,7 +60,16 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        # Ensure we mock open after argparse finishes init or avoid breaking gettext
+                        real_open = builtins.open
+                        def safe_open(*args, **kwargs):
+                            if str(args[0]).endswith('.mo'):
+                                return real_open(*args, **kwargs)
+                            mock_obj = MagicMock()
+                            mock_obj.__enter__.return_value = mock_obj
+                            return mock_obj
+
+                        with patch('builtins.open', side_effect=safe_open) as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'
@@ -70,4 +80,7 @@ class TestCliExceptions(unittest.TestCase):
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)
-                            mock_open.assert_not_called()
+                            # Ensure we don't try to open the markdown file for writing since it escapes outdir
+                            # (Ignore gettext .mo file reads)
+                            md_opens = [call for call in mock_open.call_args_list if str(call[0][0]).endswith('.md')]
+                            self.assertEqual(len(md_opens), 0)

--- a/tests/test_cli_ssrf.py
+++ b/tests/test_cli_ssrf.py
@@ -1,0 +1,49 @@
+"""Security tests for SSRF protection."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from html2md import cli
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/admin",
+        "http://127.0.0.1/server-status",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://[::1]/",
+        "http://10.0.0.1/internal",
+        "http://192.168.1.1/config",
+        "http://172.16.0.5/api",
+    ],
+)
+@patch("requests.Session.get")
+def test_ssrf_protection_blocks_local_ips(mock_get, capsys, tmp_path, url):
+    """Local, private, and reserved IPs must be blocked to prevent SSRF."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    cli.main(["--url", url, "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+
+    assert "Error: URL resolves to a local or private network address" in outerr.err
+    mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_ssrf_protection_allows_public_ips(mock_get, capsys, tmp_path):
+    """Public, safe IPs should be allowed."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>safe</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    url = "http://example.com/safe"
+    cli.main(["--url", url, "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+
+    assert "Success!" in outerr.out
+    mock_get.assert_called_once()


### PR DESCRIPTION
Fixes a high-severity Server-Side Request Forgery (SSRF) vulnerability in the URL fetching mechanism.
Added `ipaddress` validation to block access to local, private, and reserved IPs.

---
*PR created automatically by Jules for task [17516142944494868304](https://jules.google.com/task/17516142944494868304) started by @badMade*