### PR TITLE
⚡ Bolt: [Security] Add netloc validation to url parsing

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   request-review:

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -61,6 +61,9 @@ def main(argv=None):
                 target_url = target_url.replace('/?', '?')
 
             parsed = urlparse(target_url)
+            if not parsed.netloc:
+                print("Error: Invalid URL. Missing network location.", file=sys.stderr)
+                return
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -61,8 +61,8 @@ def main(argv=None):
                 target_url = target_url.replace('/?', '?')
 
             parsed = urlparse(target_url)
-            if not parsed.netloc:
-                print("Error: Invalid URL. Missing network location.", file=sys.stderr)
+            if not parsed.hostname:
+                print("Error: Invalid URL. Missing hostname.", file=sys.stderr)
                 return
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -61,12 +61,12 @@ def main(argv=None):
                 target_url = target_url.replace('/?', '?')
 
             parsed = urlparse(target_url)
-            if not parsed.hostname:
-                print("Error: Invalid URL. Missing hostname.", file=sys.stderr)
-                return
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
+                return
+            if not parsed.netloc:
+                print("Error: Invalid URL. Missing network location.", file=sys.stderr)
                 return
 
             print(f"Processing URL: {target_url}")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -51,3 +51,12 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+@patch("requests.Session.get")
+def test_process_url_missing_netloc_rejected_before_network_call(mock_get, capsys, tmp_path):
+    """Malformed http URL without netloc is rejected before any network call."""
+    cli.main(["--url", "http:///something", "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+    assert "Error: Invalid URL. Missing network location." in outerr.err
+    mock_get.assert_not_called()


### PR DESCRIPTION
💡 What: Added URL `netloc` validation in the `process_url` function to immediately reject parsed URLs without a network location.
🎯 Why: Prevents processing malformed or abusive URLs (e.g., `http:///path`), adding a layer of defense against certain SSRF vectors or parsing edge cases.
📊 Impact: Increases security boundaries without sacrificing performance or code readability.
🔬 Measurement: Verify by executing the CLI with malformed URLs like `http:///something`.

---
*PR created automatically by Jules for task [12647763977231428457](https://jules.google.com/task/12647763977231428457) started by @badMade*