### PR TITLE
🎨 Palette: Make disabled Convert button tooltip visible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-25 - [Make ToolTips visible on disabled WPF controls]
+**Learning:** In WPF (used in `gui-url-convert.ps1`), `ToolTip`s on elements like `<Button>` are hidden by default when the element is disabled (`IsEnabled="False"`). If the tooltip contains crucial information explaining *why* the element is disabled, this creates an accessibility and usability issue because users cannot see the explanation.
+**Action:** When adding a helpful explanation to a disabled control via a `ToolTip`, always add the `ToolTipService.ShowOnDisabled="True"` attached property to ensure it remains visible and accessible to users when disabled.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -112,6 +112,7 @@ $xaml = @"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"
+                ToolTipService.ShowOnDisabled="True"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
💡 What: Added `ToolTipService.ShowOnDisabled="True"` to the disabled "Convert" button.
🎯 Why: In WPF, tooltips on disabled controls are hidden by default! This meant users couldn't see the helpful tooltip explaining *why* the button was disabled. This ensures the tooltip is always visible on hover.
♿ Accessibility: Improves accessibility and usability by providing clear feedback to users on why an action is unavailable.

---
*PR created automatically by Jules for task [11556137584705641277](https://jules.google.com/task/11556137584705641277) started by @badMade*