### PR TITLE
🧪 [testing improvement] Add test for Flask health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
+          pip install -e ".[deploy]"
           pip install pytest
       - name: Test
         run: pytest -q

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,25 +1,31 @@
 import pytest
 
 # Skip this entire module if flask is not installed
-flask = pytest.importorskip("flask")
+pytest.importorskip("flask")
 
 from html2md import __version__
 from html2md.app import app
 
+
 @pytest.fixture
 def client():
     """A test client for the app."""
+    original_testing = app.config.get("TESTING", False)
     app.config["TESTING"] = True
-    with app.test_client() as client:
-        yield client
+    try:
+        with app.test_client() as client:
+            yield client
+    finally:
+        app.config["TESTING"] = original_testing
+
 
 def test_health(client):
     """Test the /health endpoint."""
     response = client.get("/health")
     assert response.status_code == 200
 
-    data = response.get_json()
-    assert data is not None
-    assert data["status"] == "ok"
-    assert data["service"] == "html2md"
-    assert data["version"] == __version__
+    assert response.get_json() == {
+        "status": "ok",
+        "service": "html2md",
+        "version": __version__,
+    }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,27 @@
+import pytest
+
+# Skip this entire module if flask is not installed
+flask = pytest.importorskip("flask")
+
+from html2md import __version__
+from html2md.app import app
+
+
+@pytest.fixture
+def client():
+    """A test client for the app."""
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_health(client):
+    """Test the /health endpoint."""
+    response = client.get("/health")
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert data is not None
+    assert data["status"] == "ok"
+    assert data["service"] == "html2md"
+    assert data["version"] == __version__

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,14 +6,12 @@ flask = pytest.importorskip("flask")
 from html2md import __version__
 from html2md.app import app
 
-
 @pytest.fixture
 def client():
     """A test client for the app."""
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
-
 
 def test_health(client):
     """Test the /health endpoint."""


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of tests for the `health()` endpoint in the `src/html2md/app.py` Flask application.
📊 **Coverage:** The new test covers the `/health` endpoint, checking the status code (200), and making sure the response body contains the expected JSON (`{'status': 'ok', 'service': 'html2md', 'version': __version__}`). The whole test module skips when flask is not installed.
✨ **Result:** A new set of reliable tests ensures that any modification to the application startup or health endpoint behaves correctly without regressions.

---
*PR created automatically by Jules for task [306050913103394122](https://jules.google.com/task/306050913103394122) started by @badMade*