### PR TITLE
Add Claude PreToolUse hook to block edits to sensitive files

### DIFF
--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Block Claude Code edits to sensitive files.
+
+This PreToolUse hook reads a Claude Code hook payload from standard input and
+exits with a non-zero status when an Edit, Write, MultiEdit, or NotebookEdit
+request targets a sensitive path.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import sys
+from typing import Any
+
+
+SENSITIVE_BASENAME_PATTERNS = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.crt",
+    "credentials.json",
+    "id_rsa",
+    "id_rsa.pub",
+)
+PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+PATH_KEYS = ("file_path", "path", "notebook_path")
+
+
+def is_sensitive(path: str) -> bool:
+    """Return whether a path matches a sensitive filename pattern.
+
+    Args:
+        path: File path from a Claude Code tool input payload.
+
+    Returns:
+        True when the basename or normalized path matches a sensitive pattern;
+        otherwise False.
+    """
+    if not path:
+        return False
+
+    normalized_path = path.replace("\\", "/").lower()
+    normalized_base = normalized_path.rsplit("/", 1)[-1]
+
+    for pattern in SENSITIVE_BASENAME_PATTERNS:
+        normalized_pattern = pattern.lower()
+        if fnmatch.fnmatchcase(normalized_base, normalized_pattern):
+            return True
+        if fnmatch.fnmatchcase(normalized_path, f"*/{normalized_pattern}"):
+            return True
+        if fnmatch.fnmatchcase(normalized_path, normalized_pattern):
+            return True
+
+    return False
+
+
+def _load_payload() -> dict[str, Any] | None:
+    """Read and parse a hook payload from standard input.
+
+    Returns:
+        A parsed JSON object, or None when input is empty or malformed.
+
+    Side Effects:
+        Writes diagnostics to standard error for malformed input or read errors.
+    """
+    try:
+        payload_raw = sys.stdin.read()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        print(f"protect-sensitive-files: failed to read stdin: {exc}", file=sys.stderr)
+        return None
+
+    if not payload_raw.strip():
+        return None
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError as exc:
+        print(f"protect-sensitive-files: bad JSON payload: {exc}", file=sys.stderr)
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    return payload
+
+
+def _target_paths(tool_input: Any) -> list[str]:
+    """Extract candidate target paths from a Claude Code tool input.
+
+    Args:
+        tool_input: The ``tool_input`` value from the hook payload.
+
+    Returns:
+        A list of non-empty path strings to inspect.
+    """
+    if not isinstance(tool_input, dict):
+        return []
+
+    candidates = []
+    for key in PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            candidates.append(value)
+    return candidates
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the PreToolUse sensitive-file guard.
+
+    Args:
+        argv: Unused command-line arguments; accepted for testability.
+
+    Returns:
+        Process exit status. ``2`` blocks a sensitive file edit; ``0`` allows
+        the tool call or fails open for malformed hook input.
+    """
+    _ = argv
+    payload = _load_payload()
+    if payload is None:
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    if tool_name not in PROTECTED_TOOLS:
+        return 0
+
+    for path in _target_paths(payload.get("tool_input") or {}):
+        if is_sensitive(path):
+            print(
+                f"protect-sensitive-files: BLOCKED — refusing to {tool_name} "
+                f"sensitive file: {path}",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -22,6 +22,12 @@ SENSITIVE_BASENAME_PATTERNS = (
     "credentials.json",
     "id_rsa",
     "id_rsa.pub",
+    "id_ed25519",
+    "id_ed25519.pub",
+    "id_ecdsa",
+    "id_ecdsa.pub",
+    "id_dsa",
+    "id_dsa.pub",
 )
 PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
 PATH_KEYS = ("file_path", "path", "notebook_path")

--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -20,14 +20,10 @@ SENSITIVE_BASENAME_PATTERNS = (
     "*.key",
     "*.crt",
     "credentials.json",
-    "id_rsa",
-    "id_rsa.pub",
-    "id_ed25519",
-    "id_ed25519.pub",
-    "id_ecdsa",
-    "id_ecdsa.pub",
-    "id_dsa",
-    "id_dsa.pub",
+    "id_rsa*",
+    "id_ed25519*",
+    "id_ecdsa*",
+    "id_dsa*",
 )
 PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
 PATH_KEYS = ("file_path", "path", "notebook_path")

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PROJECT_DIR:-$PWD}/.claude/hooks/protect-sensitive-files.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_claude_hook_protect_sensitive_files.py
+++ b/tests/test_claude_hook_protect_sensitive_files.py
@@ -1,0 +1,95 @@
+"""Tests for the Claude Code sensitive-file protection hook."""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".claude"
+    / "hooks"
+    / "protect-sensitive-files.py"
+)
+
+
+def _load_hook() -> ModuleType:
+    """Load the hook script as a Python module for direct unit testing."""
+    spec = importlib.util.spec_from_file_location("protect_sensitive_files", HOOK_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_hook(payload: object, monkeypatch) -> int:
+    """Run the hook with a JSON-serializable stdin payload."""
+    hook = _load_hook()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return hook.main([])
+
+
+def test_sensitive_basename_patterns_match_case_insensitively():
+    """Sensitive basenames are detected regardless of path depth or casing."""
+    hook = _load_hook()
+
+    assert hook.is_sensitive(".env")
+    assert hook.is_sensitive("CONFIG/.ENV.PROD")
+    assert hook.is_sensitive("secrets/api.PEM")
+    assert hook.is_sensitive("nested/credentials.json")
+    assert hook.is_sensitive(r"C:\\repo\\secrets\\id_rsa")
+    assert not hook.is_sensitive("docs/credentials-example.json")
+
+
+def test_hook_blocks_protected_tool_targeting_sensitive_file(monkeypatch, capsys):
+    """Protected edit tools return exit code 2 for sensitive target paths."""
+    status = _run_hook(
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "config/.env.local"},
+        },
+        monkeypatch,
+    )
+
+    assert status == 2
+    assert "BLOCKED" in capsys.readouterr().err
+
+
+def test_hook_allows_non_sensitive_file_for_protected_tool(monkeypatch):
+    """Protected edit tools return zero for ordinary source files."""
+    status = _run_hook(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/html2md/cli.py"},
+        },
+        monkeypatch,
+    )
+
+    assert status == 0
+
+
+def test_hook_allows_sensitive_file_for_unprotected_tool(monkeypatch):
+    """Read-only or unrelated tools are ignored by the edit guard."""
+    status = _run_hook(
+        {
+            "tool_name": "Read",
+            "tool_input": {"file_path": ".env"},
+        },
+        monkeypatch,
+    )
+
+    assert status == 0
+
+
+def test_hook_fails_open_for_malformed_json(monkeypatch, capsys):
+    """Malformed hook payloads emit diagnostics but do not block execution."""
+    hook = _load_hook()
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{"))
+
+    assert hook.main([]) == 0
+    assert "bad JSON payload" in capsys.readouterr().err

--- a/tests/test_claude_hook_protect_sensitive_files.py
+++ b/tests/test_claude_hook_protect_sensitive_files.py
@@ -44,7 +44,10 @@ def test_sensitive_basename_patterns_match_case_insensitively():
     assert hook.is_sensitive("nested/credentials.json")
     assert hook.is_sensitive(r"C:\\repo\\secrets\\id_rsa")
     assert hook.is_sensitive("~/.ssh/id_ed25519")
+    assert hook.is_sensitive("~/.ssh/id_ed25519.pub")
+    assert hook.is_sensitive("~/.ssh/id_ed25519_sk")
     assert hook.is_sensitive("~/.ssh/id_ecdsa")
+    assert hook.is_sensitive("~/.ssh/id_ecdsa_sk")
     assert hook.is_sensitive("~/.ssh/id_dsa")
     assert not hook.is_sensitive("docs/credentials-example.json")
 

--- a/tests/test_claude_hook_protect_sensitive_files.py
+++ b/tests/test_claude_hook_protect_sensitive_files.py
@@ -43,6 +43,9 @@ def test_sensitive_basename_patterns_match_case_insensitively():
     assert hook.is_sensitive("secrets/api.PEM")
     assert hook.is_sensitive("nested/credentials.json")
     assert hook.is_sensitive(r"C:\\repo\\secrets\\id_rsa")
+    assert hook.is_sensitive("~/.ssh/id_ed25519")
+    assert hook.is_sensitive("~/.ssh/id_ecdsa")
+    assert hook.is_sensitive("~/.ssh/id_dsa")
     assert not hook.is_sensitive("docs/credentials-example.json")
 
 


### PR DESCRIPTION
### Motivation
- Prevent automated Claude Code edit/write actions from modifying sensitive files (for example `.env`, key/cert files, `credentials.json`, and SSH keys) by enforcing a pre-tool-use guard. 

### Description
- Add a `PreToolUse` hook configuration at `.claude/settings.json` that runs a protection command for `Edit`, `Write`, `MultiEdit`, and `NotebookEdit` tool invocations.  
- Add an executable hook script `.claude/hooks/protect-sensitive-files.py` that normalizes path separators, extracts candidate path keys (`file_path`, `path`, `notebook_path`), and blocks tool calls that target basenames matching sensitive patterns.  
- Add unit tests `tests/test_claude_hook_protect_sensitive_files.py` covering case-insensitive matching, Windows/POSIX path normalization, blocking behavior for protected tools, allowing unprotected tools, and fail-open behavior for malformed payloads.  

### Testing
- Validated the hook script is syntactically correct with `python -m py_compile .claude/hooks/protect-sensitive-files.py` and the JSON config with `python3 -m json.tool .claude/settings.json >/dev/null`, both succeeded.  
- Ran targeted unit tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_claude_hook_protect_sensitive_files.py -q`, which passed.  
- Ran the full test suite with `PYENV_VERSION=3.12.13 LC_ALL=C LANG=C python -m pytest -q`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc05bbf8d88320841d643ef8d8dda0)