### PR TITLE
Follow-up: avoid failing Jules review workflow on fork token 403s

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -18,6 +18,10 @@ jobs:
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           python - <<'PY'
           import json
@@ -30,6 +34,15 @@ jobs:
           repo = os.environ["GITHUB_REPOSITORY"]
           pr_number = os.environ["PR_NUMBER"]
           token = os.environ["GITHUB_TOKEN"]
+          head_repo = os.environ["PR_HEAD_REPO"]
+          base_repo = os.environ["PR_BASE_REPO"]
+          pr_author = os.environ["PR_AUTHOR"]
+          actor = os.environ["GITHUB_ACTOR"]
+          is_read_only_context = (
+              head_repo != base_repo
+              or pr_author == "dependabot[bot]"
+              or actor == "dependabot[bot]"
+          )
 
           request = urllib.request.Request(
               url=f"{api_url}/repos/{repo}/issues/{pr_number}/comments",
@@ -53,10 +66,11 @@ jobs:
           except urllib.error.HTTPError as error:
               details = error.read().decode("utf-8")
               print(f"Could not request review (HTTP {error.code}): {details}")
-              if error.code == 403:
+              if error.code == 403 and is_read_only_context:
                   print(
-                      "Skipping failure: workflow tokens from forks/Dependabot "
-                      "are often read-only and cannot post PR comments."
+                      "Skipping failure: this PR is from a fork or Dependabot, "
+                      "where workflow tokens are often read-only and cannot "
+                      "post PR comments."
                   )
               else:
                   print("Ensure the workflow token has permission to comment.")

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -51,7 +51,14 @@ jobs:
                       f"PR #{pr_number} (status {response.status})"
                   )
           except urllib.error.HTTPError as error:
-              print(f"Could not request review: {error.read().decode('utf-8')}")
-              print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
+              details = error.read().decode("utf-8")
+              print(f"Could not request review (HTTP {error.code}): {details}")
+              if error.code == 403:
+                  print(
+                      "Skipping failure: workflow tokens from forks/Dependabot "
+                      "are often read-only and cannot post PR comments."
+                  )
+              else:
+                  print("Ensure the workflow token has permission to comment.")
+                  sys.exit(1)
           PY


### PR DESCRIPTION
### Motivation
- The `request-jules-review` workflow could hard-fail on `pull_request` events from forks/Dependabot because `GITHUB_TOKEN` is often read-only and posting a PR comment can return HTTP 403, which should not block external contributions.

### Description
- Update `.github/workflows/request-jules-review.yml` to log the HTTP error details and treat HTTP 403 responses as non-fatal while preserving `sys.exit(1)` for other HTTP errors so unexpected API failures still fail the job.

### Testing
- No automated tests were run because this is a workflow script change; the modification was validated by inspecting the updated `request-jules-review.yml` and committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb3a763508320a02208221162721a)