### PR TITLE
ci: pass GEMINI_API_KEY to Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,19 +17,21 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      secrets.GEMINI_API_KEY != '' &&
-      ((github.event_name == 'pull_request') ||
-       ((github.event_name == 'pull_request_review_comment' ||
-         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
-        contains(github.event.comment.body, '@gemini-code-assist') &&
-        (github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'COLLABORATOR')))
+      github.event_name == 'pull_request' ||
+      ((github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+       contains(github.event.comment.body, '@gemini-code-assist') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+    env:
+      GEMINI_API_KEY_AVAILABLE: ${{ secrets.GEMINI_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
+        if: env.GEMINI_API_KEY_AVAILABLE == 'true'
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,15 +17,18 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-code-assist'))
+      secrets.GEMINI_API_KEY != '' &&
+      ((github.event_name == 'pull_request') ||
+       (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@gemini-code-assist')) ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@gemini-code-assist')))
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
         uses: google-gemini/code-assist-action@v1
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,13 +17,14 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request') ||
-      ((github.event_name == 'pull_request_review_comment' ||
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
-       contains(github.event.comment.body, '@gemini-code-assist') &&
-       (github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
+      secrets.GEMINI_API_KEY != '' &&
+      ((github.event_name == 'pull_request') ||
+       ((github.event_name == 'pull_request_review_comment' ||
+         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+        contains(github.event.comment.body, '@gemini-code-assist') &&
+        (github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'COLLABORATOR')))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -35,4 +35,4 @@ jobs:
         if: env.GEMINI_API_KEY != ''
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
-          gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -33,3 +33,5 @@ jobs:
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != ''
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -34,4 +34,4 @@ jobs:
         if: env.GEMINI_API_KEY != ''
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_api_key: ${{ env.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,18 +17,18 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      secrets.GEMINI_API_KEY != '' &&
-      ((github.event_name == 'pull_request') ||
-       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@gemini-code-assist')) ||
-       (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@gemini-code-assist')))
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
+        if: env.GEMINI_API_KEY != ''
         uses: google-gemini/code-assist-action@v1
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -25,14 +25,11 @@ jobs:
         (github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'COLLABORATOR')))
-    env:
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != ''
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
-          gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -18,11 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-code-assist'))
+      ((github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+       contains(github.event.comment.body, '@gemini-code-assist') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
@@ -31,4 +32,4 @@ jobs:
           fetch-depth: 0
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != ''
-        uses: google-gemini/code-assist-action@v1
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22


### PR DESCRIPTION
## Summary
- Pass `GEMINI_API_KEY` to the Gemini Code Assist step via the action's `gemini_api_key` input. The secret value itself is not exposed as a job/step env var.
- Add a non-secret `GEMINI_API_KEY_AVAILABLE` job-level env (a boolean derived from `secrets.GEMINI_API_KEY != ''`) and gate the action step on `if: env.GEMINI_API_KEY_AVAILABLE == 'true'` so fork PRs (where the secret is empty) skip the Gemini step instead of failing authentication. The job itself still runs (and `actions/checkout` still executes); only the Gemini step is skipped. The secret can't be referenced directly in `jobs.<job_id>.if`, hence the boolean-env approach.
- Restrict comment-triggered runs (`@gemini-code-assist` mentions) to `MEMBER` / `OWNER` / `COLLABORATOR` authors so a fork-PR commenter can't trigger the workflow. Matches the trust gate used in `claude-agent.yml`. `pull_request` triggers are unaffected.
- Replace the unresolvable `google-gemini/code-assist-action@v1` reference with `google-github-actions/run-gemini-cli` pinned to commit `f77273f4c914e4bf38440cf36a0369cb64a37489` (v0.1.22), matching the repo's convention of pinning third-party actions to a SHA.

## Test plan
- [ ] Push a PR from a branch in this repo and confirm the Gemini step runs and authenticates.
- [ ] Open a PR from a fork and confirm the Gemini step is skipped (job succeeds) instead of failing on missing auth.
- [ ] Comment `@gemini-code-assist` from a non-collaborator account and confirm the job does not run.

https://claude.ai/code/session_01AUv7wx7bv4AaTDv1ZLeony