### PR TITLE
ci: fix Jules review workflow permissions and fork handling

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,10 +6,13 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   request-review:
     runs-on: ubuntu-latest
+    # Skip forks: the token typically can't write comments there
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Request review from Jules bot
         env:
@@ -50,7 +53,11 @@ jobs:
                       f"PR #{pr_number} (status {response.status})"
                   )
           except urllib.error.HTTPError as error:
-              print(f"Could not request review: {error.read().decode('utf-8')}")
-              print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
+              body = error.read().decode("utf-8")
+              print(f"Could not request review: {body}")
+              # Don't fail the entire workflow if GitHub forbids commenting
+              if error.code == 403:
+                  print("Skipping: token cannot comment in this PR context.")
+                  sys.exit(0)
+              raise
           PY


### PR DESCRIPTION
## Summary

Fixes the `Request Jules Review` workflow which was failing with `403 Resource not accessible by integration` when posting a PR comment with the default `GITHUB_TOKEN`.

Changes to `.github/workflows/request-jules-review.yml`:
- Add `pull-requests: write` alongside `issues: write` so the requested permissions align with the comment API.
- Add an `if:` guard on the job so it only runs when the PR head repo matches the workflow repo (skip forks where the default token cannot comment).
- Treat HTTP 403 responses as non-fatal: log and `sys.exit(0)` instead of failing the workflow, preserving the existing `raise` behavior for other errors.

## Test plan
- [ ] On reopen/synchronize of a same-repo PR, the workflow posts the `@google-labs-jules` comment and succeeds.
- [ ] On a fork PR, the job is skipped via the `if:` guard.
- [ ] If GitHub returns 403 for any other reason, the step logs the body and exits cleanly (workflow does not fail).

Related: https://github.com/badMadeC0/html2md/pull/641

---
_Generated by [Claude Code](https://claude.ai/code/session_018AuhWfDdqAWoJks5Xy3o3D)_