### PR TITLE
Fix Gemini Code Assist workflow action reference

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -44,6 +44,12 @@ jobs:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           prompt: '/pr-code-review'
+          # The run-gemini-cli `extensions` input passes each entry as the
+          # single <source> argument to `gemini extensions install`, which
+          # accepts a git ref only via a separate `--ref` flag we cannot
+          # inject through this input. The extension below tracks the
+          # default branch; last verified at commit
+          # dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04.
           extensions: |
             ["https://github.com/gemini-cli-extensions/code-review"]
           settings: |-

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   gemini-code-assist:
@@ -28,4 +29,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+        uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          prompt: '/pr-code-review'
+          extensions: |
+            ["https://github.com/gemini-cli-extensions/code-review"]

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -85,6 +85,9 @@ jobs:
           gemini_cli_version: '0.41.2'
           extensions: |
             ["${{ runner.temp }}/gemini-code-review-ext"]
+          # Keep the MCP allowlist scoped to the exact tools used by
+          # /pr-code-review's pending-review flow; do not expose broader
+          # aggregate review-write tools to the --yolo reviewer.
           settings: |-
             {
               "tools": {

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-github-actions/run-gemini-cli@v0
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -32,6 +32,40 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Comment-triggered events fire from the base repo regardless of where
+      # the PR's head lives. The job-level author_association check rejects
+      # untrusted commenters, but a trusted collaborator commenting on a
+      # fork PR would still feed the fork's diff to a --yolo run with
+      # write-capable MCP tools and GEMINI_API_KEY in scope. Verify the PR
+      # head repo before any secret-using step runs.
+      - name: Verify PR head is not a fork (comment-triggered runs)
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          head_repo=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
+          if [ "${head_repo}" != "${REPO}" ]; then
+            echo "Refusing to run secret-backed Gemini review on fork PR (head=${head_repo})" >&2
+            exit 1
+          fi
+      # Install the code-review extension from a pinned commit by cloning
+      # locally and passing the path to the action's `extensions:` input.
+      # The action's installer treats non-https sources as local paths, so
+      # this avoids the floating default-branch install while still letting
+      # `gemini extensions install` set up the manifest.
+      - name: Clone gemini code-review extension at pinned commit
+        if: env.GEMINI_API_KEY != ''
+        env:
+          EXTENSION_REF: dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04
+        run: |
+          set -euo pipefail
+          rm -rf "${RUNNER_TEMP}/gemini-code-review-ext"
+          git clone --no-tags https://github.com/gemini-cli-extensions/code-review.git \
+            "${RUNNER_TEMP}/gemini-code-review-ext"
+          git -C "${RUNNER_TEMP}/gemini-code-review-ext" checkout "${EXTENSION_REF}"
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != ''
         continue-on-error: true
@@ -44,14 +78,8 @@ jobs:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           prompt: '/pr-code-review'
-          # The run-gemini-cli `extensions` input passes each entry as the
-          # single <source> argument to `gemini extensions install`, which
-          # accepts a git ref only via a separate `--ref` flag we cannot
-          # inject through this input. The extension below tracks the
-          # default branch; last verified at commit
-          # dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04.
           extensions: |
-            ["https://github.com/gemini-cli-extensions/code-review"]
+            ["${{ runner.temp }}/gemini-code-review-ext"]
           settings: |-
             {
               "mcpServers": {

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -78,10 +78,18 @@ jobs:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           prompt: '/pr-code-review'
+          # Pin the Gemini CLI alongside the action/extension/MCP image so
+          # the full toolchain handed GITHUB_TOKEN and review-write MCP is
+          # reproducible run-to-run. The action's default of `latest`
+          # would otherwise re-resolve on every execution.
+          gemini_cli_version: '0.41.2'
           extensions: |
             ["${{ runner.temp }}/gemini-code-review-ext"]
           settings: |-
             {
+              "tools": {
+                "core": []
+              },
               "mcpServers": {
                 "github": {
                   "command": "docker",
@@ -97,7 +105,6 @@ jobs:
                     "add_comment_to_pending_review",
                     "create_pending_pull_request_review",
                     "pull_request_read",
-                    "pull_request_review_write",
                     "submit_pending_pull_request_review"
                   ],
                   "env": {

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -36,9 +36,12 @@ jobs:
       # the PR's head lives. The job-level author_association check rejects
       # untrusted commenters, but a trusted collaborator commenting on a
       # fork PR would still feed the fork's diff to a --yolo run with
-      # write-capable MCP tools and GEMINI_API_KEY in scope. Verify the PR
-      # head repo before any secret-using step runs.
+      # write-capable MCP tools and GEMINI_API_KEY in scope. Resolve the PR
+      # head repo first and gate the secret-using steps below on the result,
+      # so a fork skip looks like a clean "skipped" rather than a red
+      # failure while still keeping secrets off-runner.
       - name: Verify PR head is not a fork (comment-triggered runs)
+        id: forkcheck
         if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,8 +51,10 @@ jobs:
           set -euo pipefail
           head_repo=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
           if [ "${head_repo}" != "${REPO}" ]; then
-            echo "Refusing to run secret-backed Gemini review on fork PR (head=${head_repo})" >&2
-            exit 1
+            echo "Skipping: PR head is a fork (${head_repo}); not exposing review secrets."
+            echo "fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fork=false" >> "$GITHUB_OUTPUT"
           fi
       # Install the code-review extension from a pinned commit by cloning
       # locally and passing the path to the action's `extensions:` input.
@@ -57,7 +62,7 @@ jobs:
       # this avoids the floating default-branch install while still letting
       # `gemini extensions install` set up the manifest.
       - name: Clone gemini code-review extension at pinned commit
-        if: env.GEMINI_API_KEY != ''
+        if: env.GEMINI_API_KEY != '' && steps.forkcheck.outputs.fork != 'true'
         env:
           EXTENSION_REF: dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04
         run: |
@@ -67,7 +72,7 @@ jobs:
             "${RUNNER_TEMP}/gemini-code-review-ext"
           git -C "${RUNNER_TEMP}/gemini-code-review-ext" checkout "${EXTENSION_REF}"
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != ''
+        if: env.GEMINI_API_KEY != '' && steps.forkcheck.outputs.fork != 'true'
         continue-on-error: true
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -57,12 +57,14 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                    "ghcr.io/github/github-mcp-server@sha256:a1d43076a36638ee24520fd6e83c3905ae41bc9850179081df1de2ba3a7afae0"
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
+                    "create_pending_pull_request_review",
                     "pull_request_read",
-                    "pull_request_review_write"
+                    "pull_request_review_write",
+                    "submit_pending_pull_request_review"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,7 +17,8 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == false) ||
       (((github.event_name == 'pull_request_review_comment') ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
        (github.event.comment.author_association == 'OWNER' ||

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -12,17 +12,17 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
+      (((github.event_name == 'pull_request_review_comment') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - uses: actions/checkout@v4
@@ -32,9 +32,35 @@ jobs:
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           prompt: '/pr-code-review'
           extensions: |
             ["https://github.com/gemini-cli-extensions/code-review"]
+          settings: |-
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              }
+            }

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -55,5 +55,8 @@ jobs:
           except urllib.error.HTTPError as error:
               body = error.read().decode("utf-8")
               print(f"Could not request review: HTTP {error.code}: {body}")
-              sys.exit(1)
+              if 400 <= error.code < 500 and error.code not in (403, 429):
+                  print("Ensure the workflow token has permission to comment.")
+                  sys.exit(1)
+              print("Treating as transient or expected; not failing the workflow.")
           PY

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -22,6 +22,7 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import sys
           import urllib.error
           import urllib.request
 
@@ -55,4 +56,5 @@ jobs:
                   f"{error.read().decode('utf-8')}"
               )
               print("Ensure the workflow token has permission to comment.")
+              sys.exit(1)
           PY

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   request-review:
@@ -21,7 +22,6 @@ jobs:
           python - <<'PY'
           import json
           import os
-          import sys
           import urllib.error
           import urllib.request
 
@@ -50,7 +50,9 @@ jobs:
                       f"PR #{pr_number} (status {response.status})"
                   )
           except urllib.error.HTTPError as error:
-              print(f"Could not request review: {error.read().decode('utf-8')}")
+              print(
+                  f"Could not request review (HTTP {error.code}): "
+                  f"{error.read().decode('utf-8')}"
+              )
               print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
           PY

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -55,6 +55,8 @@ jobs:
                   f"Could not request review (HTTP {error.code}): "
                   f"{error.read().decode('utf-8')}"
               )
-              print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
+              if 400 <= error.code < 500 and error.code != 429:
+                  print("Ensure the workflow token has permission to comment.")
+                  sys.exit(1)
+              print("Treating as transient; not failing the workflow.")
           PY

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -54,10 +54,6 @@ jobs:
                   )
           except urllib.error.HTTPError as error:
               body = error.read().decode("utf-8")
-              print(f"Could not request review: {body}")
-              # Don't fail the entire workflow if GitHub forbids commenting
-              if error.code == 403:
-                  print("Skipping: token cannot comment in this PR context.")
-                  sys.exit(0)
-              raise
+              print(f"Could not request review: HTTP {error.code}: {body}")
+              sys.exit(1)
           PY

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -55,8 +55,17 @@ jobs:
           except urllib.error.HTTPError as error:
               body = error.read().decode("utf-8")
               print(f"Could not request review: HTTP {error.code}: {body}")
-              if 400 <= error.code < 500 and error.code not in (403, 429):
-                  print("Ensure the workflow token has permission to comment.")
+              if error.code == 403:
+                  # Tolerated: token lacks write permission on this PR
+                  # (e.g. base-repo policy on PRs from a fork). The job's
+                  # fork guard already filters most of these, so log and
+                  # exit clean rather than block the required check.
+                  print("Treating 403 as expected permission limit; not failing.")
+              else:
+                  # 429 (rate-limit) and 5xx are transient; bubble them up
+                  # so the workflow surfaces the dropped request and
+                  # GitHub Actions retry/visibility can act on it instead
+                  # of silently going green.
+                  print("Failing so the missing review request is visible.")
                   sys.exit(1)
-              print("Treating as transient or expected; not failing the workflow.")
           PY


### PR DESCRIPTION
## Summary

This PR addresses two GitHub Actions workflows.

### 1. `.github/workflows/gemini-code-assist.yml` (primary fix)
- Replace the unresolvable `google-gemini/code-assist-action@v1` reference with the official `google-github-actions/run-gemini-cli` action so the job can get past the "Prepare all required actions" download phase. Pin to commit SHA `f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22` for supply-chain reproducibility (matches the SHA-pin pattern used in `.github/workflows/claude-agent.yml`).
- Pin `gemini_cli_version: '0.41.2'` so the CLI itself is not silently re-resolved to `latest` on every run.
- Wire up the `code-review` extension end-to-end: pass `gemini_api_key`, `github_pr_number`, the `/pr-code-review` prompt, `REPOSITORY` / `PULL_REQUEST_NUMBER` env vars, and a `settings:` block that enables the GitHub MCP server with the exact pending-review tools the extension actually calls (`pull_request_read`, `add_comment_to_pending_review`, `create_pending_pull_request_review`, `submit_pending_pull_request_review`) so Gemini can fetch the diff and complete the pending-review lifecycle. The aggregate `pull_request_review_write` tool is intentionally _not_ exposed.
- Pre-clone the `gemini-cli-extensions/code-review` extension and `git checkout` commit `dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04`, then pass the local path to the action's `extensions:` input so the install runs against a fixed tree rather than the floating default branch.
- Pin the `ghcr.io/github/github-mcp-server` container to its v0.27.0 digest (`sha256:a1d4307…7afae0`) so the image can't shift under us.
- Disable the default core (shell / file / web) tools under `--yolo` via `"tools": {"core": []}` so a prompt-injected diff cannot run shell commands with secrets in the env and exfiltrate via the review tools.
- Restrict comment-triggered runs (`issue_comment` / `pull_request_review_comment`) to OWNER/MEMBER/COLLABORATOR comments to keep external commenters from spending the `GEMINI_API_KEY` quota, mirroring `.github/workflows/claude-agent.yml`.
- Skip `pull_request` runs from forks, since GitHub does not expose secrets to fork PRs.
- Add a fork guard for the comment-triggered paths: a pre-step uses `gh api` to resolve the PR's head repo and exposes a `forkcheck.outputs.fork` flag. The extension-clone and `run-gemini-cli` steps both gate on `fork != 'true'`, so a fork PR comment is shown as a clean skip while `GEMINI_API_KEY` and write-capable MCP tools never reach the runner.

### 2. `.github/workflows/request-jules-review.yml` (related ride-along)
This PR also fixes pre-existing failures in the Jules review-request workflow that surfaced once the workflow was running on every PR in this branch:
- Add `pull-requests: write` and `issues: write` permissions; without `pull-requests: write` the comment POST returned an HTTP error on every run.
- Skip fork PRs at the workflow level (`head.repo.full_name == github.repository`).
- On HTTPError, exit 0 only for 403 (a legitimate token-permission/policy case the fork-skip mostly filters anyway), and `sys.exit(1)` for everything else — including 429 rate-limits and 5xx server errors — so a missing review request is visible in Actions instead of silently going green.

## Why
GitHub Actions was failing with `Unable to resolve action google-gemini/code-assist-action, repository not found` because that owner/repo doesn't exist. `google-github-actions/run-gemini-cli` is the official action that powers Gemini Code Assist on PRs.

## Follow-up
- A `GEMINI_API_KEY` repository secret must be configured for the review step to succeed at runtime; without it the gated step skips via `if: env.GEMINI_API_KEY != ''`.

## Test plan
- [ ] Confirm the `Gemini Code Assist` job no longer fails at the action-resolution stage on this PR.
- [ ] Add the `GEMINI_API_KEY` secret to the repo, re-run the workflow, and verify the review step actually posts a review.
- [ ] Verify a comment from a non-collaborator on a future PR does not trigger the workflow.
- [ ] Verify a comment from a collaborator on a fork PR resolves to a clean skip (forkcheck output) rather than a red failure, and that no Gemini run is launched.
- [ ] Verify the Jules review request comment lands on a non-fork PR (and that the workflow is skipped on a fork PR), and that a forced 5xx from the GitHub API fails the step rather than silently exiting 0.

https://claude.ai/code/session_01WGLEAdB8d5hDxKFnbcuPtG