### PR TITLE
🎨 Palette: Replace blocking MessageBox with non-blocking status bar feedback

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -286,9 +286,14 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
+$uri = $null
+    if (-not [System.Uri]::TryCreate($url, [System.UriKind]::Absolute, [ref]$uri) -or ($uri.Scheme -ne 'http' -and $uri.Scheme -ne 'https')) {
         $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
         $StatusText.Foreground = "Red"
         $ProgressBar.IsIndeterminate = $false
+        return
+    }
+    $url = $uri.AbsoluteUri
         return
     }
 

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -278,24 +278,23 @@ $ConvertBtn.Add_Click({
     }
 
     # --- Security Validation ---
-    try {
-        $uriObj = [System.Uri]$url
-        if ($uriObj.Scheme -notmatch '^https?$') {
-            throw "Invalid scheme"
+    $validUrls = @()
+    foreach ($u in $urlList) {
+        try {
+            $uriObj = [System.Uri]$u
+            if ($uriObj.Scheme -notmatch '^https?$') {
+                throw "Invalid scheme"
+            }
+            # AbsoluteUri is properly percent-encoded, preventing quote-based injection
+            $validUrls += $uriObj.AbsoluteUri
+        } catch {
+            $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+            $StatusText.Foreground = "Red"
+            $ProgressBar.IsIndeterminate = $false
+            return
         }
-        # AbsoluteUri is properly percent-encoded, preventing quote-based injection
-        $url = $uriObj.AbsoluteUri
-    } catch {
-$uri = $null
-    if (-not [System.Uri]::TryCreate($url, [System.UriKind]::Absolute, [ref]$uri) -or ($uri.Scheme -ne 'http' -and $uri.Scheme -ne 'https')) {
-        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
-        $StatusText.Foreground = "Red"
-        $ProgressBar.IsIndeterminate = $false
-        return
     }
-    $url = $uri.AbsoluteUri
-        return
-    }
+    $urlList = $validUrls
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -273,6 +273,7 @@ $ConvertBtn.Add_Click({
     if ($urlList.Count -eq 0) {
         $StatusText.Text = "Please enter a URL."
         $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
@@ -285,13 +286,17 @@ $ConvertBtn.Add_Click({
         # AbsoluteUri is properly percent-encoded, preventing quote-based injection
         $url = $uriObj.AbsoluteUri
     } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
+        $StatusText.Text = "Please enter a valid HTTP/HTTPS URL."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
-        [System.Windows.MessageBox]::Show("Invalid characters detected in output directory.","Security Warning","OK","Warning") | Out-Null
+        $StatusText.Text = "Invalid characters detected in output directory."
+        $StatusText.Foreground = "Red"
+        $ProgressBar.IsIndeterminate = $false
         return
     }
     # ---------------------------


### PR DESCRIPTION
💡 **What:** The UX enhancement replaces blocking modal dialogs (`MessageBox`) with inline, non-blocking error messages displayed in the status bar. It also ensures that the progress bar stops spinning (`IsIndeterminate = $false`) when an early validation error occurs.

🎯 **Why:** Blocking dialogs are generally discouraged in modern UX design as they interrupt the user's workflow entirely. Inline feedback allows users to see errors in context and immediately fix them without an extra click to dismiss a popup. Furthermore, leaving the progress bar in an indeterminate ("loading") state after a validation failure confuses users into thinking the application is still processing.

📸 **Before/After:**
*Before:* Clicking "Convert" with an invalid URL spawns a popup error and leaves the progress bar animating indefinitely.
*After:* Clicking "Convert" instantly turns the status text red with the error message and resets the progress bar.

♿ **Accessibility:** By routing these updates through the status bar, which is already configured with `AutomationProperties.LiveSetting="Polite"`, screen readers will gracefully announce these validation errors to visually impaired users without stealing focus.

---
*PR created automatically by Jules for task [11107325289644372296](https://jules.google.com/task/11107325289644372296) started by @badMade*