### PR TITLE
Fix: align self-heal trigger to 'ci' and remove pnpm workspace flags from healthcheck

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -3,7 +3,7 @@ name: Self-heal (auto-fix & PR)
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["build-and-test"]
+    workflows: ["ci"]
     types:
       - completed
 

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -24,9 +24,9 @@ const tryRun = (name, cmd) => {
 
 try {
   // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+  tryRun("Typecheck", hasScript("typecheck") ? "pnpm run typecheck" : null);
+  tryRun("Lint", hasScript("lint") ? "pnpm run lint" : null);
+  tryRun("Unit tests", hasScript("test") ? "pnpm run test -- --run" : null);
 
   // Workspace smoke builds (apps/* and packages/* if build exists)
   const roots = ["apps", "packages"];


### PR DESCRIPTION
### Motivation
- The self-heal workflow did not run after CI failures because `workflow_run` was listening for `build-and-test` while the repository’s CI workflow is named `ci`.
- The healthcheck script failed immediately in this non-workspace repository because root checks used `pnpm -w`, which errors outside a pnpm workspace.

### Description
- Updated `.github/workflows/self-heal.yml` to listen to `workflow_run.workflows: ["ci"]` so the self-heal job runs automatically after the repository CI completes.
- Updated `scripts/healthcheck.mjs` to remove the workspace-only `-w` flags from the root checks so they run as `pnpm run <script>` in a single-package repo.
- No other behavioral changes to the workflow steps or repair logic were made.

### Testing
- `node --check scripts/healthcheck.mjs` completed successfully.
- Executed `pnpm run healthcheck`, which now reaches the intended root script invocation path but fails in this environment due to missing project setup (`node_modules` and `tsconfig.json`), confirming the previous immediate failure caused by `-w` is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb379543c8320b624c6b957c51092)