### PR TITLE
ci: pass Gemini secret directly to Code Assist action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -35,4 +35,4 @@ jobs:
         if: env.GEMINI_API_KEY != ''
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
-          gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
### Motivation
- Ensure the pinned `google-github-actions/run-gemini-cli` action actually receives authentication by wiring its `gemini_api_key` input to the repository secret instead of relying on the job-level env which can be overridden by action inputs.

### Description
- Update ` .github/workflows/gemini-code-assist.yml` so the Gemini action's `with` uses `gemini_api_key: ${{ secrets.GEMINI_API_KEY }}` while keeping the existing job/step guards that skip the step when the secret is unavailable.

### Testing
- Parsed ` .github/workflows/gemini-code-assist.yml` with `PyYAML` and asserted that `jobs.gemini-code-assist.steps[1].with.gemini_api_key` equals `${{ secrets.GEMINI_API_KEY }}`, and ran `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0e3f23c483208612b834c41ac565)