### PR TITLE
⚡ Bolt: Add URL deduplication for batch processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,9 @@
 4. **Fast type checks**: Using `type(rec) is dict` instead of `isinstance(rec, dict)` and `type(value) is str` instead of `isinstance(value, str)` skips subclass checks and is slightly faster in very tight loops.
 
 **Action:** When optimizing data-processing hot loops in Python, first eliminate string allocations (`strip`, `lstrip`), pre-compute list comprehenson iterables to avoid unpacking in the loop, and use `type() is X` for exact type checking instead of `isinstance` if subclassing isn't a concern.
+
+## 2024-05-25 - Avoid Risky Micro-Optimizations
+
+**Learning:** Optimizations like `type()` vs `isinstance()` or tweaking string `.startswith()` checks might show a microscopic gain in isolation but are rejected as "premature/micro optimizations with no measurable impact" and can cause breakage (e.g. subtyping, edge cases). True performance wins come from algorithmic changes (e.g. O(N^2) -> O(N), caching, deduplication) or eliminating network/IO bottlenecks. Also, never touch environment configs like `.python-version` unprompted.
+
+**Action:** Focus on measurable algorithmic improvements (like deduplicating network calls with a `set()`) instead of nano-second optimizations in Python hot loops.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -119,10 +119,15 @@ def main(argv=None):
             if not os.path.exists(args.batch):
                 print(f"Error: Batch file not found: {args.batch}", file=sys.stderr)
                 return 1
+
+            # Optimization: Deduplicate URLs to prevent redundant, expensive network requests
+            # and parsing when duplicate entries exist in the batch file.
+            seen = set()
             with open(args.batch, 'r', encoding='utf-8') as f:
                 for line in f:
                     u = line.strip()
-                    if u:
+                    if u and u not in seen:
+                        seen.add(u)
                         process_url(u)
 
         return 0


### PR DESCRIPTION
**💡 What**: Implemented URL deduplication during batch file processing using a `seen = set()` in `src/html2md/cli.py`.

**🎯 Why**: Processing duplicate URLs from a batch file wastes time on redundant, expensive network requests (I/O bounds) and subsequent markdown parsing. By tracking seen URLs, we prevent these redundant operations entirely.

**📊 Impact**: Massive performance improvement when processing batch files containing duplicate URLs. Time taken to process duplicates drops from `O(N)` (N network requests) to `O(1)` (instant set lookup).

**🔬 Measurement**: To verify, run the CLI with a `--batch` file containing multiple identical URLs. Previously, it would make a network call for each line. Now, it skips subsequent duplicates instantly.

---
*PR created automatically by Jules for task [9826758171633136556](https://jules.google.com/task/9826758171633136556) started by @badMade*