### PR TITLE
🎨 Palette: Add keyboard shortcut hints and improve screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2026-04-07 - [Keyboard Shortcuts Accessibility in GUI Tooltips and TextBoxes]
+**Learning:** In WPF applications using XAML (`gui-url-convert.ps1`), discoverability of keyboard shortcuts (access keys defined with `_`) is improved significantly by appending them explicitly to `ToolTip` properties. Additionally, while `Label` targeting is necessary, directly applying `AutomationProperties.Name` to a `TextBox` provides robust and unambiguous identification for screen readers, acting as a direct fallback and ensuring cross-tool compatibility.
+**Action:** Always append shortcut hints (e.g., `(Alt+C)`) to tooltips for buttons and checkboxes with access keys. Explicitly assign `AutomationProperties.Name` to complex or key input fields like TextBoxes, alongside their descriptive labels.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,32 +86,34 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard (Alt+T)"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list (Alt+R)"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 ToolTip="Enter one or more URLs (one per line)"
+                 AutomationProperties.Name="URL Input Box"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"
+                         AutomationProperties.Name="Output Directory"/>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder (Alt+B)">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder (Alt+O)">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
+                  ToolTip="If checked, includes headers and footers. Default is main content only. (Alt+W)"/>
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
-                ToolTip="Please enter at least one URL to enable conversion"
+                ToolTip="Please enter at least one URL to enable conversion (Alt+C)"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>
@@ -254,10 +256,10 @@ $ClearBtn.Add_Click({
 $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
-        $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion (Alt+C)"
     } else {
         $ConvertBtn.IsEnabled = $true
-        $ConvertBtn.ToolTip = "Start conversion process"
+        $ConvertBtn.ToolTip = "Start conversion process (Alt+C)"
     }
 })
 


### PR DESCRIPTION
🎨 **Palette's Daily Enhancement**

**💡 What:**
- Added explicit keyboard shortcut hints (like `(Alt+T)`) to the `ToolTip` attributes of all buttons and the checkbox.
- Added explicit `AutomationProperties.Name` labels to the `UrlBox` and `OutBox` TextBoxes.
- Updated the dynamic event handler logic for the `ConvertBtn` to preserve its shortcut hint when the text box state changes.
- Updated `.jules/palette.md` with a new journal entry about WPF accessibility patterns.

**🎯 Why:** 
- The WPF application defined its access keys using `_` (e.g., `_Browse`), which allows users to press `Alt+B` to activate it. However, unless the user accidentally pressed `Alt`, these shortcuts were hidden. Adding them to the ToolTip improves discoverability.
- While the text boxes are targeted by `Label` tags, adding a direct `AutomationProperties.Name` provides a robust fallback for various screen readers to ensure they are always announced clearly.

**♿ Accessibility:**
- Improves keyboard navigation discoverability for power users and those with motor disabilities.
- Increases screen reader reliability for complex text input fields.

---
*PR created automatically by Jules for task [3581766749362635768](https://jules.google.com/task/3581766749362635768) started by @badMade*