### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-03 - [MEDIUM] Add input length limits to prevent DoS
+**Vulnerability:** The CLI was downloading files by reading the entire response body into memory at once (`session.get(target_url)`), leaving it vulnerable to Out-Of-Memory (OOM) / Denial of Service (DoS) attacks if a malicious server returned an endless or massive payload.
+**Learning:** In python scripts dealing with external URLs, always use stream processing and size limits, as malicious payload sizes can crash memory.
+**Prevention:** Use `stream=True` in `requests.get` and process content in chunks, explicitly tracking accumulated size and terminating the request if it exceeds reasonable bounds (e.g., 10MB).

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -70,11 +70,23 @@ def main(argv=None):
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = session.get(target_url, timeout=30, stream=True)
                 response.raise_for_status()
 
+                # Enforce a 10MB limit on the downloaded content to prevent DoS (OOM)
+                MAX_SIZE = 10 * 1024 * 1024
+                content_bytes = bytearray()
+                for chunk in response.iter_content(chunk_size=8192):
+                    content_bytes.extend(chunk)
+                    if len(content_bytes) > MAX_SIZE:
+                        print("Error: Response exceeded maximum allowed size (10MB).", file=sys.stderr)
+                        return
+
+                response.encoding = response.encoding or 'utf-8'
+                html_text = content_bytes.decode(response.encoding, errors='replace')
+
                 print("Converting to Markdown...")
-                md_content = md(response.text, heading_style="ATX")
+                md_content = md(html_text, heading_style="ATX")
 
                 if args.outdir:
                     if not os.path.exists(args.outdir):

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -49,6 +49,8 @@ class TestCliError(unittest.TestCase):
         mock_requests.Session.return_value = mock_session
         mock_response = MagicMock()
         mock_response.text = "<html></html>"
+        mock_response.encoding = "utf-8"
+        mock_response.iter_content.return_value = [b"<html></html>"]
         mock_session.get.return_value = mock_response
 
         mock_markdownify = MagicMock()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -31,12 +31,14 @@ class TestCliExceptions(unittest.TestCase):
             with patch('requests.Session.get') as mock_get:
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
+                mock_resp.encoding = "utf-8"
+                mock_resp.iter_content.return_value = [b"<h1>Hello</h1>"]
                 mock_resp.status_code = 200
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
+                        with patch('html2md.cli.open', side_effect=OSError("Permission denied")):
                              try:
                                  main(['--url', 'http://example.com', '--outdir', 'dummy'])
                              except Exception as e:
@@ -54,12 +56,14 @@ class TestCliExceptions(unittest.TestCase):
             with patch('requests.Session.get') as mock_get:
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
+                mock_resp.encoding = "utf-8"
+                mock_resp.iter_content.return_value = [b"<h1>Hello</h1>"]
                 mock_resp.status_code = 200
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        with patch('html2md.cli.open') as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -34,6 +34,8 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
 
     response = MagicMock()
     response.text = "<h1>dummy</h1>"
+    response.encoding = "utf-8"
+    response.iter_content.return_value = [b"<h1>dummy</h1>"]
     response.raise_for_status.return_value = None
     mock_get.return_value = response
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The CLI read entire external HTTP responses directly into memory via `requests.get()`. A malicious server returning a massive or endless payload could crash the application by triggering an Out-Of-Memory (OOM) error (Denial of Service).
🎯 **Impact:** Potential application crash and denial of service.
🔧 **Fix:** Refactored the `requests` fetching logic to use `stream=True`, processing the response via `iter_content()`, and returning early with an error if the accumulated size exceeds 10MB.
✅ **Verification:** Updated all relevant mock setups in the pytest suite (`test_cli_error.py`, `test_cli_exceptions.py`, `test_cli_security.py`) to correctly reflect `iter_content` behaviour, and verified `python -m pytest tests/` passes successfully.

---
*PR created automatically by Jules for task [7567255175311465560](https://jules.google.com/task/7567255175311465560) started by @badMade*