### PR TITLE
Fix CLI parser construction under mocked file writes

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,21 +6,29 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
-def main(argv=None):
-    """Run the CLI."""
-    ap = argparse.ArgumentParser(
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser."""
+    parser = argparse.ArgumentParser(
         prog='html2md',
         description='Convert HTML URL to Markdown.'
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    parser.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
+    parser.add_argument('--url', help='Input URL to convert')
+    parser.add_argument('--batch', help='File containing URLs to process (one per line)')
+    parser.add_argument('--outdir', help='Output directory to save the file')
+    return parser
 
-    args = ap.parse_args(argv)
+
+_PARSER = _build_parser()
+
+
+def main(argv=None):
+    """Run the CLI."""
+    args = _PARSER.parse_args(argv)
 
     if args.help_only:
-        ap.print_help()
+        _PARSER.print_help()
         return 0
 
     if args.url or args.batch:
@@ -127,5 +135,5 @@ def main(argv=None):
 
         return 0
 
-    ap.print_help()
+    _PARSER.print_help()
     return 0


### PR DESCRIPTION
### Motivation

- Tests that mock `builtins.open` caused `argparse.ArgumentParser()` to trigger gettext translation file reads which, when intercepted by a `MagicMock`, raised a `TypeError` during test runs. 
- The goal is to avoid triggering translation file parsing during `main()` so unit tests that mock filesystem calls do not fail spuriously. 

### Description

- Extracted CLI argument parser creation into a helper function `_build_parser()` and created a module-level `_PARSER` initialized at import time. 
- Updated `main()` to call `_PARSER.parse_args()` and use `_PARSER.print_help()` so parser construction is not performed inside `main()` while tests may have patched I/O. 
- Preserved existing CLI behavior and help output; no changes to arguments or runtime semantics. 

### Testing

- Ran the full test suite with `uv run --python 3.12 --with pytest python -m pytest -q`, and all tests passed (`[100%]`).
- Verified the previously observed failure in `TestCliExceptions.test_outdir_containment_uses_path_aware_check` was resolved by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc01ba02e0832087789a3ab4a48218)