### PR TITLE
Add Claude PreToolUse hook to block edits to sensitive files

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -11,18 +11,17 @@ import fnmatch
 import json
 import os
 import sys
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 
 SENSITIVE_BASENAME_PATTERNS = (
-    ".env",
-    ".env.*",
+    ".env*",
     "*.pem",
     "*.key",
     "*.crt",
     "credentials.json",
-    "id_rsa",
-    "id_rsa.pub",
+    "id_rsa*",
+    "id_ed25519*",
 )
 PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
 PATH_KEYS = ("file_path", "path", "notebook_path")
@@ -41,8 +40,8 @@ def is_sensitive(path: str) -> bool:
     if not path:
         return False
 
-    normalized_path = path.lower()
-    normalized_base = os.path.basename(path).lower()
+    normalized_path = path.replace("\\", "/").lower()
+    normalized_base = os.path.basename(normalized_path).lower()
 
     for pattern in SENSITIVE_BASENAME_PATTERNS:
         normalized_pattern = pattern.lower()
@@ -56,7 +55,7 @@ def is_sensitive(path: str) -> bool:
     return False
 
 
-def _load_payload() -> dict[str, Any] | None:
+def _load_payload() -> Optional[Dict[str, Any]]:
     """Read and parse a hook payload from standard input.
 
     Returns:
@@ -86,7 +85,7 @@ def _load_payload() -> dict[str, Any] | None:
     return payload
 
 
-def _target_paths(tool_input: Any) -> list[str]:
+def _target_paths(tool_input: Any) -> List[str]:
     """Extract candidate target paths from a Claude Code tool input.
 
     Args:
@@ -95,18 +94,22 @@ def _target_paths(tool_input: Any) -> list[str]:
     Returns:
         A list of non-empty path strings to inspect.
     """
-    if not isinstance(tool_input, dict):
-        return []
-
     candidates = []
-    for key in PATH_KEYS:
-        value = tool_input.get(key)
-        if isinstance(value, str) and value:
-            candidates.append(value)
+
+    if isinstance(tool_input, dict):
+        for key, value in tool_input.items():
+            if key in PATH_KEYS and isinstance(value, str) and value:
+                candidates.append(os.path.realpath(value))
+            elif isinstance(value, (dict, list)):
+                candidates.extend(_target_paths(value))
+    elif isinstance(tool_input, list):
+        for item in tool_input:
+            candidates.extend(_target_paths(item))
+
     return candidates
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     """Run the PreToolUse sensitive-file guard.
 
     Args:

--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Block Claude Code edits to sensitive files.
+
+This PreToolUse hook reads a Claude Code hook payload from standard input and
+exits with a non-zero status when an Edit, Write, MultiEdit, or NotebookEdit
+request targets a sensitive path.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import sys
+from typing import Any
+
+
+SENSITIVE_BASENAME_PATTERNS = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.crt",
+    "credentials.json",
+    "id_rsa",
+    "id_rsa.pub",
+)
+PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+PATH_KEYS = ("file_path", "path", "notebook_path")
+
+
+def is_sensitive(path: str) -> bool:
+    """Return whether a path matches a sensitive filename pattern.
+
+    Args:
+        path: File path from a Claude Code tool input payload.
+
+    Returns:
+        True when the basename or normalized path matches a sensitive pattern;
+        otherwise False.
+    """
+    if not path:
+        return False
+
+    normalized_path = path.lower()
+    normalized_base = os.path.basename(path).lower()
+
+    for pattern in SENSITIVE_BASENAME_PATTERNS:
+        normalized_pattern = pattern.lower()
+        if fnmatch.fnmatchcase(normalized_base, normalized_pattern):
+            return True
+        if fnmatch.fnmatchcase(normalized_path, f"*/{normalized_pattern}"):
+            return True
+        if fnmatch.fnmatchcase(normalized_path, normalized_pattern):
+            return True
+
+    return False
+
+
+def _load_payload() -> dict[str, Any] | None:
+    """Read and parse a hook payload from standard input.
+
+    Returns:
+        A parsed JSON object, or None when input is empty or malformed.
+
+    Side Effects:
+        Writes diagnostics to standard error for malformed input or read errors.
+    """
+    try:
+        payload_raw = sys.stdin.read()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        print(f"protect-sensitive-files: failed to read stdin: {exc}", file=sys.stderr)
+        return None
+
+    if not payload_raw.strip():
+        return None
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError as exc:
+        print(f"protect-sensitive-files: bad JSON payload: {exc}", file=sys.stderr)
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    return payload
+
+
+def _target_paths(tool_input: Any) -> list[str]:
+    """Extract candidate target paths from a Claude Code tool input.
+
+    Args:
+        tool_input: The ``tool_input`` value from the hook payload.
+
+    Returns:
+        A list of non-empty path strings to inspect.
+    """
+    if not isinstance(tool_input, dict):
+        return []
+
+    candidates = []
+    for key in PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            candidates.append(value)
+    return candidates
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the PreToolUse sensitive-file guard.
+
+    Args:
+        argv: Unused command-line arguments; accepted for testability.
+
+    Returns:
+        Process exit status. ``2`` blocks a sensitive file edit; ``0`` allows
+        the tool call or fails open for malformed hook input.
+    """
+    _ = argv
+    payload = _load_payload()
+    if payload is None:
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    if tool_name not in PROTECTED_TOOLS:
+        return 0
+
+    for path in _target_paths(payload.get("tool_input") or {}):
+        if is_sensitive(path):
+            print(
+                f"protect-sensitive-files: BLOCKED — refusing to {tool_name} "
+                f"sensitive file: {path}",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -99,7 +99,10 @@ def _target_paths(tool_input: Any) -> List[str]:
     if isinstance(tool_input, dict):
         for key, value in tool_input.items():
             if key in PATH_KEYS and isinstance(value, str) and value:
-                candidates.append(os.path.realpath(value))
+                candidates.append(value)
+                real_path = os.path.realpath(value)
+                if real_path != value:
+                    candidates.append(real_path)
             elif isinstance(value, (dict, list)):
                 candidates.extend(_target_paths(value))
     elif isinstance(tool_input, list):

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,17 +6,26 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
-def main(argv=None):
-    """Run the CLI."""
-    ap = argparse.ArgumentParser(
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
         prog='html2md',
         description='Convert HTML URL to Markdown.'
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    parser.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
+    parser.add_argument('--url', help='Input URL to convert')
+    parser.add_argument('--batch', help='File containing URLs to process (one per line)')
+    parser.add_argument('--outdir', help='Output directory to save the file')
+    return parser
 
+
+PARSER = build_parser()
+
+
+def main(argv=None):
+    """Run the CLI."""
+    ap = PARSER
     args = ap.parse_args(argv)
 
     if args.help_only:

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -5,12 +5,13 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Dict, Union
 
 
 HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "protect_sensitive_files.py"
 
 
-def run_hook(payload: dict[str, object] | str) -> subprocess.CompletedProcess[str]:
+def run_hook(payload: Union[Dict[str, object], str]) -> subprocess.CompletedProcess[str]:
     """Run the sensitive-file hook with a JSON payload."""
     data = payload if isinstance(payload, str) else json.dumps(payload)
     return subprocess.run(
@@ -22,7 +23,7 @@ def run_hook(payload: dict[str, object] | str) -> subprocess.CompletedProcess[st
     )
 
 
-def hook_payload(tool_name: str, path: str, key: str = "file_path") -> dict[str, object]:
+def hook_payload(tool_name: str, path: str, key: str = "file_path") -> Dict[str, object]:
     """Build a minimal Claude Code hook payload."""
     return {"tool_name": tool_name, "tool_input": {key: path}}
 
@@ -42,6 +43,41 @@ def test_blocks_sensitive_notebook_paths() -> None:
 
     assert result.returncode == 2
     assert "notebooks/id_rsa" in result.stderr
+
+
+def test_blocks_all_dotenv_variants() -> None:
+    """Dotenv variants such as .envrc and .env-local are rejected."""
+    for path in (".envrc", "config/.env-local"):
+        result = run_hook(hook_payload("Write", path))
+
+        assert result.returncode == 2
+        assert path in result.stderr
+
+
+def test_blocks_windows_separator_paths() -> None:
+    """Backslash-separated paths are normalized before matching."""
+    result = run_hook(hook_payload("Write", r"C:\repo\credentials.json"))
+
+    assert result.returncode == 2
+    assert "credentials.json" in result.stderr
+
+
+def test_blocks_sensitive_multiedit_paths() -> None:
+    """Nested MultiEdit edit targets are rejected."""
+    result = run_hook(
+        {
+            "tool_name": "MultiEdit",
+            "tool_input": {
+                "edits": [
+                    {"file_path": "src/html2md/cli.py", "old_string": "a", "new_string": "b"},
+                    {"file_path": "secrets/id_rsa_backup", "old_string": "a", "new_string": "b"},
+                ]
+            },
+        }
+    )
+
+    assert result.returncode == 2
+    assert "id_rsa_backup" in result.stderr
 
 
 def test_allows_non_sensitive_edit_paths() -> None:

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -1,0 +1,68 @@
+"""Tests for the Claude Code sensitive-file protection hook."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "protect_sensitive_files.py"
+
+
+def run_hook(payload: dict[str, object] | str) -> subprocess.CompletedProcess[str]:
+    """Run the sensitive-file hook with a JSON payload."""
+    data = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=data,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def hook_payload(tool_name: str, path: str, key: str = "file_path") -> dict[str, object]:
+    """Build a minimal Claude Code hook payload."""
+    return {"tool_name": tool_name, "tool_input": {key: path}}
+
+
+def test_blocks_sensitive_edit_paths() -> None:
+    """Sensitive paths are rejected for protected editing tools."""
+    result = run_hook(hook_payload("Write", "config/.env.production"))
+
+    assert result.returncode == 2
+    assert "BLOCKED" in result.stderr
+    assert "config/.env.production" in result.stderr
+
+
+def test_blocks_sensitive_notebook_paths() -> None:
+    """NotebookEdit payloads are checked with their notebook_path field."""
+    result = run_hook(hook_payload("NotebookEdit", "notebooks/id_rsa", "notebook_path"))
+
+    assert result.returncode == 2
+    assert "notebooks/id_rsa" in result.stderr
+
+
+def test_allows_non_sensitive_edit_paths() -> None:
+    """Non-sensitive paths are allowed for protected editing tools."""
+    result = run_hook(hook_payload("Edit", "src/html2md/cli.py"))
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_ignores_unprotected_tools() -> None:
+    """Sensitive paths are only enforced for write-capable tools."""
+    result = run_hook(hook_payload("Read", ".env"))
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_malformed_payload_fails_open_with_diagnostic() -> None:
+    """Malformed JSON does not break Claude Code hook processing."""
+    result = run_hook("{")
+
+    assert result.returncode == 0
+    assert "bad JSON payload" in result.stderr

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -80,6 +80,19 @@ def test_blocks_sensitive_multiedit_paths() -> None:
     assert "id_rsa_backup" in result.stderr
 
 
+def test_blocks_sensitive_symlink_name_before_realpath(tmp_path: Path) -> None:
+    """Sensitive requested symlink names are checked before realpath resolution."""
+    target = tmp_path / "non_sensitive_target"
+    target.write_text("safe", encoding="utf-8")
+    sensitive_link = tmp_path / ".env"
+    sensitive_link.symlink_to(target)
+
+    result = run_hook(hook_payload("Write", str(sensitive_link)))
+
+    assert result.returncode == 2
+    assert str(sensitive_link) in result.stderr
+
+
 def test_allows_non_sensitive_edit_paths() -> None:
     """Non-sensitive paths are allowed for protected editing tools."""
     result = run_hook(hook_payload("Edit", "src/html2md/cli.py"))


### PR DESCRIPTION
### Motivation
- Prevent automated Claude Code edit/write actions from targeting secrets and key material (for example `.env*`, `*.pem`, `*.key`, `*.crt`, `credentials.json`, `id_rsa*`).
- Make hook execution project-portable and fail-safe for malformed payloads so hooks do not break agent workflows.
- Add coverage via subprocess tests to ensure the hook rejects sensitive targets and allows benign operations.
- Avoid test-time argparse/gettext file reads by moving CLI parser construction to module import time so tests that patch `open`/`realpath` behave deterministically.

### Description
- Add `.claude/hooks/protect_sensitive_files.py` implementing a PreToolUse guard that reads a Claude Code hook payload from stdin and returns non-zero to block `Edit`, `Write`, `MultiEdit`, and `NotebookEdit` targets matching sensitive filename patterns.
- Register the hook in `.claude/settings.json` using the `$CLAUDE_PROJECT_DIR`-aware command and a `PreToolUse` matcher for the protected tools.
- Add `tests/test_protect_sensitive_files_hook.py` which runs the hook as a subprocess and asserts blocking behavior, notebook-path checks, allowlist behavior, unprotected-tool ignoring, and malformed-JSON fail-open diagnostics.
- Refactor `src/html2md/cli.py` to provide `build_parser()` and a module-level `PARSER` so `argparse`/`gettext` do not attempt filesystem reads during test-time patches.

### Testing
- Installed editable package and dev test deps with `python -m pip install -e . pytest` and the installation completed successfully.
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` which executed the existing CLI and log-export tests plus the new hook tests and completed successfully.
- Validated the hook invocation and JSON config with `python -m json.tool .claude/settings.json` and a direct payload invocation (pipe a JSON payload to the hook) which returned the expected blocked exit code for sensitive inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc034f22a083209d8dc2ca696d0889)