### PR TITLE
🎨 Palette: Make Tooltip Visible on Disabled Convert Button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Add labels to output directory field and screen reader polite announcement for status bar in GUI]
 **Learning:** For WPF applications using XAML to define UI (as in `gui-url-convert.ps1`), inputs should have `<Label>` associated with them, pointing to the input field using `Target="{Binding ElementName=...}"`. Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers unless configured with `AutomationProperties.LiveSetting="Polite"`.
 **Action:** When working on WPF UI files, ensure `TextBox` fields have a designated `Label` with `Target` bound properly, and status text blocks should have `AutomationProperties.LiveSetting="Polite"` for screen readers to pick up state changes unobtrusively.
+
+## 2026-04-13 - [Make disabled button tooltips visible in WPF XAML]
+**Learning:** In WPF applications using XAML (such as `gui-url-convert.ps1`), tooltips on disabled elements are hidden by default. This hides important context from users regarding *why* an action (like a "Convert" button) is disabled. Setting `ToolTipService.ShowOnDisabled="True"` ensures the tooltip remains visible, improving usability and accessibility.
+**Action:** When adding or maintaining `ToolTip`s on WPF buttons or controls that can be disabled, explicitly set `ToolTipService.ShowOnDisabled="True"` so users can read the tooltip and learn what action they need to take to enable the control.

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -111,6 +111,7 @@ $xaml = @"
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
+                ToolTipService.ShowOnDisabled="True"
                 ToolTip="Please enter at least one URL to enable conversion"
                 />
 


### PR DESCRIPTION
💡 **What:**
Added `ToolTipService.ShowOnDisabled="True"` to the main "Convert" button in the WPF UI (`gui-url-convert.ps1`).
    
🎯 **Why:**
In WPF, tooltips are hidden on disabled elements by default. This prevents users from understanding why an action is blocked. This change ensures users can always see the helpful text ("Please enter at least one URL to enable conversion") that explains exactly what they need to do to proceed.

♿ **Accessibility:**
Provides crucial context to screen readers and visual users about the disabled state of a primary action control, making the interface more inclusive and self-explanatory.

Also added a journal entry noting this WPF XAML specific behaviour.

---
*PR created automatically by Jules for task [9220599202462893641](https://jules.google.com/task/9220599202462893641) started by @badMade*