### PR TITLE
Limit Gemini Code Assist workflow to manual dispatch

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,12 +1,7 @@
 name: Gemini Code Assist
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review_comment:
-    types: [created]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -11,13 +11,6 @@ permissions:
 jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
-    if: >
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Motivation
- Prevent the Gemini Code Assist action from running automatically on pull requests and comments and require a manual trigger to reduce unintended executions and scope workflow permissions.

### Description
- Replace the `pull_request`, `pull_request_review_comment`, and `issue_comment` triggers with a single `workflow_dispatch` entry in `.github/workflows/gemini-code-assist.yml` so the job runs only when manually invoked.

### Testing
- Verified the change with a quick assertion using `python3` that the file contains `workflow_dispatch` and no `pull_request` entry before `permissions`, and confirmed the working tree was clean after committing the change (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0363eb6c8320a592fed5bbc2153e)