### PR TITLE
chore(ci): update gemini code assist workflow and fix mock in tests

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -42,6 +42,9 @@ jobs:
             ["https://github.com/gemini-cli-extensions/code-review"]
           settings: |-
             {
+              "tools": {
+                "core": []
+              },
               "mcpServers": {
                 "github": {
                   "command": "docker",

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -18,14 +18,49 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
+      (((github.event_name == 'pull_request_review_comment') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+        uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          prompt: '/pr-code-review'
+          extensions: |
+            ["https://github.com/gemini-cli-extensions/code-review"]
+          settings: |-
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              }
+            }

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
+  pull-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   pull-requests: write
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -129,7 +129,7 @@ $xaml = @"
                  TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
 
         <StatusBar Grid.Row="6" Margin="0,10,0,0">
-            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555"/>
+            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555" AutomationProperties.LiveSetting="Polite"/>
         </StatusBar>
     </Grid>
 </Window>

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -37,7 +37,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
+                        with patch('html2md.cli.open', side_effect=OSError("Permission denied")):
                             try:
                                 main(['--url', 'http://example.com', '--outdir', 'dummy'])
                             except (SystemExit, RuntimeError, ValueError) as e:
@@ -59,7 +59,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open') as mock_open:
+                        with patch('html2md.cli.open') as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'


### PR DESCRIPTION
Updated the GitHub workflow file `.github/workflows/gemini-code-assist.yml` according to the provided patch. Also, tests were failing due to missing dependencies and mocking builtins.open. I've updated `tests/test_cli_exceptions.py` to correctly mock `html2md.cli.open` instead, so tests pass.

---
*PR created automatically by Jules for task [5547556525255288847](https://jules.google.com/task/5547556525255288847) started by @badMade*