### PR TITLE
Restore batch processing when response exceeds size limit

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,7 @@ def main(argv=None):
                         content_bytes.extend(chunk)
                         if len(content_bytes) > max_size:
                             print("Error: Response too large (>10MB). Aborting to prevent memory exhaustion.", file=sys.stderr)
-                            sys.exit(1)
+                            return
 
                 encoding = response.encoding if isinstance(getattr(response, 'encoding', None), str) else 'utf-8'
                 text_content = content_bytes.decode(encoding, errors='replace')

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,6 +81,9 @@ def main(argv=None):
                         content_bytes.extend(chunk)
                         if len(content_bytes) > max_size:
                             print("Error: Response too large (>10MB). Aborting to prevent memory exhaustion.", file=sys.stderr)
+                            response.close()
+                            if not args.batch:
+                                sys.exit(1)
                             return
 
                 encoding = response.encoding if isinstance(getattr(response, 'encoding', None), str) else 'utf-8'

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -51,3 +51,50 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+@patch("requests.Session.get")
+def test_oversize_single_url_closes_response_and_exits(mock_get, capsys):
+    """Oversized streamed responses are closed and fail single-URL runs."""
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.iter_content.return_value = [b"x" * (10 * 1024 * 1024 + 1)]
+    mock_get.return_value = response
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--url", "http://example.com/huge"])
+
+    assert excinfo.value.code == 1
+    response.close.assert_called_once_with()
+    outerr = capsys.readouterr()
+    assert "Response too large" in outerr.err
+
+
+@patch("requests.Session.get")
+def test_oversize_batch_closes_response_and_continues(mock_get, capsys, tmp_path):
+    """Oversized batch entries are closed without aborting later URLs."""
+    batch_file = tmp_path / "urls.txt"
+    batch_file.write_text(
+        "http://example.com/huge\nhttp://example.com/small\n",
+        encoding="utf-8",
+    )
+
+    huge_response = MagicMock()
+    huge_response.raise_for_status.return_value = None
+    huge_response.iter_content.return_value = [b"x" * (10 * 1024 * 1024 + 1)]
+
+    small_response = MagicMock()
+    small_response.raise_for_status.return_value = None
+    small_response.iter_content.return_value = [b"<h1>ok</h1>"]
+    small_response.encoding = "utf-8"
+
+    mock_get.side_effect = [huge_response, small_response]
+
+    result = cli.main(["--batch", str(batch_file)])
+
+    assert result == 0
+    huge_response.close.assert_called_once_with()
+    assert mock_get.call_count == 2
+    outerr = capsys.readouterr()
+    assert "Response too large" in outerr.err
+    assert "# ok" in outerr.out.lower()


### PR DESCRIPTION
### Motivation
- Prevent a single oversized HTTP response from terminating the entire CLI run by fixing the behavior where an over-size response called `sys.exit(1)` and aborted batch processing.

### Description
- Replace the `sys.exit(1)` call with `return` in `src/html2md/cli.py` so streamed responses that exceed the 10MB limit are logged as a per-URL failure and processing continues for remaining URLs.

### Testing
- Ran `pytest -q` which failed in this environment due to `pyenv` pointing to an unavailable Python version `3.12.11`.
- Re-ran `PYENV_VERSION=3.12.12 python -m pytest -q` and test collection failed because the `requests` dependency is not installed and the `html2md` package is not importable in this test environment, so no tests completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb3afdb8c832096aabab6d7a3cdd3)