### PR TITLE
[AI-Assisted] Add AI-assisted PR guard workflow

### DIFF
--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -21,6 +21,9 @@ jobs:
           set -euo pipefail
           echo "PR title: $PR_TITLE"
 
+          # The guard is opt-in: human-authored PRs without the explicit
+          # [AI-Assisted] marker must pass so this required check does not
+          # block unrelated work.
           if [[ "$PR_TITLE" != \[AI-Assisted\]* ]]; then
             echo "OK: PR title is not tagged [AI-Assisted]; skipping AI-assisted transcript checks."
             exit 0

--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -22,11 +22,11 @@ jobs:
           echo "PR title: $PR_TITLE"
 
           if [[ "$PR_TITLE" != \[AI-Assisted\]* ]]; then
-            echo "::error::PR title does not start with [AI-Assisted]. AI-assisted PRs MUST start with [AI-Assisted]."
-            exit 1
+            echo "OK: PR title is not tagged [AI-Assisted]; skipping AI-assisted transcript checks."
+            exit 0
           fi
 
-          # Body must reference a Claude chat URL or other agent transcript.
+          # Tagged AI-assisted PRs must reference a Claude chat URL or other agent transcript.
           # Accept claude.ai links, cursor.com, codex, jules.google, or the
           # literal placeholder <CLAUDE_CHAT_URL> for drafts (warn only).
           body="${PR_BODY:-}"

--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -1,0 +1,45 @@
+name: ai-assisted-pr-guard
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check-ai-assisted-marker:
+    name: Verify [AI-Assisted] tag and Claude chat link
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect PR title and body
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          echo "PR title: $PR_TITLE"
+
+          if [[ "$PR_TITLE" != \[AI-Assisted\]* ]]; then
+            echo "::error::PR title does not start with [AI-Assisted]. AI-assisted PRs MUST start with [AI-Assisted]."
+            exit 1
+          fi
+
+          # Body must reference a Claude chat URL or other agent transcript.
+          # Accept claude.ai links, cursor.com, codex, jules.google, or the
+          # literal placeholder <CLAUDE_CHAT_URL> for drafts (warn only).
+          body="${PR_BODY:-}"
+
+          if printf '%s' "$body" | grep -Eqi 'https?://(claude\.ai|cursor\.com|chatgpt\.com/codex|jules\.google\.com)'; then
+            echo "OK: PR body contains an agent chat URL."
+            exit 0
+          fi
+
+          if printf '%s' "$body" | grep -qF '<CLAUDE_CHAT_URL>'; then
+            echo "::warning::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before merging."
+            exit 0
+          fi
+
+          echo "::error::PR title is tagged [AI-Assisted] but the body does not include a Claude chat URL (or accepted alternative). Add the URL or remove the tag."
+          exit 1

--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -10,13 +10,14 @@ permissions:
 
 jobs:
   check-ai-assisted-marker:
-    name: Verify [AI-Assisted] tag and Claude chat link
+    name: Verify [AI-Assisted] tag and agent chat link
     runs-on: ubuntu-latest
     steps:
       - name: Inspect PR title and body
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
           echo "PR title: $PR_TITLE"
@@ -29,20 +30,26 @@ jobs:
             exit 0
           fi
 
-          # Tagged AI-assisted PRs must reference a Claude chat URL or other agent transcript.
-          # Accept claude.ai links, cursor.com, codex, jules.google, or the
-          # literal placeholder <CLAUDE_CHAT_URL> for drafts (warn only).
+          # Tagged AI-assisted PRs must reference a real agent transcript URL.
+          # Accept claude.ai links, cursor.com, chatgpt.com/codex, jules.google.com,
+          # or the literal placeholder <CLAUDE_CHAT_URL> for drafts only (warn only).
           body="${PR_BODY:-}"
+          transcript_url_pattern='https?://((claude\.ai|cursor\.com|jules\.google\.com)(:[0-9]+)?([/?#]|$)|chatgpt\.com(:[0-9]+)?/codex([/?#]|$))'
 
-          if printf '%s' "$body" | grep -Eqi 'https?://(claude\.ai|cursor\.com|chatgpt\.com/codex|jules\.google\.com)'; then
+          if printf '%s' "$body" | grep -Eqi "$transcript_url_pattern"; then
             echo "OK: PR body contains an agent chat URL."
             exit 0
           fi
 
           if printf '%s' "$body" | grep -qF '<CLAUDE_CHAT_URL>'; then
-            echo "::warning::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before merging."
-            exit 0
+            if [[ "${PR_DRAFT:-false}" == "true" ]]; then
+              echo "::warning::Draft PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before marking ready for review."
+              exit 0
+            fi
+
+            echo "::error::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with a real agent chat URL before merging."
+            exit 1
           fi
 
-          echo "::error::PR title is tagged [AI-Assisted] but the body does not include a Claude chat URL (or accepted alternative). Add the URL or remove the tag."
+          echo "::error::PR title is tagged [AI-Assisted] but the body does not include an accepted agent chat URL. Add the URL or remove the tag."
           exit 1

--- a/tests/test_ai_assisted_pr_guard.py
+++ b/tests/test_ai_assisted_pr_guard.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github/workflows/ai-assisted-pr-guard.yml"
+
+
+def _guard_script() -> str:
+    workflow = WORKFLOW_PATH.read_text()
+    _, run_block = workflow.split("        run: |\n", 1)
+    lines = []
+    for line in run_block.splitlines():
+        if line.startswith("          ") or not line:
+            lines.append(line)
+            continue
+        break
+    return textwrap.dedent("\n".join(lines))
+
+
+def _run_guard(title: str, body: str = "") -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update({"PR_TITLE": title, "PR_BODY": body})
+    return subprocess.run(
+        ["bash", "-c", _guard_script()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_untagged_prs_skip_ai_assisted_checks_successfully():
+    result = _run_guard("Fix parser edge case")
+
+    assert result.returncode == 0, result.stderr
+    assert "skipping AI-assisted transcript checks" in result.stdout
+
+
+def test_tagged_prs_still_require_transcript_links():
+    result = _run_guard("[AI-Assisted] Fix parser edge case")
+
+    assert result.returncode == 1
+    assert "does not include a Claude chat URL" in result.stdout
+
+
+def test_tagged_prs_with_accepted_transcript_links_pass():
+    result = _run_guard(
+        "[AI-Assisted] Fix parser edge case",
+        "Transcript: https://claude.ai/chat/2c4f3e25-4e34-4dfd-b186-341a40a491f0",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "contains an agent chat URL" in result.stdout

--- a/tests/test_ai_assisted_pr_guard.py
+++ b/tests/test_ai_assisted_pr_guard.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 import os
+import shutil
 import subprocess
 import textwrap
 from pathlib import Path
+
+import pytest
 
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github/workflows/ai-assisted-pr-guard.yml"
 
 
 def _guard_script() -> str:
-    workflow = WORKFLOW_PATH.read_text()
-    _, run_block = workflow.split("        run: |\n", 1)
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    _, step_block = workflow.split("      - name: Inspect PR title and body\n", 1)
+    _, run_block = step_block.split("        run: |\n", 1)
     lines = []
     for line in run_block.splitlines():
         if line.startswith("          ") or not line:
@@ -19,11 +25,15 @@ def _guard_script() -> str:
     return textwrap.dedent("\n".join(lines))
 
 
-def _run_guard(title: str, body: str = "") -> subprocess.CompletedProcess[str]:
+def _run_guard(title: str, body: str = "", draft: bool = False) -> subprocess.CompletedProcess[str]:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("workflow guard script uses bash syntax")
+
     env = os.environ.copy()
-    env.update({"PR_TITLE": title, "PR_BODY": body})
+    env.update({"PR_TITLE": title, "PR_BODY": body, "PR_DRAFT": str(draft).lower()})
     return subprocess.run(
-        ["bash", "-c", _guard_script()],
+        [bash, "-c", _guard_script()],
         env=env,
         text=True,
         capture_output=True,
@@ -42,7 +52,28 @@ def test_tagged_prs_still_require_transcript_links():
     result = _run_guard("[AI-Assisted] Fix parser edge case")
 
     assert result.returncode == 1
-    assert "does not include a Claude chat URL" in result.stdout
+    assert "does not include an accepted agent chat URL" in result.stdout
+
+
+def test_draft_tagged_prs_may_temporarily_use_transcript_placeholder():
+    result = _run_guard(
+        "[AI-Assisted] Fix parser edge case",
+        "Transcript: <CLAUDE_CHAT_URL>",
+        draft=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Draft PR body still contains the <CLAUDE_CHAT_URL> placeholder" in result.stdout
+
+
+def test_ready_tagged_prs_reject_transcript_placeholder():
+    result = _run_guard(
+        "[AI-Assisted] Fix parser edge case",
+        "Transcript: <CLAUDE_CHAT_URL>",
+    )
+
+    assert result.returncode == 1
+    assert "Replace it with a real agent chat URL before merging" in result.stdout
 
 
 def test_tagged_prs_with_accepted_transcript_links_pass():
@@ -53,3 +84,13 @@ def test_tagged_prs_with_accepted_transcript_links_pass():
 
     assert result.returncode == 0, result.stderr
     assert "contains an agent chat URL" in result.stdout
+
+
+def test_tagged_prs_reject_lookalike_transcript_hosts():
+    result = _run_guard(
+        "[AI-Assisted] Fix parser edge case",
+        "Transcript: https://claude.ai.evil.example/chat/not-real",
+    )
+
+    assert result.returncode == 1
+    assert "does not include an accepted agent chat URL" in result.stdout


### PR DESCRIPTION
### Motivation
- Enforce that pull requests claimed as AI-assisted include a clear `[AI-Assisted]` title prefix and a link to the agent/chat transcript to improve transparency for reviewers.

### Description
- Add `.github/workflows/ai-assisted-pr-guard.yml` which runs on `pull_request` events and verifies the PR title begins with `[AI-Assisted]` and the PR body includes an accepted agent URL (accepts `claude.ai`, `cursor.com`, `chatgpt.com/codex`, `jules.google.com`) or the draft placeholder `<CLAUDE_CHAT_URL>` (warning-only).

### Testing
- Verified the workflow YAML parses successfully using `python` with `yaml.safe_load` against `.github/workflows/ai-assisted-pr-guard.yml`.
- Installed the package in editable mode and ran `pytest -q`; the test run executed but one existing test `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` failed due to an unrelated `argparse`/`gettext` interaction when tests patch `open`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc04116e9c8320ae03230282ee13a8)