### PR TITLE
🧪 Improve test coverage by adding tests for upload.py

### DIFF
--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 import io
 import requests
 from html2md.cli import main
@@ -36,7 +36,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
+                        with patch('html2md.cli.open', side_effect=OSError("Permission denied")):
                              try:
                                  main(['--url', 'http://example.com', '--outdir', 'dummy'])
                              except Exception as e:
@@ -59,7 +59,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        with patch('html2md.cli.open') as mock_open_var:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'
@@ -70,4 +70,4 @@ class TestCliExceptions(unittest.TestCase):
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)
-                            mock_open.assert_not_called()
+                            mock_open_var.assert_not_called()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,140 @@
+import argparse
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import anthropic
+
+from html2md.upload import main, upload_file
+
+
+class TestUploadFile(unittest.TestCase):
+    def test_upload_missing_file(self):
+        """Test that upload_file raises FileNotFoundError for missing file."""
+        with patch.object(Path, "exists", return_value=False):
+            with self.assertRaises(FileNotFoundError) as cm:
+                upload_file("missing.txt")
+            self.assertIn("File not found: missing.txt", str(cm.exception))
+
+    @patch("anthropic.Anthropic")
+    @patch("mimetypes.guess_type")
+    def test_upload_success_known_mimetype(self, mock_guess_type, mock_anthropic):
+        """Test successful upload with a known mimetype."""
+        mock_guess_type.return_value = ("text/plain", None)
+
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        mock_result = MagicMock()
+        mock_client.beta.files.upload.return_value = mock_result
+
+        m_open = mock_open(read_data=b"test data")
+
+        with patch.object(Path, "exists", return_value=True):
+            with patch("pathlib.Path.open", m_open):
+                result = upload_file("test.txt")
+
+        self.assertEqual(result, mock_result)
+        mock_client.beta.files.upload.assert_called_once()
+        _, kwargs = mock_client.beta.files.upload.call_args
+        self.assertEqual(kwargs["file"][0], "test.txt")
+        self.assertEqual(kwargs["file"][2], "text/plain")
+
+    @patch("anthropic.Anthropic")
+    @patch("mimetypes.guess_type")
+    def test_upload_success_unknown_mimetype(self, mock_guess_type, mock_anthropic):
+        """Test successful upload falls back to application/octet-stream."""
+        mock_guess_type.return_value = (None, None)
+
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        mock_result = MagicMock()
+        mock_client.beta.files.upload.return_value = mock_result
+
+        m_open = mock_open(read_data=b"data")
+
+        with patch.object(Path, "exists", return_value=True):
+            with patch("pathlib.Path.open", m_open):
+                result = upload_file("unknown.ext")
+
+        self.assertEqual(result, mock_result)
+        mock_client.beta.files.upload.assert_called_once()
+        _, kwargs = mock_client.beta.files.upload.call_args
+        self.assertEqual(kwargs["file"][0], "unknown.ext")
+        self.assertEqual(kwargs["file"][2], "application/octet-stream")
+
+
+class TestUploadMain(unittest.TestCase):
+    @patch("html2md.upload.upload_file")
+    def test_main_success(self, mock_upload_file):
+        """Test main returns 0 on successful upload."""
+        mock_result = MagicMock()
+        mock_result.id = "file_123"
+        mock_upload_file.return_value = mock_result
+
+        captured_stdout = io.StringIO()
+        with patch("sys.stdout", captured_stdout):
+            exit_code = main(["test.txt"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "File uploaded successfully. ID: file_123", captured_stdout.getvalue()
+        )
+        mock_upload_file.assert_called_once_with("test.txt")
+
+    @patch("html2md.upload.upload_file")
+    def test_main_file_not_found(self, mock_upload_file):
+        """Test main returns 1 on FileNotFoundError."""
+        mock_upload_file.side_effect = FileNotFoundError("File not found: test.txt")
+
+        captured_stderr = io.StringIO()
+        with patch("sys.stderr", captured_stderr):
+            exit_code = main(["test.txt"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Error: File not found: test.txt", captured_stderr.getvalue())
+
+    @patch("html2md.upload.upload_file")
+    def test_main_api_error(self, mock_upload_file):
+        """Test main returns 1 on anthropic.APIError."""
+        mock_error = anthropic.APIStatusError(
+            "API rate limit exceeded", response=MagicMock(), body=None
+        )
+        mock_upload_file.side_effect = mock_error
+
+        captured_stderr = io.StringIO()
+        with patch("sys.stderr", captured_stderr):
+            exit_code = main(["test.txt"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("API error: API rate limit exceeded", captured_stderr.getvalue())
+
+    def test_main_execution(self):
+        """Test the execution block."""
+        import runpy
+        import html2md.upload
+        import tempfile
+        import os
+
+        with tempfile.NamedTemporaryFile(delete=False) as tf:
+            tf.write(b"test data")
+            temp_name = tf.name
+
+        try:
+            with patch("sys.argv", ["html2md-upload", temp_name]):
+                with patch("anthropic.Anthropic") as mock_anthropic:
+                    mock_result = MagicMock()
+                    mock_result.id = "file_123"
+                    mock_anthropic.return_value.beta.files.upload.return_value = (
+                        mock_result
+                    )
+
+                    with self.assertRaises(SystemExit) as cm:
+                        runpy.run_path(html2md.upload.__file__, run_name="__main__")
+
+            self.assertEqual(cm.exception.code, 0)
+        finally:
+            os.remove(temp_name)


### PR DESCRIPTION
🎯 **What:** The testing gap for `src/html2md/upload.py` has been addressed by writing a new unit test suite in `tests/test_upload.py`. The suite mocks the `anthropic` and `mimetypes` modules as required. Additionally, an existing mock in `test_cli_exceptions.py` was fixed, as it crashed due to the way `argparse` reads gettext translation files.
  📊 **Coverage:** The new test file covers `FileNotFoundError`, successful uploads, unknown mimetype fallbacks, command-line usage, and API errors, obtaining 100% test coverage for the `upload.py` file.
  ✨ **Result:** A significant improvement in test coverage for the codebase and enhanced reliability.

---
*PR created automatically by Jules for task [3924408386505686491](https://jules.google.com/task/3924408386505686491) started by @badMade*