### PR TITLE
🔒 Fix SSRF vulnerability in CLI URL fetching

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   request-review:

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -111,29 +111,7 @@ def main(argv=None):  # pylint: disable=too-many-statements
 
             print(f"Processing URL: {target_url}")
 
-            parsed = urlparse(target_url)
-            # Resolve hostname to IP to prevent DNS rebinding
-            try:
-                addr_info = socket.getaddrinfo(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80))
-                ip = addr_info[0][4][0]
-            except socket.gaierror:
-                print(f"Error: Could not resolve {parsed.hostname}", file=sys.stderr)
-                return
-
             if not is_safe_url(target_url):
-                print(
-                    f"Error: URL '{target_url}' resolves to a non-public IP address.",
-                    file=sys.stderr,
-                )
-                return
-
-            # Use the resolved IP and set the Host header for SNI/TLS
-            safe_url = target_url.replace(parsed.hostname, ip, 1)
-            headers = {"Host": parsed.hostname}
-
-            try:
-                print("Fetching content...")
-                response = session.get(safe_url, headers=headers, timeout=30)
                 print(
                     f"Error: URL '{target_url}' resolves to a non-public IP address.",
                     file=sys.stderr,

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -8,11 +8,13 @@ import os
 import socket
 import sys
 from contextlib import contextmanager
-from typing import Optional
+from typing import Optional, Union
 from urllib.parse import unquote, urljoin, urlparse
 
 
 MAX_REDIRECTS = 10
+NAT64_WELL_KNOWN_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+IpAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 
 class UnsafeUrlError(ValueError):
@@ -34,11 +36,35 @@ def _url_port(parsed) -> Optional[int]:
     return None
 
 
+def _nat64_embedded_ipv4(ip: IpAddress) -> Optional[ipaddress.IPv4Address]:
+    """Return the IPv4 address embedded in the well-known NAT64 prefix, if any."""
+    if not isinstance(ip, ipaddress.IPv6Address):
+        return None
+    if ip not in NAT64_WELL_KNOWN_PREFIX:
+        return None
+    return ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+
+
+def _ensure_global_address(ip: IpAddress) -> None:
+    """Raise UnsafeUrlError if an address can route to a non-public target."""
+    if not ip.is_global:
+        raise UnsafeUrlError(f"hostname resolved to non-public address {ip}")
+
+    nat64_ipv4 = _nat64_embedded_ipv4(ip)
+    if nat64_ipv4 is not None and not nat64_ipv4.is_global:
+        raise UnsafeUrlError(
+            "hostname resolved to NAT64 address "
+            f"{ip} for non-public IPv4 address {nat64_ipv4}"
+        )
+
+
 def _global_addr_info(hostname: str, port: Optional[int]):
     """Resolve a hostname and return address records only if all are public."""
     # Resolve hostname to all associated IPv4 and IPv6 addresses. Treat any
     # address that is not globally routable as unsafe, including shared,
     # documentation, benchmarking, private, loopback, and link-local ranges.
+    # NAT64 well-known prefix answers can appear globally routable while
+    # embedding private/link-local IPv4 destinations, so validate those too.
     addr_info = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
     if not addr_info:
         raise UnsafeUrlError("hostname did not resolve")
@@ -46,8 +72,7 @@ def _global_addr_info(hostname: str, port: Optional[int]):
     for info in addr_info:
         ip_str = info[4][0]
         ip = ipaddress.ip_address(ip_str)
-        if not ip.is_global:
-            raise UnsafeUrlError(f"hostname resolved to non-public address {ip}")
+        _ensure_global_address(ip)
     return addr_info
 
 

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -1,38 +1,34 @@
 """CLI entry point for html2md."""
 
 from __future__ import annotations
+
 import argparse
-import os
-import sys
-import socket
 import ipaddress
-from urllib.parse import urlparse, unquote
+import os
+import socket
+import sys
+from urllib.parse import unquote, urlparse
 
 
-def is_safe_url(url: str) -> bool:  # pylint: disable=too-many-boolean-expressions
-    """Check if the URL resolves to a safe, public IP address."""
+def is_safe_url(url: str) -> bool:
+    """Check if the URL resolves only to globally reachable IP addresses."""
     try:
         parsed = urlparse(url)
         hostname = parsed.hostname
         if not hostname:
             return False
 
-        # Resolve hostname to all associated IPs
-        # This handles IPv4 and IPv6
+        # Resolve hostname to all associated IPv4 and IPv6 addresses. Treat any
+        # address that is not globally routable as unsafe, including shared,
+        # documentation, benchmarking, private, loopback, and link-local ranges.
         addr_info = socket.getaddrinfo(hostname, None)
+        if not addr_info:
+            return False
 
         for info in addr_info:
             ip_str = info[4][0]
             ip = ipaddress.ip_address(ip_str)
-            # Check if the IP is private, loopback, link-local, multicast, or reserved
-            if (  # pylint: disable=too-many-boolean-expressions
-                ip.is_loopback
-                or ip.is_private
-                or ip.is_link_local
-                or ip.is_multicast
-                or getattr(ip, "is_reserved", False)
-                or getattr(ip, "is_unspecified", False)
-            ):
+            if not ip.is_global:
                 return False
         return True
     except (socket.gaierror, ValueError):

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -111,7 +111,29 @@ def main(argv=None):  # pylint: disable=too-many-statements
 
             print(f"Processing URL: {target_url}")
 
+            parsed = urlparse(target_url)
+            # Resolve hostname to IP to prevent DNS rebinding
+            try:
+                addr_info = socket.getaddrinfo(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80))
+                ip = addr_info[0][4][0]
+            except socket.gaierror:
+                print(f"Error: Could not resolve {parsed.hostname}", file=sys.stderr)
+                return
+
             if not is_safe_url(target_url):
+                print(
+                    f"Error: URL '{target_url}' resolves to a non-public IP address.",
+                    file=sys.stderr,
+                )
+                return
+
+            # Use the resolved IP and set the Host header for SNI/TLS
+            safe_url = target_url.replace(parsed.hostname, ip, 1)
+            headers = {"Host": parsed.hostname}
+
+            try:
+                print("Fetching content...")
+                response = session.get(safe_url, headers=headers, timeout=30)
                 print(
                     f"Error: URL '{target_url}' resolves to a non-public IP address.",
                     file=sys.stderr,

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -123,6 +123,12 @@ def _ssrf_safe_connection():
 
 def _safe_session_get(session, target_url: str):
     """Fetch a URL with DNS-pinned connects and manually validated redirects."""
+    # Environment-configured proxies perform their own target DNS resolution,
+    # which would bypass the DNS pinning enforced by _ssrf_safe_connection().
+    # Disable requests' trust in proxy-related environment variables for this
+    # SSRF-protected fetch path so the validated socket is the target socket.
+    session.trust_env = False
+
     current_url = target_url
     for _ in range(MAX_REDIRECTS + 1):
         parsed = urlparse(current_url)

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,18 +4,51 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import socket
+import ipaddress
 from urllib.parse import urlparse, unquote
 
-def main(argv=None):
+
+def is_safe_url(url: str) -> bool:  # pylint: disable=too-many-boolean-expressions
+    """Check if the URL resolves to a safe, public IP address."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Resolve hostname to all associated IPs
+        # This handles IPv4 and IPv6
+        addr_info = socket.getaddrinfo(hostname, None)
+
+        for info in addr_info:
+            ip_str = info[4][0]
+            ip = ipaddress.ip_address(ip_str)
+            # Check if the IP is private, loopback, link-local, multicast, or reserved
+            if (  # pylint: disable=too-many-boolean-expressions
+                ip.is_loopback
+                or ip.is_private
+                or ip.is_link_local
+                or ip.is_multicast
+                or getattr(ip, "is_reserved", False)
+                or getattr(ip, "is_unspecified", False)
+            ):
+                return False
+        return True
+    except (socket.gaierror, ValueError):
+        # If DNS resolution fails or IP parsing fails, consider it unsafe
+        return False
+
+
+def main(argv=None):  # pylint: disable=too-many-statements
     """Run the CLI."""
     ap = argparse.ArgumentParser(
-        prog='html2md',
-        description='Convert HTML URL to Markdown.'
+        prog="html2md", description="Convert HTML URL to Markdown."
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    ap.add_argument("--help-only", action="store_true", help=argparse.SUPPRESS)
+    ap.add_argument("--url", help="Input URL to convert")
+    ap.add_argument("--batch", help="File containing URLs to process (one per line)")
+    ap.add_argument("--outdir", help="Output directory to save the file")
 
     args = ap.parse_args(argv)
 
@@ -26,47 +59,64 @@ def main(argv=None):
     if args.url or args.batch:
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
-            from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from markdownify import (
+                markdownify as md,
+            )  # pylint: disable=import-outside-toplevel
         except ImportError as e:
-            print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+            print(
+                f"Error: Missing dependency {e.name}."
+                "Please run: pip install requests markdownify",
+                file=sys.stderr,
+            )
             return 1
 
         session = requests.Session()
-        session.headers.update({
-            'User-Agent': (
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/120.0.0.0 Safari/537.36'
-            ),
-            'Accept': (
-                'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                'image/avif,image/webp,image/apng,*/*;q=0.8'
-            ),
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://www.google.com/',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'cross-site',
-            'Sec-Fetch-User': '?1',
-        })
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,image/apng,*/*;q=0.8"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Referer": "https://www.google.com/",
+                "Connection": "keep-alive",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "cross-site",
+                "Sec-Fetch-User": "?1",
+            }
+        )
 
         def process_url(target_url: str) -> None:
             """Process a single URL."""
             # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
+            if "/?" in target_url:
+                target_url = target_url.replace("/?", "?")
 
             parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
+            if parsed.scheme not in ("http", "https"):
+                print(
+                    f"Error: Unsupported URL scheme '{parsed.scheme}'. "
+                    "Only http and https are allowed.",
+                    file=sys.stderr,
+                )
                 return
 
             print(f"Processing URL: {target_url}")
+
+            if not is_safe_url(target_url):
+                print(
+                    f"Error: URL '{target_url}' resolves to a non-public IP address.",
+                    file=sys.stderr,
+                )
+                return
 
             try:
                 print("Fetching content...")
@@ -82,12 +132,12 @@ def main(argv=None):
 
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
+                    url_path = target_url.split("?")[0].rstrip("/")
                     if url_path:
                         base = os.path.basename(unquote(url_path))
                         # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
-                        base = base.strip('. ')
+                        base = base.replace("/", "_").replace("\\", "_")
+                        base = base.strip(". ")
                         if base:
                             filename = f"{base}.md"
 
@@ -96,10 +146,12 @@ def main(argv=None):
                     real_outdir = os.path.realpath(args.outdir)
                     real_out_path = os.path.realpath(out_path)
                     if os.path.commonpath([real_outdir, real_out_path]) != real_outdir:
-                        print("Error: Output path escapes output directory.",
-                              file=sys.stderr)
+                        print(
+                            "Error: Output path escapes output directory.",
+                            file=sys.stderr,
+                        )
                         return
-                    with open(out_path, 'w', encoding='utf-8') as f:
+                    with open(out_path, "w", encoding="utf-8") as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
@@ -119,7 +171,7 @@ def main(argv=None):
             if not os.path.exists(args.batch):
                 print(f"Error: Batch file not found: {args.batch}", file=sys.stderr)
                 return 1
-            with open(args.batch, 'r', encoding='utf-8') as f:
+            with open(args.batch, "r", encoding="utf-8") as f:
                 for line in f:
                     u = line.strip()
                     if u:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -7,7 +7,48 @@ import ipaddress
 import os
 import socket
 import sys
-from urllib.parse import unquote, urlparse
+from contextlib import contextmanager
+from typing import Optional
+from urllib.parse import unquote, urljoin, urlparse
+
+
+MAX_REDIRECTS = 10
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a URL resolves to a non-public network address."""
+
+
+class UnsafeRedirectError(ValueError):
+    """Raised when a redirect points to an unsupported or unsafe URL."""
+
+
+def _url_port(parsed) -> Optional[int]:
+    """Return the explicit or default network port for a parsed URL."""
+    if parsed.port is not None:
+        return parsed.port
+    if parsed.scheme == "https":
+        return 443
+    if parsed.scheme == "http":
+        return 80
+    return None
+
+
+def _global_addr_info(hostname: str, port: Optional[int]):
+    """Resolve a hostname and return address records only if all are public."""
+    # Resolve hostname to all associated IPv4 and IPv6 addresses. Treat any
+    # address that is not globally routable as unsafe, including shared,
+    # documentation, benchmarking, private, loopback, and link-local ranges.
+    addr_info = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    if not addr_info:
+        raise UnsafeUrlError("hostname did not resolve")
+
+    for info in addr_info:
+        ip_str = info[4][0]
+        ip = ipaddress.ip_address(ip_str)
+        if not ip.is_global:
+            raise UnsafeUrlError(f"hostname resolved to non-public address {ip}")
+    return addr_info
 
 
 def is_safe_url(url: str) -> bool:
@@ -17,23 +58,98 @@ def is_safe_url(url: str) -> bool:
         hostname = parsed.hostname
         if not hostname:
             return False
-
-        # Resolve hostname to all associated IPv4 and IPv6 addresses. Treat any
-        # address that is not globally routable as unsafe, including shared,
-        # documentation, benchmarking, private, loopback, and link-local ranges.
-        addr_info = socket.getaddrinfo(hostname, None)
-        if not addr_info:
-            return False
-
-        for info in addr_info:
-            ip_str = info[4][0]
-            ip = ipaddress.ip_address(ip_str)
-            if not ip.is_global:
-                return False
+        _global_addr_info(hostname, _url_port(parsed))
         return True
     except (socket.gaierror, ValueError):
         # If DNS resolution fails or IP parsing fails, consider it unsafe
         return False
+
+
+@contextmanager
+def _ssrf_safe_connection():
+    """Patch urllib3 connection creation to connect only to validated IPs.
+
+    The CLI performs a pre-flight safety check for friendly error messages, but
+    the security boundary must be the address used by the actual socket connect.
+    Requests/urllib3 normally resolves hostnames inside its connection helper;
+    replacing that helper lets us validate the fresh DNS answer and then pin the
+    TCP connection to that exact IP address so DNS rebinding cannot swap in a
+    private address after the pre-flight check.
+    """
+    import urllib3.connection  # type: ignore  # pylint: disable=import-outside-toplevel
+    import urllib3.util.connection  # type: ignore  # pylint: disable=import-outside-toplevel
+
+    original_util_create_connection = urllib3.util.connection.create_connection
+    original_connection_create_connection = getattr(
+        urllib3.connection, "create_connection", None
+    )
+
+    def create_safe_connection(
+        address,
+        timeout=socket._GLOBAL_DEFAULT_TIMEOUT,  # pylint: disable=protected-access
+        source_address=None,
+        socket_options=None,
+    ):
+        host, port = address
+        addr_info = _global_addr_info(host, port)
+        last_error = None
+
+        for info in addr_info:
+            ip_address = info[4][0]
+            try:
+                return original_util_create_connection(
+                    (ip_address, port),
+                    timeout=timeout,
+                    source_address=source_address,
+                    socket_options=socket_options,
+                )
+            except OSError as exc:
+                last_error = exc
+
+        if last_error is not None:
+            raise last_error
+        raise UnsafeUrlError("hostname did not resolve to a connectable address")
+
+    urllib3.util.connection.create_connection = create_safe_connection
+    if original_connection_create_connection is not None:
+        urllib3.connection.create_connection = create_safe_connection
+    try:
+        yield
+    finally:
+        urllib3.util.connection.create_connection = original_util_create_connection
+        if original_connection_create_connection is not None:
+            urllib3.connection.create_connection = original_connection_create_connection
+
+
+def _safe_session_get(session, target_url: str):
+    """Fetch a URL with DNS-pinned connects and manually validated redirects."""
+    current_url = target_url
+    for _ in range(MAX_REDIRECTS + 1):
+        parsed = urlparse(current_url)
+        if parsed.scheme not in ("http", "https"):
+            raise UnsafeRedirectError(
+                f"Redirect target uses unsupported URL scheme '{parsed.scheme}'."
+            )
+        if not is_safe_url(current_url):
+            raise UnsafeUrlError(
+                f"URL '{current_url}' resolves to a non-public IP address."
+            )
+
+        with _ssrf_safe_connection():
+            response = session.get(current_url, timeout=30, allow_redirects=False)
+
+        status_code = getattr(response, "status_code", None)
+        location = getattr(response, "headers", {}).get("Location") or getattr(
+            response, "headers", {}
+        ).get("location")
+        if not isinstance(status_code, int) or not (300 <= status_code < 400):
+            return response
+        if not location:
+            return response
+
+        current_url = urljoin(current_url, location)
+
+    raise UnsafeRedirectError("Too many redirects while fetching URL.")
 
 
 def main(argv=None):  # pylint: disable=too-many-statements
@@ -116,7 +232,7 @@ def main(argv=None):  # pylint: disable=too-many-statements
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = _safe_session_get(session, target_url)
                 response.raise_for_status()
 
                 print("Converting to Markdown...")
@@ -153,6 +269,8 @@ def main(argv=None):  # pylint: disable=too-many-statements
                 else:
                     print(md_content)
 
+            except (UnsafeUrlError, UnsafeRedirectError) as e:
+                print(f"Error: {e}", file=sys.stderr)
             except requests.RequestException as e:
                 print(f"Network error: {e}", file=sys.stderr)
             except OSError as e:

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -1,4 +1,5 @@
 """Tests for html2md CLI exception-handling paths."""
+
 import unittest
 from unittest.mock import patch, MagicMock
 import io
@@ -12,12 +13,12 @@ class TestCliExceptions(unittest.TestCase):
     def test_network_error(self):
         """Test that network errors are caught and printed."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
+        with patch("sys.stderr", captured_stderr):
+            with patch("requests.Session.get") as mock_get:
                 mock_get.side_effect = requests.RequestException("Network unreachable")
 
                 try:
-                    main(['--url', 'http://example.com'])
+                    main(["--url", "http://example.com"])
                 except (SystemExit, RuntimeError, ValueError) as e:
                     self.fail(f"main raised exception {e}")
 
@@ -28,18 +29,24 @@ class TestCliExceptions(unittest.TestCase):
     def test_file_error(self):
         """Test that file I/O errors are caught and printed."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
+        with patch("sys.stderr", captured_stderr):
+            with patch("requests.Session.get") as mock_get:
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
                 mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
-                    with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
+                with patch("markdownify.markdownify", return_value="# Hello"):
+                    with patch("os.makedirs"), patch(
+                        "os.path.exists", return_value=False
+                    ):
+                        with patch(
+                            "builtins.open", side_effect=OSError("Permission denied")
+                        ):
                             try:
-                                main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                                main(
+                                    ["--url", "http://example.com", "--outdir", "dummy"]
+                                )
                             except (SystemExit, RuntimeError, ValueError) as e:
                                 self.fail(f"main raised exception {e}")
 
@@ -47,27 +54,39 @@ class TestCliExceptions(unittest.TestCase):
                             self.assertIn("File error", output)
                             self.assertIn("Permission denied", output)
 
-    def test_outdir_containment_uses_path_aware_check(self):
+    @patch("html2md.cli.is_safe_url", return_value=True)
+    def test_outdir_containment_uses_path_aware_check(self, mock_is_safe_url):
         """Test that output containment check rejects prefix-matching escapes."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
+        with patch("sys.stderr", captured_stderr):
+            with patch("requests.Session.get") as mock_get:
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
                 mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
-                    with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
-                            def fake_realpath(path):
-                                if str(path).endswith('.md'):
-                                    return '/tmp/outside/a.md'
-                                return '/tmp/out'
+                with patch("markdownify.markdownify", return_value="# Hello"):
+                    with patch("os.path.exists", return_value=True):
+                        # Mock the open used in cli.py instead of builtins.open to avoid breaking argparse locale loading
+                        with patch("html2md.cli.open") as mock_open:
 
-                            with patch('os.path.realpath', side_effect=fake_realpath):
-                                main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
+                            def fake_realpath(path):
+                                if str(path).endswith(".md"):
+                                    return "/tmp/outside/a.md"
+                                return "/tmp/out"
+
+                            with patch("os.path.realpath", side_effect=fake_realpath):
+                                main(
+                                    [
+                                        "--url",
+                                        "http://example.com/a",
+                                        "--outdir",
+                                        "/tmp/out",
+                                    ]
+                                )
 
                             output = captured_stderr.getvalue()
-                            self.assertIn("Output path escapes output directory", output)
+                            self.assertIn(
+                                "Output path escapes output directory", output
+                            )
                             mock_open.assert_not_called()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -142,6 +142,32 @@ def test_process_url_revalidates_redirect_target(
     )
 
 
+def test_safe_session_get_disables_environment_proxies(monkeypatch):
+    """SSRF-protected fetches must not honor HTTP(S)_PROXY from the environment."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+
+    session = MagicMock()
+    session.trust_env = True
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    session.get.return_value = response
+
+    with patch("html2md.cli.is_safe_url", return_value=True), patch(
+        "html2md.cli._ssrf_safe_connection"
+    ) as mock_safe_connection:
+        mock_safe_connection.return_value.__enter__.return_value = None
+        mock_safe_connection.return_value.__exit__.return_value = None
+
+        assert cli._safe_session_get(session, "https://example.com/") is response
+
+    assert session.trust_env is False
+    session.get.assert_called_once_with(
+        "https://example.com/", timeout=30, allow_redirects=False
+    )
+
+
 @patch("html2md.cli.socket.getaddrinfo")
 def test_safe_connection_validates_and_pins_actual_connect_address(mock_getaddrinfo):
     """The socket connect helper rejects a rebinding answer before connecting."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -48,6 +48,55 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
-    assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
+    assert list(
+        outdir.rglob("*.md")
+    ), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+import socket
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "http://localhost/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://0.0.0.0/",
+        "http://[::1]/",
+    ],
+)
+@patch("requests.Session.get")
+def test_process_url_ssrf_protection_blocked(mock_get, capsys, tmp_path, url):
+    """SSRF protection should block internal/private/loopback/metadata IP addresses."""
+    cli.main(["--url", url, "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+    assert f"Error: URL '{url}' resolves to a non-public IP address." in outerr.err
+    mock_get.assert_not_called()
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_process_url_ssrf_protection_allowed(
+    mock_get, mock_getaddrinfo, capsys, tmp_path
+):
+    """SSRF protection should allow public IP addresses."""
+    # Mock getaddrinfo to return a public IP
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))  # example.com
+    ]
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://example.com/", "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    mock_get.assert_called_once()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -89,6 +89,40 @@ def test_process_url_ssrf_protection_blocked(mock_get, capsys, tmp_path, url):
     mock_get.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "nat64_address, embedded_ipv4",
+    [
+        ("64:ff9b::a9fe:a9fe", "169.254.169.254"),
+        ("64:ff9b::a00:1", "10.0.0.1"),
+        ("64:ff9b::7f00:1", "127.0.0.1"),
+    ],
+)
+@patch("html2md.cli.socket.getaddrinfo")
+def test_global_addr_info_blocks_nat64_embedded_non_public_ipv4(
+    mock_getaddrinfo, nat64_address, embedded_ipv4
+):
+    """NAT64 answers must not tunnel SSRF fetches to embedded private targets."""
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", (nat64_address, 443, 0, 0))
+    ]
+
+    with pytest.raises(cli.UnsafeUrlError) as excinfo:
+        cli._global_addr_info("example.com", 443)  # pylint: disable=protected-access
+
+    assert nat64_address in str(excinfo.value)
+    assert embedded_ipv4 in str(excinfo.value)
+
+
+@patch("html2md.cli.socket.getaddrinfo")
+def test_global_addr_info_allows_nat64_embedded_public_ipv4(mock_getaddrinfo):
+    """NAT64 answers remain allowed when their embedded IPv4 target is public."""
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("64:ff9b::808:808", 443, 0, 0))
+    ]
+
+    assert cli._global_addr_info("example.com", 443) == mock_getaddrinfo.return_value
+
+
 @patch("html2md.cli.socket.getaddrinfo")
 @patch("requests.Session.get")
 def test_process_url_ssrf_protection_allowed(

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -4,6 +4,7 @@ import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
+import urllib3.connection
 
 from html2md import cli
 
@@ -108,3 +109,46 @@ def test_process_url_ssrf_protection_allowed(
     outerr = capsys.readouterr()
     assert "Success!" in outerr.out
     mock_get.assert_called_once()
+
+
+@patch("html2md.cli.socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_process_url_revalidates_redirect_target(
+    mock_get, mock_getaddrinfo, capsys, tmp_path
+):
+    """Redirect targets must pass SSRF validation before being fetched."""
+
+    def fake_getaddrinfo(hostname, port, *args, **kwargs):
+        del port, args, kwargs
+        if hostname == "example.com":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+        if hostname == "169.254.169.254":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))]
+        raise socket.gaierror(hostname)
+
+    redirect = MagicMock()
+    redirect.status_code = 302
+    redirect.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+    mock_get.return_value = redirect
+    mock_getaddrinfo.side_effect = fake_getaddrinfo
+
+    cli.main(["--url", "http://example.com/", "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+
+    assert "http://169.254.169.254/latest/meta-data/" in outerr.err
+    assert "resolves to a non-public IP address" in outerr.err
+    mock_get.assert_called_once_with(
+        "http://example.com/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("html2md.cli.socket.getaddrinfo")
+def test_safe_connection_validates_and_pins_actual_connect_address(mock_getaddrinfo):
+    """The socket connect helper rejects a rebinding answer before connecting."""
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))
+    ]
+
+    with cli._ssrf_safe_connection():  # pylint: disable=protected-access
+        with pytest.raises(cli.UnsafeUrlError):
+            urllib3.connection.connection.create_connection(("example.com", 80))

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,6 +1,8 @@
 """Security-focused tests for CLI URL and output path handling."""
 
+import socket
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 from html2md import cli
@@ -23,9 +25,16 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
     mock_get.assert_not_called()
 
 
+@patch("html2md.cli.socket.getaddrinfo")
 @patch("requests.Session.get")
-def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
+def test_traversal_like_paths_stay_within_outdir(
+    mock_get, mock_getaddrinfo, capsys, tmp_path
+):
     """Traversal-like URL paths must never write outside of --outdir."""
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+    ]
+
     outdir = tmp_path / "output"
     outdir.mkdir()
 
@@ -55,9 +64,6 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert not (tmp_path / "secret.txt.md").exists()
 
 
-import socket
-
-
 @pytest.mark.parametrize(
     "url",
     [
@@ -68,6 +74,8 @@ import socket
         "http://192.168.1.1/",
         "http://172.16.0.1/",
         "http://0.0.0.0/",
+        "http://100.64.0.1/",
+        "http://198.18.0.1/",
         "http://[::1]/",
     ],
 )
@@ -80,7 +88,7 @@ def test_process_url_ssrf_protection_blocked(mock_get, capsys, tmp_path, url):
     mock_get.assert_not_called()
 
 
-@patch("socket.getaddrinfo")
+@patch("html2md.cli.socket.getaddrinfo")
 @patch("requests.Session.get")
 def test_process_url_ssrf_protection_allowed(
     mock_get, mock_getaddrinfo, capsys, tmp_path


### PR DESCRIPTION
🎯 **What:** The application fetched URLs blindly, which allowed attackers to fetch from internal/metadata IPs.

⚠️ **Risk:** Attackers could scan internal networks or exfiltrate sensitive cloud metadata (e.g., via 169.254.169.254 on AWS) by passing these IPs as input URLs.

🛡️ **Solution:** Implemented `is_safe_url` to resolve the hostname to IP addresses and block requests if any of the IPs reside in private, loopback, link-local, multicast, or reserved ranges, thus mitigating SSRF. Added robust testing and mock handling for these updates.

---
*PR created automatically by Jules for task [14279266969373528429](https://jules.google.com/task/14279266969373528429) started by @badMade*