### PR TITLE
[AI-Assisted] Add codebase issue backlog with typo/bug/docs/test tasks

### DIFF
--- a/docs/codebase_issue_tasks.md
+++ b/docs/codebase_issue_tasks.md
@@ -44,24 +44,30 @@ This document lists four scoped follow-up tasks discovered during a repository s
 ---
 
 ## 3) Docs/Comment Discrepancy Task: Align README with actual CLI behavior
+## 3) Docs/Comment Discrepancy Task: Resolve CLI source-of-truth conflict
 
 **Evidence**
 - README describes `html2md` as a placeholder runtime command.
+- Other repository guidance (for example `CLAUDE.md` and `.github/copilot-instructions.md`) also describes `src/html2md/cli.py` as a placeholder stub.
 - The current CLI includes concrete conversion flow (`--url`, `--batch`, requests fetch, markdownify conversion, file output support).
+- As written, a docs-only update could bless behavior that is out of contract with the rest of the repository guidance.
 
 **Locations**
 - `README.md`
-**Location**
-- `README.md`
+- `CLAUDE.md`
+- `.github/copilot-instructions.md`
+- `src/html2md/cli.py`
 
 **Proposed task**
-- Rewrite README sections that call the CLI a placeholder so documentation matches implemented behavior and constraints.
-- Explicitly document supported schemes, exit-code behavior, and dependency requirements.
+- First decide and document the source of truth for CLI behavior: either `src/html2md/cli.py` must match the placeholder-stub contract, or the repository documentation must be updated to reflect the implemented runtime behavior.
+- After that decision, update all affected docs and/or implementation together so the repository presents one consistent contract.
+- Explicitly document the chosen contract, including any supported options, constraints, exit-code behavior, and dependency expectations that should remain visible to contributors.
 
 **Acceptance criteria**
-- README no longer labels the CLI as placeholder-only.
-- CLI options and observed behavior match docs.
-- A docs-focused test/checklist step is added to prevent future drift.
+- A single source of truth for CLI behavior is identified and recorded in the updated task output.
+- If the placeholder-stub contract is retained, `src/html2md/cli.py` and contributor-facing docs consistently describe that placeholder behavior.
+- If the current runtime behavior is retained, all relevant docs (not just `README.md`) are updated to match it.
+- A docs-focused test/checklist step is added to prevent future drift across contributor guidance and user-facing documentation.
 
 ---
 

--- a/docs/codebase_issue_tasks.md
+++ b/docs/codebase_issue_tasks.md
@@ -1,0 +1,82 @@
+# Codebase Issue Backlog (2026-04-28)
+
+This document lists four scoped follow-up tasks discovered during a repository scan.
+
+## 1) Typo/UX Task: Fix missing whitespace in dependency error message
+
+**Evidence**
+- In the CLI import error path, two adjacent string literals are concatenated without a space after the period.
+- Current output can render as: `Error: Missing dependency requests.Please run: ...`.
+
+**Location**
+- `src/html2md/cli.py`
+
+**Proposed task**
+- Update the error message so the sentence spacing is correct and user-facing output is readable.
+
+**Acceptance criteria**
+- Error output includes a space after the period (`... dependency <name>. Please run ...`).
+- Existing error-path tests are updated/added to assert exact message formatting.
+
+---
+
+## 2) Bug Task: Return non-zero exit code when conversions fail
+
+**Evidence**
+- `process_url()` prints network/conversion/file errors but does not communicate failure back to `main()`.
+- `main()` currently returns `0` after processing URL(s) even when all conversions fail.
+
+**Location**
+- `src/html2md/cli.py`
+
+**Impact**
+- Automation/CI scripts can treat failed runs as successful.
+
+**Proposed task**
+- Make `process_url()` return a success/failure boolean.
+- Aggregate per-item results in `main()` and return `1` if any requested conversion fails.
+
+**Acceptance criteria**
+- Single URL failure exits non-zero.
+- Batch mode exits non-zero if at least one URL fails.
+- Batch mode exits zero only when all attempted conversions succeed.
+
+---
+
+## 3) Docs/Comment Discrepancy Task: Align README with actual CLI behavior
+
+**Evidence**
+- README describes `html2md` as a placeholder runtime command.
+- The current CLI includes concrete conversion flow (`--url`, `--batch`, requests fetch, markdownify conversion, file output support).
+
+**Locations**
+- `README.md`
+- `src/html2md/cli.py`
+
+**Proposed task**
+- Rewrite README sections that call the CLI a placeholder so documentation matches implemented behavior and constraints.
+- Explicitly document supported schemes, exit-code behavior, and dependency requirements.
+
+**Acceptance criteria**
+- README no longer labels the CLI as placeholder-only.
+- CLI options and observed behavior match docs.
+- A docs-focused test/checklist step is added to prevent future drift.
+
+---
+
+## 4) Test Improvement Task: Strengthen CLI smoke coverage beyond return code
+
+**Evidence**
+- Smoke test only asserts `--help` returns zero.
+- It does not assert that expected options appear, and it uses `shell=True` unnecessarily.
+
+**Location**
+- `tests/test_cli_smoke.py`
+
+**Proposed task**
+- Replace shell-based invocation with argument-list invocation (`subprocess.run([...])`).
+- Assert help output includes critical flags (`--url`, `--batch`, `--outdir`).
+
+**Acceptance criteria**
+- Smoke test validates both successful execution and basic CLI contract.
+- Test remains platform-agnostic and avoids shell quoting edge cases.

--- a/docs/codebase_issue_tasks.md
+++ b/docs/codebase_issue_tasks.md
@@ -51,7 +51,8 @@ This document lists four scoped follow-up tasks discovered during a repository s
 
 **Locations**
 - `README.md`
-- `src/html2md/cli.py`
+**Location**
+- `README.md`
 
 **Proposed task**
 - Rewrite README sections that call the CLI a placeholder so documentation matches implemented behavior and constraints.


### PR DESCRIPTION
### Motivation
- Capture and prioritize four small, actionable follow-ups (typo/UX, functional bug, docs discrepancy, and test improvement) discovered during a quick codebase scan by adding a focused backlog entry for maintainers to pick up (`docs/codebase_issue_tasks.md`).

### Description
- Add `docs/codebase_issue_tasks.md` containing one scoped task each to: fix a missing whitespace in the CLI dependency error message, ensure non-zero exit codes on conversion failures, align `README.md` with actual CLI behavior, and strengthen the CLI smoke test; each task includes evidence, location, proposed change, and acceptance criteria.

### Testing
- No automated tests were executed for this documentation-only change; the change is purely a new docs file and does not alter runtime code or test behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f012e429948320ad39cde3ae9ffa93)