### PR TITLE
🎨 Palette: Improve GUI input accessibility and access key discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2025-04-01 - [Improve GUI access key discoverability and text box readability]
+**Learning:** Access keys (like `_B` for Alt+B) in WPF buttons are not always obvious to users without pressing Alt. Appending the keyboard shortcut (e.g., "(Alt+B)") to the `ToolTip` significantly improves discoverability for keyboard users. Additionally, raw `<TextBox>` inputs in WPF often lack padding, making text hug the borders, and require `AutomationProperties.Name` to ensure screen readers announce them properly beyond just the associated label.
+**Action:** Always append keyboard shortcuts to `ToolTip`s of controls with access keys. Apply `Padding="4"` and `AutomationProperties.Name` to text inputs for better visual breathing room and enhanced accessibility.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,27 +86,28 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard (Alt+T)"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list (Alt+R)"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
+                 Padding="4" AutomationProperties.Name="URLs to convert"
                  ToolTip="Enter one or more URLs (one per line)"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <TextBox Name="OutBox" Width="340" FontSize="14" Padding="4" AutomationProperties.Name="Output Directory" ToolTip="Directory where files will be saved"/>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder (Alt+B)">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder (Alt+O)">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
+                  ToolTip="If checked, includes headers and footers. Default is main content only. (Alt+W)"/>
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
@@ -257,7 +258,7 @@ $UrlBox.Add_TextChanged({
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
     } else {
         $ConvertBtn.IsEnabled = $true
-        $ConvertBtn.ToolTip = "Start conversion process"
+        $ConvertBtn.ToolTip = "Start conversion process (Alt+C)"
     }
 })
 


### PR DESCRIPTION
💡 **What:** 
- Added `Padding="4"` and `AutomationProperties.Name` to text inputs (`UrlBox`, `OutBox`) in the WPF GUI (`gui-url-convert.ps1`).
- Appended keyboard access key shortcuts (e.g., `(Alt+T)`) to the `ToolTip`s of interactive buttons (`PasteBtn`, `ClearBtn`, `BrowseBtn`, `OpenFolderBtn`, `WholePageChk`).
- Updated the dynamic `ToolTip` logic for `ConvertBtn` to include `(Alt+C)` when enabled.

🎯 **Why:** 
- Raw text inputs in WPF can appear cramped without padding, making them harder to read.
- `AutomationProperties.Name` ensures screen readers explicitly announce the input's purpose beyond just the label context.
- Access keys (the `_` shortcut in WPF, e.g. `_Browse`) require holding `Alt` to become visible, making them hidden to many users. Adding them to tooltips improves discoverability for keyboard users.

♿ **Accessibility:** 
- Better screen reader announcements for text inputs.
- Clearer keyboard shortcut discoverability for power users and those relying on keyboard navigation.

---
*PR created automatically by Jules for task [2210725480228260472](https://jules.google.com/task/2210725480228260472) started by @badMade*