### PR TITLE
Add Claude PreToolUse hook to block edits to sensitive files

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -81,14 +81,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"protect-sensitive-files: failed to read stdin: {exc}",
             file=sys.stderr,
         )
-        return 1
+        return 2
 
     if not payload_raw.strip():
         print(
             "protect-sensitive-files: empty hook payload",
             file=sys.stderr,
         )
-        return 1
+        return 2
 
     try:
         payload = json.loads(payload_raw)
@@ -97,14 +97,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"protect-sensitive-files: bad JSON payload: {exc}",
             file=sys.stderr,
         )
-        return 1
+        return 2
 
     if not isinstance(payload, dict):
         print(
             "protect-sensitive-files: hook payload must be a JSON object",
             file=sys.stderr,
         )
-        return 1
+        return 2
 
     tool_name = payload.get("tool_name") or ""
     if tool_name not in PROTECTED_TOOLS:

--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -12,7 +12,7 @@ import fnmatch
 import json
 import os
 import sys
-from typing import Any
+from typing import Any, List, Optional
 
 
 SENSITIVE_BASENAME_PATTERNS = (
@@ -24,6 +24,13 @@ SENSITIVE_BASENAME_PATTERNS = (
     "credentials.json",
     "id_rsa",
     "id_rsa.pub",
+    "id_ed25519",
+    "id_ed25519.pub",
+    "id_ecdsa",
+    "id_ecdsa.pub",
+    "id_dsa",
+    "id_dsa.pub",
+    "authorized_keys",
 )
 
 PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
@@ -49,18 +56,24 @@ def is_sensitive(path: str) -> bool:
     return False
 
 
-def candidate_paths(tool_input: dict[str, Any]) -> list[str]:
-    """Extract target file paths from a Claude Code tool input object."""
+def candidate_paths(tool_input: Any) -> List[str]:
+    """Extract and normalize target file paths recursively."""
     candidates = []
-    for key in PATH_KEYS:
-        value = tool_input.get(key)
-        if isinstance(value, str) and value:
-            candidates.append(value)
+    if isinstance(tool_input, dict):
+        for key, value in tool_input.items():
+            if key in PATH_KEYS and isinstance(value, str) and value:
+                candidates.append(os.path.realpath(value))
+            elif isinstance(value, (dict, list)):
+                candidates.extend(candidate_paths(value))
+    elif isinstance(tool_input, list):
+        for item in tool_input:
+            candidates.extend(candidate_paths(item))
     return candidates
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     """Run the hook and return a process exit status."""
+    del argv
     try:
         payload_raw = sys.stdin.read()
     except Exception as exc:  # pragma: no cover - defensive
@@ -68,10 +81,14 @@ def main(argv: list[str] | None = None) -> int:
             f"protect-sensitive-files: failed to read stdin: {exc}",
             file=sys.stderr,
         )
-        return 0
+        return 1
 
     if not payload_raw.strip():
-        return 0
+        print(
+            "protect-sensitive-files: empty hook payload",
+            file=sys.stderr,
+        )
+        return 1
 
     try:
         payload = json.loads(payload_raw)
@@ -80,15 +97,20 @@ def main(argv: list[str] | None = None) -> int:
             f"protect-sensitive-files: bad JSON payload: {exc}",
             file=sys.stderr,
         )
-        return 0
+        return 1
+
+    if not isinstance(payload, dict):
+        print(
+            "protect-sensitive-files: hook payload must be a JSON object",
+            file=sys.stderr,
+        )
+        return 1
 
     tool_name = payload.get("tool_name") or ""
     if tool_name not in PROTECTED_TOOLS:
         return 0
 
     tool_input = payload.get("tool_input") or {}
-    if not isinstance(tool_input, dict):
-        return 0
 
     for path in candidate_paths(tool_input):
         if is_sensitive(path):

--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""PreToolUse hook that blocks edits to sensitive files.
+
+The hook reads a Claude Code hook payload from stdin and exits non-zero with a
+stderr diagnostic when an Edit/Write-style tool targets a sensitive file path.
+It is intentionally stdlib-only so it can run before project dependencies are
+installed.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import sys
+from typing import Any
+
+
+SENSITIVE_BASENAME_PATTERNS = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.crt",
+    "credentials.json",
+    "id_rsa",
+    "id_rsa.pub",
+)
+
+PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+PATH_KEYS = ("file_path", "path", "notebook_path")
+
+
+def is_sensitive(path: str) -> bool:
+    """Return whether ``path`` matches a sensitive filename pattern."""
+    if not path:
+        return False
+
+    normalized_path = os.path.normpath(path)
+    basename = os.path.basename(normalized_path)
+
+    for pattern in SENSITIVE_BASENAME_PATTERNS:
+        if fnmatch.fnmatch(basename, pattern):
+            return True
+        if fnmatch.fnmatch(normalized_path, pattern):
+            return True
+        if fnmatch.fnmatch(normalized_path, os.path.join("*", pattern)):
+            return True
+
+    return False
+
+
+def candidate_paths(tool_input: dict[str, Any]) -> list[str]:
+    """Extract target file paths from a Claude Code tool input object."""
+    candidates = []
+    for key in PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            candidates.append(value)
+    return candidates
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the hook and return a process exit status."""
+    try:
+        payload_raw = sys.stdin.read()
+    except Exception as exc:  # pragma: no cover - defensive
+        print(
+            f"protect-sensitive-files: failed to read stdin: {exc}",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not payload_raw.strip():
+        return 0
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"protect-sensitive-files: bad JSON payload: {exc}",
+            file=sys.stderr,
+        )
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    if tool_name not in PROTECTED_TOOLS:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    for path in candidate_paths(tool_input):
+        if is_sensitive(path):
+            print(
+                f"protect-sensitive-files: BLOCKED — refusing to {tool_name} "
+                f"sensitive file: {path}",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/protect_sensitive_files.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/protect_sensitive_files.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -1,18 +1,32 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Dict
 
 
-HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "protect_sensitive_files.py"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+HOOK = PROJECT_ROOT / ".claude" / "hooks" / "protect_sensitive_files.py"
+
+spec = importlib.util.spec_from_file_location("protect_sensitive_files", str(HOOK))
+assert spec is not None
+assert spec.loader is not None
+protect_sensitive_files = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(protect_sensitive_files)
+SENSITIVE_BASENAME_PATTERNS = protect_sensitive_files.SENSITIVE_BASENAME_PATTERNS
 
 
-def run_hook(payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
+def run_hook(payload: Dict[str, Any]) -> subprocess.CompletedProcess:
+    return run_hook_raw(json.dumps(payload))
+
+
+def run_hook_raw(payload: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(HOOK)],
-        input=json.dumps(payload),
+        input=payload,
         text=True,
         capture_output=True,
         check=False,
@@ -20,16 +34,17 @@ def run_hook(payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
 
 
 def test_blocks_sensitive_file_path() -> None:
+    sensitive_env = SENSITIVE_BASENAME_PATTERNS[1].replace("*", "production")
     result = run_hook(
         {
             "tool_name": "Write",
-            "tool_input": {"file_path": "config/.env.production"},
+            "tool_input": {"file_path": "config/" + sensitive_env},
         }
     )
 
     assert result.returncode == 2
     assert "BLOCKED" in result.stderr
-    assert "config/.env.production" in result.stderr
+    assert sensitive_env in result.stderr
 
 
 def test_allows_non_sensitive_file_path() -> None:
@@ -48,9 +63,79 @@ def test_ignores_unprotected_tool() -> None:
     result = run_hook(
         {
             "tool_name": "Read",
-            "tool_input": {"file_path": ".env"},
+            "tool_input": {"file_path": SENSITIVE_BASENAME_PATTERNS[0]},
         }
     )
 
     assert result.returncode == 0
     assert result.stderr == ""
+
+
+def test_blocks_nested_multi_edit_sensitive_file_path() -> None:
+    ssh_private_key = next(
+        pattern
+        for pattern in SENSITIVE_BASENAME_PATTERNS
+        if pattern.startswith("id_ed") and not pattern.endswith(".pub")
+    )
+
+    result = run_hook(
+        {
+            "tool_name": "MultiEdit",
+            "tool_input": {
+                "edits": [
+                    {
+                        "file_path": "src/html2md/cli.py",
+                        "old_string": "a",
+                        "new_string": "b",
+                    },
+                    {
+                        "metadata": {
+                            "file_path": ".ssh/" + ssh_private_key,
+                        },
+                        "old_string": "old",
+                        "new_string": "new",
+                    },
+                ],
+            },
+        }
+    )
+
+    assert result.returncode == 2
+    assert "BLOCKED" in result.stderr
+    assert ssh_private_key in result.stderr
+
+
+def test_blocks_notebook_edit_sensitive_notebook_path() -> None:
+    certificate_pattern = SENSITIVE_BASENAME_PATTERNS[4]
+    sensitive_certificate = certificate_pattern.replace("*", "client")
+    result = run_hook(
+        {
+            "tool_name": "NotebookEdit",
+            "tool_input": {"notebook_path": "notebooks/" + sensitive_certificate},
+        }
+    )
+
+    assert result.returncode == 2
+    assert "BLOCKED" in result.stderr
+    assert sensitive_certificate in result.stderr
+
+
+def test_bad_json_payload_fails_closed() -> None:
+    result = run_hook_raw("{")
+
+    assert result.returncode == 1
+    assert "bad JSON payload" in result.stderr
+
+
+def test_empty_payload_fails_closed() -> None:
+    result = run_hook_raw("")
+
+    assert result.returncode == 1
+    assert "empty hook payload" in result.stderr
+
+
+def test_non_object_json_payload_fails_closed() -> None:
+    result = run_hook_raw("[]")
+
+    assert result.returncode == 1
+    assert "hook payload must be a JSON object" in result.stderr

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "protect_sensitive_files.py"
+
+
+def run_hook(payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_blocks_sensitive_file_path() -> None:
+    result = run_hook(
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "config/.env.production"},
+        }
+    )
+
+    assert result.returncode == 2
+    assert "BLOCKED" in result.stderr
+    assert "config/.env.production" in result.stderr
+
+
+def test_allows_non_sensitive_file_path() -> None:
+    result = run_hook(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/html2md/cli.py"},
+        }
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_ignores_unprotected_tool() -> None:
+    result = run_hook(
+        {
+            "tool_name": "Read",
+            "tool_input": {"file_path": ".env"},
+        }
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -123,19 +123,19 @@ def test_blocks_notebook_edit_sensitive_notebook_path() -> None:
 def test_bad_json_payload_fails_closed() -> None:
     result = run_hook_raw("{")
 
-    assert result.returncode == 1
+    assert result.returncode == 2
     assert "bad JSON payload" in result.stderr
 
 
 def test_empty_payload_fails_closed() -> None:
     result = run_hook_raw("")
 
-    assert result.returncode == 1
+    assert result.returncode == 2
     assert "empty hook payload" in result.stderr
 
 
 def test_non_object_json_payload_fails_closed() -> None:
     result = run_hook_raw("[]")
 
-    assert result.returncode == 1
+    assert result.returncode == 2
     assert "hook payload must be a JSON object" in result.stderr


### PR DESCRIPTION
### Motivation
- Prevent automated Edit/Write-style tools from modifying sensitive files (env files, keys/certs, credentials, SSH keys) before project dependencies are available.
- Provide a small stdlib-only hook that can run early in a Claude agent workflow to reduce accidental secret exposure.

### Description
- Add a stdlib-only hook at `.claude/hooks/protect_sensitive_files.py` that inspects a Claude Code `PreToolUse` payload on stdin and returns non-zero when a target path matches sensitive patterns (e.g. `.env`, `.env.*`, `*.pem`, `*.key`, `*.crt`, `credentials.json`, `id_rsa`, `id_rsa.pub`).
- Wire the hook into `.claude/settings.json` for `Edit`, `Write`, `MultiEdit`, and `NotebookEdit` tool matchers so it runs automatically for those tool types.
- Add integration tests `tests/test_protect_sensitive_files_hook.py` exercising blocked sensitive paths, allowed non-sensitive paths, and ignored unprotected tools using a subprocess invocation of the hook.

### Testing
- Ran `python -m py_compile .claude/hooks/protect_sensitive_files.py` to verify syntax; compilation succeeded.
- Ran `pytest -q tests/test_protect_sensitive_files_hook.py` to run the new hook tests; those tests passed.
- Ran full test suite `pytest -q`; the run completed but encountered an unrelated existing failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by test-wide `builtins.open` mocking intercepting stdlib `gettext` loading, not by the new hook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc029818d88320b8cf747588d3f695)