### PR TITLE
🎨 Palette: Disable Clear button when URL box is empty

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -87,7 +87,7 @@ $xaml = @"
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Nothing to clear" IsEnabled="False"/>
             </StackPanel>
         </Grid>
 
@@ -255,9 +255,13 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
+        $ClearBtn.ToolTip = "Nothing to clear"
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
+        $ClearBtn.ToolTip = "Clear URL list"
     }
 })
 


### PR DESCRIPTION
🎨 Palette: Improved Clear button UX in GUI

💡 **What**: Disabled the "Clear" button and updated its tooltip to "Nothing to clear" when the URL input box is empty.
🎯 **Why**: Prevents users from interacting with a disabled action and gives them a clear explanation via the tooltip, making the interface more intuitive.
♿ **Accessibility**: Improves clarity and context for users by preventing interaction with non-functional UI elements.

---
*PR created automatically by Jules for task [3061556571025638940](https://jules.google.com/task/3061556571025638940) started by @badMade*