### PR TITLE
🎨 Palette: Add accessibility label and tooltip to conversion log

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+## 2024-05-25 - [Added Label and ToolTip to LogBox in GUI]
+**Learning:** For WPF applications using XAML to define UI, inputs should have a `<Label>` with `Target` pointing to the input field, which improves accessibility for screen readers and keyboard navigation. Using access keys (like `_L` for Alt+L) in the label content provides a helpful keyboard shortcut.
+**Action:** When creating or modifying WPF UI files, ensure all input fields (including read-only logs) have a designated `Label` with `Target` bound properly and consider adding a `ToolTip` to explain their purpose.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -75,7 +75,9 @@ $xaml = @"
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -116,10 +118,12 @@ $xaml = @"
 
         <ProgressBar Name="ProgressBar" Grid.Row="4" Height="10" Margin="0,10,0,0" IsIndeterminate="False" AutomationProperties.Name="Conversion Progress"/>
         
-        <TextBox Name="LogBox" Grid.Row="5" Margin="0,10,0,0" FontFamily="Consolas" FontSize="12"
-                 TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
+        <Label Grid.Row="5" Content="_Log Output:" Target="{Binding ElementName=LogBox}" FontSize="14" Padding="0,0,0,2" Margin="0,10,0,0"/>
+        <TextBox Name="LogBox" Grid.Row="6" Margin="0,2,0,0" FontFamily="Consolas" FontSize="12"
+                 TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"
+                 ToolTip="Displays progress and error logs during conversion"/>
 
-        <StatusBar Grid.Row="6" Margin="0,10,0,0">
+        <StatusBar Grid.Row="7" Margin="0,10,0,0">
             <TextBlock Name="StatusText" Text="Ready" AutomationProperties.LiveSetting="Polite">
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">


### PR DESCRIPTION
💡 What: Added a `<Label>` with an access key and `Target` binding for the `LogBox`, and included a `ToolTip` to explain its purpose.
🎯 Why: To improve the user experience by making the log output area more accessible to screen readers, providing a keyboard shortcut, and clearly explaining its function.
♿ Accessibility: Associated a descriptive label with the read-only log output field and provided a tool tip.

---
*PR created automatically by Jules for task [16481488904668854762](https://jules.google.com/task/16481488904668854762) started by @badMade*