### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to Flask application

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2024-03-28 - Missing Security Headers in Flask App
+**Vulnerability:** The Flask application `app.py` does not set security headers (CSP, X-Frame-Options, etc.), increasing the risk of XSS and clickjacking if the app expands beyond API endpoints.
+**Learning:** Even simple API or utility applications should enforce security headers to establish defense-in-depth and establish secure baselines.
+**Prevention:** Integrate a security header middleware (e.g., `@app.after_request` or Flask-Talisman) by default for all new web interfaces.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,16 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Content-Security-Policy'] = "default-src 'none'; frame-ancestors 'none'"
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,37 @@
+import pytest
+
+pytest.importorskip("flask")
+
+from html2md.app import app
+
+@pytest.fixture
+def client():
+    """Create a test client for the app."""
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_health_endpoint(client):
+    """Test the /health endpoint returns correct JSON."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["service"] == "html2md"
+
+
+def test_security_headers(client):
+    """Test that all required security headers are present in the response."""
+    response = client.get("/health")
+
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"
+
+    csp = response.headers.get("Content-Security-Policy", "")
+    assert "default-src 'none'" in csp
+    assert "frame-ancestors 'none'" in csp
+
+    hsts = response.headers.get("Strict-Transport-Security", "")
+    assert "max-age=31536000" in hsts
+    assert "includeSubDomains" in hsts


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Flask application `app.py` did not set any security headers, which increases the risk of attacks like XSS or clickjacking, especially if the API or endpoints are expanded in the future.
🎯 Impact: Attackers could potentially perform clickjacking or mime-sniffing attacks on users accessing the Flask app, or if HTML is served in the future without headers.
🔧 Fix: Added a standard `@app.after_request` middleware to automatically set `X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, and `Strict-Transport-Security` headers.
✅ Verification: Created `tests/test_app.py` to verify the headers are correctly applied on the `/health` endpoint. The tests use `pytest.importorskip("flask")` to ensure they don't break when Flask is absent.

---
*PR created automatically by Jules for task [376333121268524576](https://jules.google.com/task/376333121268524576) started by @badMade*