### PR TITLE
Add self-healing workflow and scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Assign @google-labs-jules as a reviewer for all pull requests
-* @jules
+* @badMade
+apps/** @badMade
+packages/** @badMade

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -1,0 +1,85 @@
+name: Self-heal (auto-fix & PR)
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  self-heal:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install deps (best-effort frozen)
+        id: install_try_frozen
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
+
+      - name: Install deps (fallback non-frozen)
+        if: steps.install_try_frozen.outputs.FROZEN_FAILED == '1'
+        run: |
+          set -euxo pipefail
+          pnpm install
+
+      - name: Run healthcheck (pre-repair)
+        continue-on-error: true
+        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+
+      - name: Attempt self-heal repairs
+        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+
+      - name: Run healthcheck (post-repair)
+        id: post
+        continue-on-error: true
+        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+
+      - name: Collect logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfheal-logs
+          path: |
+            selfheal-pre.txt
+            selfheal-repair.txt
+            selfheal-post.txt
+
+      - name: Create PR with fixes
+        if: steps.post.outcome == 'success'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(self-heal): auto-fix CI failures"
+          title: "🤖 Self-heal auto-fixes"
+          body: |
+            Automated fixes from the `self-heal` workflow.
+
+            Logs have been uploaded to job artifacts.
+          branch: "auto-heal/fixes"
+          labels: "self-heal"
+          assignees: "badMade"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "healthcheck": "node scripts/healthcheck.mjs",
+    "self:heal": "node scripts/self-heal.mjs",
+    "lint": "eslint .",
+    "format": "prettier -w .",
+    "typecheck": "tsc -b",
+    "test": "vitest run"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'apps/*'

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/* Minimal, opinionated healthcheck for a pnpm monorepo:
+   - root: typecheck? test? lint? build?
+   - workspaces: smoke build where available
+*/
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const run = (cmd) => execSync(cmd, { stdio: "inherit" });
+const hasScript = (name) => {
+  try {
+    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
+    return out.includes(name);
+  } catch { return false; }
+};
+
+const tryRun = (name, cmd) => {
+  if (!cmd) return;
+  console.log(`\n==> ${name}`);
+  run(cmd);
+};
+
+try {
+  // Root-level checks (best-effort if scripts exist)
+  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
+  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
+  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+
+  // Workspace smoke builds (apps/* and packages/* if build exists)
+  const roots = ["apps", "packages"];
+  for (const base of roots) {
+    if (!existsSync(base)) continue;
+    for (const name of readdirSync(base)) {
+      const dir = join(base, name);
+      if (!statSync(dir).isDirectory()) continue;
+      try {
+        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
+      } catch (e) {
+        console.error(`[healthcheck] build failed in ${dir}`);
+        process.exitCode = 1;
+      }
+    }
+  }
+  process.exit(process.exitCode ?? 0);
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/* Targeted, ordered repairs. Each step is idempotent and re-runs healthcheck.
+   Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
+*/
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+
+const sh = (cmd, opts={}) => {
+  console.log(`\n$ ${cmd}`);
+  return execSync(cmd, { stdio: "inherit", ...opts });
+};
+const trySh = (cmd, opts={}) => {
+  try { sh(cmd, opts); return true; } catch { return false; }
+};
+const changed = () => {
+  const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
+  return (out.stdout || "").trim().length > 0;
+};
+const passHealth = () => {
+  try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
+};
+
+let fixed = false;
+
+// 1) Lint/format
+trySh("pnpm -w run lint --fix");
+trySh("pnpm -w run format");
+if (passHealth()) fixed = fixed || changed();
+
+// 2) Snapshot updates (only if tests fail with snapshots)
+if (!passHealth()) {
+  trySh("pnpm -w exec vitest -u");
+  if (passHealth()) fixed = fixed || changed();
+}
+
+// 3) Type acquisition
+if (!passHealth()) {
+  trySh("pnpm dlx typesync --save-dev");
+  // In case typesync suggests @types/node et al.
+  trySh("pnpm -w install");
+  if (passHealth()) fixed = fixed || changed();
+}
+
+// 4) Lockfile repair (only if integrity complaints)
+if (!passHealth()) {
+  // Try a clean install + re-resolve
+  trySh("pnpm install");
+  if (!passHealth()) {
+    // Last resort: refresh lockfile (scoped)
+    trySh("pnpm -w up --latest --interactive=false");
+  }
+  if (passHealth()) fixed = fixed || changed();
+}
+
+// 5) Known generators (icons/docs), if present
+if (!passHealth()) {
+  if (existsSync("scripts/update-icon-docs.mjs")) {
+    trySh("node scripts/update-icon-docs.mjs");
+  }
+  if (existsSync("scripts/verify-static.mjs")) {
+    trySh("node scripts/verify-static.mjs");
+  }
+  if (passHealth()) fixed = fixed || changed();
+}
+
+if (fixed && passHealth()) {
+  console.log("\n[self-heal] Repairs successful and verified!");
+  process.exit(0);
+} else {
+  console.log("\n[self-heal] No repairs succeeded or repairs did not pass healthcheck.");
+  process.exit(1);
+}


### PR DESCRIPTION
- Add `.github/workflows/self-heal.yml` to trigger on CI failures.
- Add `scripts/healthcheck.mjs` and `scripts/self-heal.mjs` for running checks and repairs.
- Add `package.json` and `pnpm-workspace.yaml` to run scripts.
- Add `.github/CODEOWNERS` mapped to `@badMade`.

---
*PR created automatically by Jules for task [17609970804676036648](https://jules.google.com/task/17609970804676036648) started by @badMade*