### PR TITLE
🎨 Palette: Show ToolTip on disabled Convert button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2024-05-24 - [Show tooltips on disabled WPF buttons]
+**Learning:** In WPF (Windows Presentation Foundation), when an element like a `<Button>` is disabled (`IsEnabled="False"`), its `ToolTip` is also disabled by default. This is problematic for accessibility and UX because users need to know *why* the button is disabled, and the tooltip often contains this explanation (e.g., "Please enter at least one URL to enable conversion").
+**Action:** When adding explanatory tooltips to buttons or other elements that can be disabled, always add `ToolTipService.ShowOnDisabled="True"` to the element in XAML to ensure the helpful text remains accessible.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -112,6 +112,7 @@ $xaml = @"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
                 ToolTip="Please enter at least one URL to enable conversion"
+                ToolTipService.ShowOnDisabled="True"
                 />
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>


### PR DESCRIPTION
### 💡 What: 
Added `ToolTipService.ShowOnDisabled="True"` to the `ConvertBtn` in `gui-url-convert.ps1`.

### 🎯 Why: 
In WPF, elements that are `IsEnabled="False"` do not display their `ToolTip` by default. The Convert button has a helpful tooltip ("Please enter at least one URL to enable conversion") but users couldn't see it when they needed it most—when trying to figure out why they couldn't click the button!

### ♿ Accessibility:
Ensures that explanatory text for disabled states is accessible via mouse hover, improving overall usability and meeting standard UX expectations for disabled controls.

### 📝 Journal:
Added an entry to `.jules/palette.md` to document this WPF-specific behavior and solution for future use.

---
*PR created automatically by Jules for task [12640092778664089858](https://jules.google.com/task/12640092778664089858) started by @badMade*