### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in URL fetching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-09 - Server-Side Request Forgery (SSRF) via Unvalidated URL Fetching
+**Vulnerability:** The CLI `html2md` tool fetched URLs directly using `requests.get` without any validation of the target IP address. This allowed users to supply URLs like `http://localhost:8080` or `http://169.254.169.254/latest/meta-data/` to access internal services, metadata APIs, and loopback interfaces.
+**Learning:** Any tool that accepts a user-provided URL and fetches its content on behalf of the user is fundamentally an SSRF vector if the target IP is not validated. The application must not implicitly trust that standard URLs point to external resources.
+**Prevention:** Always perform DNS resolution *before* making the HTTP request, and use the `ipaddress` module to ensure the resolved IP does not belong to private (`is_private`), loopback (`is_loopback`), or link-local (`is_link_local`) subnets.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import socket
+import ipaddress
 from urllib.parse import urlparse, unquote
 
 def main(argv=None):
@@ -64,6 +66,28 @@ def main(argv=None):
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
+                return
+
+            # SSRF Protection: Resolve hostname and verify it's not internal/private
+            try:
+                hostname = parsed.hostname or ""
+                # Use getaddrinfo to support both IPv4 and IPv6
+                addr_info = socket.getaddrinfo(hostname, None)
+                # Check all resolved IPs for the hostname
+                for info in addr_info:
+                    ip = info[4][0]
+                    # Strip IPv6 scope ID if present (e.g. fe80::1%eth0)
+                    if '%' in ip:
+                        ip = ip.split('%')[0]
+                    ip_obj = ipaddress.ip_address(ip)
+                    if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+                        print(f"Error: Security violation - accessing internal/private IP ({ip}) is prohibited.", file=sys.stderr)
+                        return
+            except socket.gaierror:
+                print(f"Error: Could not resolve hostname '{hostname}'.", file=sys.stderr)
+                return
+            except ValueError:
+                print(f"Error: Invalid IP address resolved for '{hostname}'.", file=sys.stderr)
                 return
 
             print(f"Processing URL: {target_url}")

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -10,64 +10,68 @@ class TestCliExceptions(unittest.TestCase):
         # Mock sys.stderr to capture output
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
-            # Patch requests.Session.get directly
-            with patch('requests.Session.get') as mock_get:
-                mock_get.side_effect = requests.RequestException("Network unreachable")
+            with patch('socket.getaddrinfo', return_value=[(2, 1, 6, '', ("8.8.8.8", 80))]):
+                # Patch requests.Session.get directly
+                with patch('requests.Session.get') as mock_get:
+                    mock_get.side_effect = requests.RequestException("Network unreachable")
 
-                try:
-                    main(['--url', 'http://example.com'])
-                except Exception as e:
-                    self.fail(f"main raised exception {e}")
+                    try:
+                        main(['--url', 'http://example.com'])
+                    except Exception as e:
+                        self.fail(f"main raised exception {e}")
 
-                output = captured_stderr.getvalue()
-                # Expect "Network error: Network unreachable"
-                self.assertIn("Network error", output)
-                self.assertIn("Network unreachable", output)
+                    output = captured_stderr.getvalue()
+                    # Expect "Network error: Network unreachable"
+                    self.assertIn("Network error", output)
+                    self.assertIn("Network unreachable", output)
 
     def test_file_error(self):
         """Test that file I/O errors are caught and printed."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+            with patch('socket.getaddrinfo', return_value=[(2, 1, 6, '', ("8.8.8.8", 80))]):
+                with patch('requests.Session.get') as mock_get:
+                    mock_resp = MagicMock()
+                    mock_resp.text = "<h1>Hello</h1>"
+                    mock_resp.status_code = 200
+                    mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
-                    with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
-                             try:
-                                 main(['--url', 'http://example.com', '--outdir', 'dummy'])
-                             except Exception as e:
-                                 self.fail(f"main raised exception {e}")
+                    with patch('markdownify.markdownify', return_value="# Hello"):
+                        with patch('os.makedirs'), patch('os.path.exists', return_value=False):
+                            with patch('builtins.open', side_effect=OSError("Permission denied")):
+                                 try:
+                                     main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                                 except Exception as e:
+                                     self.fail(f"main raised exception {e}")
 
-                             output = captured_stderr.getvalue()
-                             # Expect "File error: Permission denied"
-                             self.assertIn("File error", output)
-                             self.assertIn("Permission denied", output)
+                                 output = captured_stderr.getvalue()
+                                 # Expect "File error: Permission denied"
+                                 self.assertIn("File error", output)
+                                 self.assertIn("Permission denied", output)
 
     def test_outdir_containment_uses_path_aware_check(self):
         """Test that output containment check rejects prefix-matching escapes."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+            with patch('socket.getaddrinfo', return_value=[(2, 1, 6, '', ("8.8.8.8", 80))]):
+                with patch('requests.Session.get') as mock_get:
+                    mock_resp = MagicMock()
+                    mock_resp.text = "<h1>Hello</h1>"
+                    mock_resp.status_code = 200
+                    mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
-                    with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
-                            def fake_realpath(path):
-                                if str(path).endswith('.md'):
-                                    return '/tmp/outside/a.md'
-                                return '/tmp/out'
+                    with patch('markdownify.markdownify', return_value="# Hello"):
+                        with patch('os.path.exists', return_value=True):
+                            # Ensure we don't mock open globally to break argparse gettext inside python 3.12+
+                            with patch('html2md.cli.open') as mock_open:
+                                def fake_realpath(path):
+                                    if str(path).endswith('.md'):
+                                        return '/tmp/outside/a.md'
+                                    return '/tmp/out'
 
-                            with patch('os.path.realpath', side_effect=fake_realpath):
-                                main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
+                                with patch('os.path.realpath', side_effect=fake_realpath):
+                                    main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
 
-                            output = captured_stderr.getvalue()
-                            self.assertIn("Output path escapes output directory", output)
-                            mock_open.assert_not_called()
+                                output = captured_stderr.getvalue()
+                                self.assertIn("Output path escapes output directory", output)
+                                mock_open.assert_not_called()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -23,8 +23,36 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
     mock_get.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "url, mock_ip, expected_error",
+    [
+        ("http://localhost/admin", "127.0.0.1", "Error: Security violation - accessing internal/private IP (127.0.0.1) is prohibited."),
+        ("http://127.0.0.1:8080", "127.0.0.1", "Error: Security violation - accessing internal/private IP (127.0.0.1) is prohibited."),
+        ("http://169.254.169.254/metadata", "169.254.169.254", "Error: Security violation - accessing internal/private IP (169.254.169.254) is prohibited."),
+        ("http://10.0.0.1/internal", "10.0.0.1", "Error: Security violation - accessing internal/private IP (10.0.0.1) is prohibited."),
+        ("http://172.16.0.1/", "172.16.0.1", "Error: Security violation - accessing internal/private IP (172.16.0.1) is prohibited."),
+        ("http://192.168.1.100/", "192.168.1.100", "Error: Security violation - accessing internal/private IP (192.168.1.100) is prohibited."),
+        ("http://[::1]/", "::1", "Error: Security violation - accessing internal/private IP (::1) is prohibited."),
+        ("http://[fe80::1%eth0]/", "fe80::1%eth0", "Error: Security violation - accessing internal/private IP (fe80::1) is prohibited."),
+        ("http://[fd00::1]/", "fd00::1", "Error: Security violation - accessing internal/private IP (fd00::1) is prohibited."),
+    ]
+)
+@patch("socket.getaddrinfo")
 @patch("requests.Session.get")
-def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
+def test_ssrf_protection_blocks_internal_ips(mock_get, mock_getaddrinfo, capsys, tmp_path, url, mock_ip, expected_error):
+    """SSRF protection blocks requests to internal/private IPs."""
+    # socket.getaddrinfo returns a list of tuples: (family, type, proto, canonname, sockaddr)
+    mock_getaddrinfo.return_value = [(2, 1, 6, '', (mock_ip, 80))]
+
+    cli.main(["--url", url, "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert expected_error in outerr.err
+    mock_get.assert_not_called()
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_traversal_like_paths_stay_within_outdir(mock_get, mock_getaddrinfo, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""
     outdir = tmp_path / "output"
     outdir.mkdir()
@@ -36,6 +64,7 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     response.text = "<h1>dummy</h1>"
     response.raise_for_status.return_value = None
     mock_get.return_value = response
+    mock_getaddrinfo.return_value = [(2, 1, 6, '', ("8.8.8.8", 80))]
 
     urls = [
         "http://example.com/foo/../..%2Fsecret.txt",


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The CLI `html2md` tool fetched URLs directly using `requests.get` without any validation of the target IP address. This allowed users to supply URLs pointing to internal loopback addresses (e.g., `http://localhost:8080`) or cloud metadata endpoints (e.g., `http://169.254.169.254/latest/meta-data/`).
🎯 **Impact:** An attacker could exploit this to perform Server-Side Request Forgery (SSRF), accessing internal applications, restricted network segments, or sensitive cloud metadata instances.
🔧 **Fix:** Implemented a pre-flight DNS resolution check using `socket.getaddrinfo`. The resolved IP address is verified against private, loopback, and link-local ranges using the `ipaddress` module. If the target is internal, the request is blocked before any HTTP connection is established. This supports both IPv4 and IPv6.
✅ **Verification:**
1. Unit tests added to verify protection for IPv4 and IPv6 loopback, link-local, and private ranges.
2. Verified all tests pass via `PYTHONPATH=src pytest`.
3. Code review completed successfully.

---
*PR created automatically by Jules for task [17452291482652371047](https://jules.google.com/task/17452291482652371047) started by @badMade*