### PR TITLE
Follow-up: close SSRF redirect and non-global IP bypasses in CLI fetching

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -24,8 +24,9 @@ def is_safe_url(url: str) -> bool:
         for info in addr_info:
             ip_str = info[4][0]
             ip = ipaddress.ip_address(ip_str)
-            # Require globally reachable IPs only.
-            if not ip.is_global:
+            # Require globally reachable IPs only, while explicitly rejecting
+            # multicast addresses because Python 3.12 may report them as global.
+            if not ip.is_global or ip.is_multicast:
                 return False
         return True
     except (socket.gaierror, ValueError):

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,10 +6,10 @@ import os
 import sys
 import socket
 import ipaddress
-from urllib.parse import urlparse, unquote
+from urllib.parse import urljoin, urlparse, unquote
 
 
-def is_safe_url(url: str) -> bool:  # pylint: disable=too-many-boolean-expressions
+def is_safe_url(url: str) -> bool:
     """Check if the URL resolves to a safe, public IP address."""
     try:
         parsed = urlparse(url)
@@ -24,20 +24,45 @@ def is_safe_url(url: str) -> bool:  # pylint: disable=too-many-boolean-expressio
         for info in addr_info:
             ip_str = info[4][0]
             ip = ipaddress.ip_address(ip_str)
-            # Check if the IP is private, loopback, link-local, multicast, or reserved
-            if (  # pylint: disable=too-many-boolean-expressions
-                ip.is_loopback
-                or ip.is_private
-                or ip.is_link_local
-                or ip.is_multicast
-                or getattr(ip, "is_reserved", False)
-                or getattr(ip, "is_unspecified", False)
-            ):
+            # Require globally reachable IPs only.
+            if not ip.is_global:
                 return False
         return True
     except (socket.gaierror, ValueError):
         # If DNS resolution fails or IP parsing fails, consider it unsafe
         return False
+
+
+def fetch_with_safe_redirects(session, url: str, timeout: int, max_redirects: int = 10):
+    """Fetch URL while validating every redirect hop against SSRF rules."""
+    try:
+        import requests  # type: ignore  # pylint: disable=import-outside-toplevel
+    except ImportError:  # pragma: no cover
+        raise
+
+    current_url = url
+    for _ in range(max_redirects + 1):
+        if not is_safe_url(current_url):
+            raise requests.RequestException(
+                f"URL '{current_url}' resolves to a non-public IP address."
+            )
+
+        response = session.get(current_url, timeout=timeout, allow_redirects=False)
+
+        status_code = getattr(response, "status_code", 0)
+        if not isinstance(status_code, int):
+            status_code = 0
+        is_redirect = 300 <= status_code < 400
+        if not is_redirect:
+            return response
+
+        headers = getattr(response, "headers", {}) or {}
+        location = headers.get("Location") if hasattr(headers, "get") else None
+        if not isinstance(location, str) or not location:
+            return response
+        current_url = urljoin(current_url, location)
+
+    raise requests.TooManyRedirects(f"Exceeded {max_redirects} redirects for URL: {url}")
 
 
 def main(argv=None):  # pylint: disable=too-many-statements
@@ -111,16 +136,9 @@ def main(argv=None):  # pylint: disable=too-many-statements
 
             print(f"Processing URL: {target_url}")
 
-            if not is_safe_url(target_url):
-                print(
-                    f"Error: URL '{target_url}' resolves to a non-public IP address.",
-                    file=sys.stderr,
-                )
-                return
-
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = fetch_with_safe_redirects(session, target_url, timeout=30)
                 response.raise_for_status()
 
                 print("Converting to Markdown...")
@@ -158,7 +176,11 @@ def main(argv=None):  # pylint: disable=too-many-statements
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                error_message = str(e)
+                if "resolves to a non-public IP address" in error_message:
+                    print(f"Error: {error_message}", file=sys.stderr)
+                else:
+                    print(f"Network error: {e}", file=sys.stderr)
             except OSError as e:
                 print(f"File error: {e}", file=sys.stderr)
             except Exception as e:  # pylint: disable=broad-exception-caught

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -64,6 +64,7 @@ import socket
         "http://127.0.0.1/",
         "http://localhost/",
         "http://169.254.169.254/latest/meta-data/",
+        "http://100.64.0.1/",
         "http://10.0.0.1/",
         "http://192.168.1.1/",
         "http://172.16.0.1/",
@@ -100,3 +101,35 @@ def test_process_url_ssrf_protection_allowed(
     outerr = capsys.readouterr()
     assert "Success!" in outerr.out
     mock_get.assert_called_once()
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_process_url_redirect_to_blocked_ip_is_rejected(
+    mock_get, mock_getaddrinfo, capsys, tmp_path
+):
+    """Redirect chains are blocked when any hop resolves to a non-public IP."""
+    def fake_getaddrinfo(hostname, *_args, **_kwargs):
+        if hostname == "example.com":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+        if hostname == "127.0.0.1":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+        raise socket.gaierror
+
+    mock_getaddrinfo.side_effect = fake_getaddrinfo
+
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {"Location": "http://127.0.0.1/admin"}
+    mock_get.return_value = redirect_response
+
+    cli.main(["--url", "http://example.com/", "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+
+    assert (
+        "Error: URL 'http://127.0.0.1/admin' resolves to a non-public IP address."
+        in outerr.err
+    )
+    mock_get.assert_called_once_with(
+        "http://example.com/", timeout=30, allow_redirects=False
+    )

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -65,11 +65,13 @@ import socket
         "http://localhost/",
         "http://169.254.169.254/latest/meta-data/",
         "http://100.64.0.1/",
+        "http://239.255.255.250/",
         "http://10.0.0.1/",
         "http://192.168.1.1/",
         "http://172.16.0.1/",
         "http://0.0.0.0/",
         "http://[::1]/",
+        "http://[ff02::1]/",
     ],
 )
 @patch("requests.Session.get")
@@ -80,6 +82,23 @@ def test_process_url_ssrf_protection_blocked(mock_get, capsys, tmp_path, url):
     assert f"Error: URL '{url}' resolves to a non-public IP address." in outerr.err
     mock_get.assert_not_called()
 
+
+@pytest.mark.parametrize(
+    "ip_address",
+    [
+        "239.255.255.250",
+        "ff02::1",
+    ],
+)
+@patch("socket.getaddrinfo")
+def test_is_safe_url_rejects_multicast_dns_results(mock_getaddrinfo, ip_address):
+    """SSRF protection should explicitly reject multicast DNS results."""
+    family = socket.AF_INET6 if ":" in ip_address else socket.AF_INET
+    mock_getaddrinfo.return_value = [
+        (family, socket.SOCK_STREAM, 6, "", (ip_address, 0))
+    ]
+
+    assert not cli.is_safe_url("http://example.com/")
 
 @patch("socket.getaddrinfo")
 @patch("requests.Session.get")


### PR DESCRIPTION
### Motivation
- Close two high-priority SSRF gaps: validation was only applied to the initial URL (redirect hops could bypass checks) and some non-global but non-private ranges (e.g., 100.64.0.0/10) were not being rejected.

### Description
- Require globally-reachable addresses by changing the IP check to `ip.is_global` in `is_safe_url(...)` so non-global ranges are blocked.  
- Add `fetch_with_safe_redirects(session, url, timeout, max_redirects=10)` which calls `session.get(..., allow_redirects=False)` and validates every redirect hop with `is_safe_url(...)`, resolves relative `Location` headers with `urljoin(...)`, and enforces a redirect limit.  
- Switch CLI fetching to use `fetch_with_safe_redirects(...)` and surface SSRF blocks with explicit error text while preserving other network error messages.  
- Improve robustness when reading response attributes (handle non-int `status_code` and missing/none `headers`).  
- Update tests to include `http://100.64.0.1/` in blocked cases and add a regression test that simulates a `302` redirect from a public host to `127.0.0.1` and asserts the redirect target is rejected and never fetched.

### Testing
- Installed test deps and ran the focused test suite with `PYENV_VERSION=3.12.12 PYTHONPATH=src python -m pytest -q tests/test_cli_security.py tests/test_cli_exceptions.py tests/test_cli_error.py`.  
- All tests in those files passed after the changes (`... [100%]`), verifying SSRF blocking, redirect handling, filename containment, and error reporting behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb3b1eec0832087a8c93a4461b667)