### PR TITLE
Handle --outdir creation errors in CLI (fix P1 regression)

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -55,8 +55,13 @@ def main(argv=None):
         })
 
         # Bolt: Optimize by creating outdir once, outside the loop
-        if args.outdir and not os.path.exists(args.outdir):
-            os.makedirs(args.outdir)
+        if args.outdir:
+            try:
+                if not os.path.exists(args.outdir):
+                    os.makedirs(args.outdir)
+            except OSError as e:
+                print(f"File error: {e}", file=sys.stderr)
+                return 1
 
         def process_url(target_url: str) -> None:
             """Process a single URL."""

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -60,7 +60,7 @@ class TestCliExceptions(unittest.TestCase):
 
         output = captured_stderr.getvalue()
         self.assertEqual(result, 1)
-        self.assertIn("Batch file not found", output)
+        self.assertIn("Error: Batch file not found: missing.txt", output)
         mock_makedirs.assert_not_called()
 
     def test_outdir_creation_error(self):

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -47,6 +47,19 @@ class TestCliExceptions(unittest.TestCase):
                              self.assertIn("File error", output)
                              self.assertIn("Permission denied", output)
 
+    def test_outdir_creation_error(self):
+        """Test that outdir creation errors are caught and surfaced."""
+        captured_stderr = io.StringIO()
+        with patch('sys.stderr', captured_stderr):
+            with patch('os.path.exists', return_value=False):
+                with patch('os.makedirs', side_effect=OSError("Permission denied")):
+                    exit_code = main(['--url', 'http://example.com', '--outdir', '/root/forbidden'])
+
+        output = captured_stderr.getvalue()
+        self.assertEqual(exit_code, 1)
+        self.assertIn("File error", output)
+        self.assertIn("Permission denied", output)
+
     def test_outdir_containment_uses_path_aware_check(self):
         """Test that output containment check rejects prefix-matching escapes."""
         captured_stderr = io.StringIO()


### PR DESCRIPTION
### Motivation
- The hoisted `--outdir` creation moved `os.makedirs` outside the existing `process_url` error path which caused `OSError` (e.g. `PermissionError`) to escape as an uncaught exception, regressing user-facing error handling.

### Description
- Guard `--outdir` initialization in `src/html2md/cli.py` with a `try/except OSError` that prints `File error: ...` to `stderr` and returns `1` on failure to preserve the previous CLI behavior.
- Add a regression test `test_outdir_creation_error` in `tests/test_cli_exceptions.py` that simulates `os.makedirs` raising `OSError("Permission denied")` and verifies the CLI returns `1` and prints the expected `File error` message.

### Testing
- Installed test dependencies with `python -m pip install -q pytest requests markdownify` and ran the CLI exception tests with `PYTHONPATH=src python -m pytest -q tests/test_cli_exceptions.py tests/test_cli_error.py`.
- The test run completed successfully and the modified test suite passed (`...... [100%]`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb37ade4c83209d6a2a7152605c99)