### PR TITLE
🎨 Palette: Add keyboard shortcut hints to ToolTips for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2026-04-08 - [Add keyboard shortcut hints to ToolTips for accessibility]
+**Learning:** In WPF applications using XAML, keyboard shortcuts defined via mnemonics (e.g., `_Paste`) are not always obvious to sighted users without pressing Alt, and screen readers may not clearly announce them. Adding explicit keyboard shortcut hints (e.g., `(Alt+P)`) to the `ToolTip` properties greatly improves discoverability and provides important context for accessibility.
+**Action:** When designing WPF UIs with mnemonics, always append the shortcut hint to the element's `ToolTip` to ensure all users can easily discover and use keyboard navigation.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -86,27 +86,27 @@ $xaml = @"
             </Grid.ColumnDefinitions>
             <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
-                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard (Alt+T)"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list (Alt+R)"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
-                 ToolTip="Enter one or more URLs (one per line)"/>
+                 ToolTip="Enter one or more URLs (one per line) (Alt+P)"/>
 
         <StackPanel Grid.Row="2" Orientation="Vertical">
             <Label Content="Output _Directory:" Target="{Binding ElementName=OutBox}" FontSize="14" Padding="0,0,0,2"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved"/>
-                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder">_Browse...</Button>
-                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
+                <TextBox Name="OutBox" Width="340" FontSize="14" ToolTip="Directory where files will be saved (Alt+D)"/>
+                <Button Name="BrowseBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Select output folder (Alt+B)">_Browse...</Button>
+                <Button Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder (Alt+O)">_Open Folder</Button>
             </StackPanel>
         </StackPanel>
 
         <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
+                  ToolTip="If checked, includes headers and footers. Default is main content only. (Alt+W)"/>
 
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
@@ -257,7 +257,7 @@ $UrlBox.Add_TextChanged({
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
     } else {
         $ConvertBtn.IsEnabled = $true
-        $ConvertBtn.ToolTip = "Start conversion process"
+        $ConvertBtn.ToolTip = "Start conversion process (Alt+C)"
     }
 })
 


### PR DESCRIPTION
### 💡 What
Added explicit keyboard shortcuts (e.g., `(Alt+P)`, `(Alt+T)`) to the `ToolTip` properties of UI elements in `gui-url-convert.ps1` that have mnemonic keys.

### 🎯 Why
In WPF applications, mnemonic shortcut keys (defined by prefixing characters with `_`) are not always obvious to sighted users unless they press the `Alt` key, and screen readers may not clearly announce them based on the label alone. Appending the shortcut directly to the tooltip significantly improves discoverability without visual clutter.

### 📸 Before/After
- **Before:** Hovering over the URL textbox showed `Enter one or more URLs (one per line)`
- **After:** Hovering over the URL textbox shows `Enter one or more URLs (one per line) (Alt+P)`

### ♿ Accessibility
This provides crucial context for screen reader users and improves the discoverability of keyboard navigation for users who rely on the keyboard over a mouse.

---
*PR created automatically by Jules for task [17571443938645524374](https://jules.google.com/task/17571443938645524374) started by @badMade*