### PR TITLE
🧪 [Testing Improvement] Add error handling test for invalid PORT env var

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -27,4 +27,6 @@ jobs:
             } catch (error) {
               console.log(`Could not request review: ${error.message}`);
               console.log('Ensure @google-labs-jules[bot] has access to this repository.');
+              // We do not fail the step if requesting review fails because of permissions
+              // so we don't block the PR.
             }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,21 @@
+import pytest
+
+try:
+    import flask  # noqa: F401
+except ImportError:
+    pytest.skip("flask is not installed", allow_module_level=True)
+
+from html2md.app import get_host_port, DEFAULT_PORT
+
+
+def test_get_host_port_invalid_port(capsys, monkeypatch):
+    monkeypatch.setenv("PORT", "not-an-int")
+
+    host, port = get_host_port()
+
+    assert host == "0.0.0.0"
+    assert port == DEFAULT_PORT
+
+    captured = capsys.readouterr()
+    assert "Warning: Invalid PORT environment variable value" in captured.out
+    assert "'not-an-int'" in captured.out

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,5 +43,6 @@ def test_get_host_port_invalid_port(capsys, monkeypatch):
     assert port == DEFAULT_PORT
 
     captured = capsys.readouterr()
-    assert "Warning: Invalid PORT environment variable value" in captured.out
-    assert "'not-an-int'" in captured.out
+    output = captured.out + captured.err
+    assert "Warning: Invalid PORT environment variable value" in output
+    assert "'not-an-int'" in output

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,6 +10,7 @@ from html2md.app import get_host_port, DEFAULT_PORT
 
 def test_get_host_port_invalid_port(capsys, monkeypatch):
     monkeypatch.setenv("PORT", "not-an-int")
+    monkeypatch.delenv("HOST", raising=False)
 
     host, port = get_host_port()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,36 @@
-import pytest
+from __future__ import annotations
 
-try:
-    import flask  # noqa: F401
-except ImportError:
-    pytest.skip("flask is not installed", allow_module_level=True)
+import sys
+import types
 
-from html2md.app import get_host_port, DEFAULT_PORT
+
+def _ensure_flask_stub() -> None:
+    """Inject a minimal Flask stub so html2md.app can be imported without Flask."""
+    if "flask" in sys.modules:
+        return
+
+    flask_stub = types.ModuleType("flask")
+
+    class _FakeFlask:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def route(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+
+    flask_stub.Flask = _FakeFlask
+    flask_stub.jsonify = lambda *args, **kwargs: {}
+    sys.modules["flask"] = flask_stub
+
+
+_ensure_flask_stub()
+
+# html2md.app may have been cached before our stub was in place; evict it.
+sys.modules.pop("html2md.app", None)
+
+from html2md.app import DEFAULT_PORT, get_host_port  # noqa: E402
 
 
 def test_get_host_port_invalid_port(capsys, monkeypatch):


### PR DESCRIPTION
🎯 **What:** The missing error handling test case for when an invalid `PORT` environment variable is supplied to `get_host_port()` in `src/html2md/app.py`.
📊 **Coverage:** A new test `test_get_host_port_invalid_port` was implemented using `monkeypatch` to set `PORT` to a non-integer value, capturing warnings, and verifying the port falls back gracefully to `DEFAULT_PORT`.
✨ **Result:** Test coverage for this error handling scenario increases reliability by confirming the application doesn't crash on invalid integer configurations from environment variables.

---
*PR created automatically by Jules for task [12787391477907377107](https://jules.google.com/task/12787391477907377107) started by @badMade*