### PR TITLE
🎨 Palette: Show tooltip on disabled convert button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Show tooltips on disabled elements in WPF GUI]
+**Learning:** In WPF (Windows Presentation Foundation) XAML definitions, tooltips on elements do not display by default when the element is disabled (`IsEnabled="False"`). If a disabled control has a helpful tooltip explaining *why* it's disabled, users will never see it unless explicitly configured.
+**Action:** When creating WPF controls that convey disabled state reasons via `ToolTip`, add the attached property `ToolTipService.ShowOnDisabled="True"` to ensure the accessibility/UX information is actually presented to the user.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -112,6 +112,7 @@ $xaml = @"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"
+                ToolTipService.ShowOnDisabled="True"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
## Summary
Added `ToolTipService.ShowOnDisabled="True"` to the disabled `ConvertBtn` in `gui-url-convert.ps1` to ensure users can read its tooltip and understand *why* the button is disabled upon app launch. Appended corresponding learning to `.jules/palette.md`.

## AI Usage
AI-generated analysis of WPF disabled tooltips, and file replacement patches.

## Assumptions & Validation
Assumed WPF's default behavior is to hide tooltips on disabled controls. Validated that `ToolTipService.ShowOnDisabled` is the correct attached property to resolve this in XAML. Validated changes to `gui-url-convert.ps1` via shell. Tested Python unit tests and found existing failure not related to WPF UI changes.

## Design Rationale
Using a built-in WPF attached property is the cleanest, most idiomatic way to expose disabled tooltips without writing custom styles or code-behind logic.

## Testing
Tested local python exceptions, but this is a pure UI change in a PowerShell XAML file.

## Risk & Rollback
Extremely low risk (single XAML attribute addition). Rollback by removing the attribute.

## Tech Debt (If any)
None.

---
*PR created automatically by Jules for task [3977847988726551504](https://jules.google.com/task/3977847988726551504) started by @badMade*