### PR TITLE
🎨 Palette: Replace blocking MessageBox with non-blocking inline feedback in WPF GUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Use non-blocking StatusText over MessageBox for form validation in WPF]
+**Learning:** Using `[System.Windows.MessageBox]::Show` blocks the main UI thread in WPF/PowerShell applications and forces the user to manually dismiss a dialog for minor validation errors, which disrupts the flow.
+**Action:** Replace blocking MessageBox dialogs with inline feedback updates, such as setting `$StatusText.Text` with error messages, changing the text color to "Red" for visibility, and ensuring `$ProgressBar.IsIndeterminate = $false` is set to revert loading states.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -285,13 +285,17 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
+        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------


### PR DESCRIPTION
🎨 Palette: Replace blocking MessageBox with non-blocking inline feedback in WPF GUI

💡 What: Replaced `[System.Windows.MessageBox]::Show` calls with direct updates to the `$StatusText.Text` property and `$ProgressBar.IsIndeterminate = $false` within `gui-url-convert.ps1`.
🎯 Why: Modal dialogs block the main thread and disrupt the user's flow by forcing them to dismiss a popup for a simple validation error (like an invalid URL or output path). Inline status messages provide immediate, unobtrusive feedback.
♿ Accessibility: Ensures that status updates are delivered visually inline (with a red foreground color for errors) while maintaining focus context, and relies on the previously added `AutomationProperties.LiveSetting="Polite"` for screen reader announcements.

---
*PR created automatically by Jules for task [1979533563352377306](https://jules.google.com/task/1979533563352377306) started by @badMade*