### PR TITLE
🎨 Palette: Use non-blocking status errors in GUI

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -285,13 +285,17 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
+        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------


### PR DESCRIPTION
Replaced intrusive modal `MessageBox` popups for URL and output directory validation with non-blocking inline `$StatusText` updates and `$ProgressBar` resets in the WPF GUI (`gui-url-convert.ps1`). This micro-UX improvement prevents user flow interruptions and leverages the status bar's screen reader polite automation property.

---
*PR created automatically by Jules for task [4388602158513641414](https://jules.google.com/task/4388602158513641414) started by @badMade*