### PR TITLE
Update Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   gemini-code-assist:
@@ -28,4 +29,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+        uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          prompt: '/pr-code-review'
+          extensions: |
+            ["https://github.com/gemini-cli-extensions/code-review"]

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -35,6 +35,31 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          settings: |
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              }
+            }
           prompt: '/pr-code-review'
           extensions: |
             ["https://github.com/gemini-cli-extensions/code-review"]

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -33,6 +33,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -35,6 +35,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -57,11 +58,15 @@ jobs:
                     "pull_request_review_write"
                   ],
                   "env": {
-                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ github.token }}"
                   }
                 }
               }
             }
-          prompt: '/pr-code-review'
+          prompt: |
+            /pr-code-review
+            Repository: ${{ github.repository }}
+            Pull Request Number: ${{ github.event.pull_request.number || github.event.issue.number }}
+            Pull Request URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}
           extensions: |
             ["https://github.com/gemini-cli-extensions/code-review"]


### PR DESCRIPTION
### Motivation
- Enable the Gemini CLI runner and OIDC token support for automated PR code review by switching to the maintained runner and granting `id-token: write` permission.

### Description
- Replace `google-gemini/code-assist-action@v1` with `google-github-actions/run-gemini-cli@v0`, add `id-token: write` to `.github/workflows/gemini-code-assist.yml`, and configure `GITHUB_TOKEN`, `GEMINI_API_KEY`, `gemini_api_key`, the `prompt` (`/pr-code-review`), and the `extensions` input.

### Testing
- Verified the change applied cleanly and the workflow YAML parses successfully using `git diff --cached --check` and `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'YAML OK'"`, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc045ca4dc8320a251af6d6fee0656)