### PR TITLE
Fix invalid Gemini Code Assist GitHub Action reference

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,7 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      ((github.event_name == 'pull_request_review_comment' || github.event_name == 'issue_comment') &&
+      (github.event_name == 'pull_request_review_comment' &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       (contains(github.event.comment.body, '@gemini-cli') ||
+        contains(github.event.comment.body, '@gemini-code-assist'))) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
        (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR') &&

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -19,13 +19,15 @@ jobs:
     if: >
       (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
+       contains(github.event.comment.body, '@gemini-cli')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-code-assist'))
+       contains(github.event.comment.body, '@gemini-cli'))
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+        uses: google-github-actions/run-gemini-cli@v0
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,8 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -17,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       ((github.event_name == 'pull_request_review_comment' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
         (github.event.comment.author_association == 'MEMBER' ||
@@ -26,7 +30,7 @@ jobs:
          contains(github.event.comment.body, '@gemini-code-assist')))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GEMINI_CLI_TRUST_WORKSPACE: true
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: Resolve PR head SHA
         id: pr_head
@@ -35,7 +39,9 @@ jobs:
         with:
           script: |
             let pr;
-            if (context.eventName === "pull_request_review_comment") {
+            if (context.eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            } else if (context.eventName === "pull_request_review_comment") {
               pr = context.payload.pull_request;
             } else if (context.eventName === "issue_comment" && context.payload.issue?.pull_request) {
               const response = await github.rest.pulls.get({
@@ -47,13 +53,14 @@ jobs:
             }
 
             if (!pr) {
-              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request_review_comment or issue_comment on a pull request.");
+              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request, pull_request_review_comment, or issue_comment on a pull request.");
               return;
             }
 
             const sameRepo = pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("is_same_repo", String(sameRepo));
+            core.setOutput("number", String(pr.number));
 
       - uses: actions/checkout@v6
         if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
@@ -73,12 +80,13 @@ jobs:
             You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.
 
             Event: ${{ github.event_name }}
-            Pull request: #${{ github.event.pull_request.number || github.event.issue.number || 'manual workflow_dispatch' }}
+            Pull request: #${{ steps.pr_head.outputs.number || 'manual workflow_dispatch' }}
             Comment author: ${{ github.event.comment.user.login || github.actor }}
             Comment URL: ${{ github.event.comment.html_url || github.server_url }}
 
-            Respond to the pull request by carrying out the request in the triggering comment.
             Use the GitHub CLI or GitHub API when you need pull request details, diffs, or to post feedback.
 
+            ${{ github.event.comment.body && 'Respond to the pull request by carrying out the request in the triggering comment.' || 'Automatically review the checked-out pull request and post actionable feedback on the PR.' }}
+
             Triggering comment:
-            ${{ github.event.comment.body || 'Manual workflow_dispatch run: review the checked-out repository and summarize any actionable findings.' }}
+            ${{ github.event.comment.body || 'No triggering comment: automatic pull request review or manual workflow_dispatch run.' }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -26,7 +26,7 @@ jobs:
          contains(github.event.comment.body, '@gemini-code-assist')))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GEMINI_CLI_TRUST_WORKSPACE: "true"
+      GEMINI_CLI_TRUST_WORKSPACE: true
     steps:
       - name: Resolve PR head SHA
         id: pr_head
@@ -47,7 +47,7 @@ jobs:
             }
 
             if (!pr) {
-              core.setFailed("Could not resolve pull request from event payload.");
+              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request_review_comment or issue_comment on a pull request.");
               return;
             }
 

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -24,10 +24,12 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@gemini-cli'))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
         uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: true
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -19,19 +19,50 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       ((github.event_name == 'pull_request_review_comment' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
-       (github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR') &&
-       (contains(github.event.comment.body, '@gemini-cli') ||
-        contains(github.event.comment.body, '@gemini-code-assist')))
+        (github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'COLLABORATOR') &&
+        (contains(github.event.comment.body, '@gemini-cli') ||
+         contains(github.event.comment.body, '@gemini-code-assist')))
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GEMINI_CLI_TRUST_WORKSPACE: "true"
     steps:
+      - name: Resolve PR head SHA
+        id: pr_head
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+            if (context.eventName === "pull_request_review_comment") {
+              pr = context.payload.pull_request;
+            } else if (context.eventName === "issue_comment" && context.payload.issue?.pull_request) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+              pr = response.data;
+            }
+
+            if (!pr) {
+              core.setFailed("Could not resolve pull request from event payload.");
+              return;
+            }
+
+            const sameRepo = pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            core.setOutput("head_sha", pr.head.sha);
+            core.setOutput("is_same_repo", String(sameRepo));
+
       - uses: actions/checkout@v6
+        if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
       - name: Gemini Code Assist
+        if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         uses: google-github-actions/run-gemini-cli@v0
-        env:
-          GEMINI_CLI_TRUST_WORKSPACE: true
         with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_api_key: ${{ env.GEMINI_API_KEY }}
           gemini_model: gemini-2.0-flash

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,8 +1,7 @@
 name: Gemini Code Assist
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -17,12 +16,13 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-cli')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-cli'))
+      github.event_name == 'workflow_dispatch' ||
+      ((github.event_name == 'pull_request_review_comment' || github.event_name == 'issue_comment') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       (contains(github.event.comment.body, '@gemini-cli') ||
+        contains(github.event.comment.body, '@gemini-code-assist')))
     steps:
       - uses: actions/checkout@v6
         with:
@@ -33,3 +33,4 @@ jobs:
           GEMINI_CLI_TRUST_WORKSPACE: true
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_model: gemini-1.5-flash

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -63,6 +63,22 @@ jobs:
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           gemini_model: gemini-2.0-flash
+          prompt: |
+            You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.
+
+            Event: ${{ github.event_name }}
+            Pull request: #${{ github.event.pull_request.number || github.event.issue.number || 'manual workflow_dispatch' }}
+            Comment author: ${{ github.event.comment.user.login || github.actor }}
+            Comment URL: ${{ github.event.comment.html_url || github.server_url }}
+
+            Respond to the pull request by carrying out the request in the triggering comment.
+            Use the GitHub CLI or GitHub API when you need pull request details, diffs, or to post feedback.
+
+            Triggering comment:
+            ${{ github.event.comment.body || 'Manual workflow_dispatch run: review the checked-out repository and summarize any actionable findings.' }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,8 +2,6 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -19,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
       ((github.event_name == 'pull_request_review_comment' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
        (github.event.comment.author_association == 'MEMBER' ||
@@ -37,4 +34,4 @@ jobs:
           GEMINI_CLI_TRUST_WORKSPACE: true
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          gemini_model: gemini-1.5-flash
+          gemini_model: gemini-2.0-flash

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,8 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -17,29 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_review_comment' &&
+      github.event_name == 'pull_request' ||
+      ((github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
        (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR') &&
        (contains(github.event.comment.body, '@gemini-cli') ||
-        contains(github.event.comment.body, '@gemini-code-assist'))) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-        (github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'COLLABORATOR') &&
-        (contains(github.event.comment.body, '@gemini-cli') ||
-         contains(github.event.comment.body, '@gemini-code-assist')))
-    env:
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GEMINI_CLI_TRUST_WORKSPACE: "true"
+        contains(github.event.comment.body, '@gemini-code-assist')))
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != ''
-        continue-on-error: true
-        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: true
         with:
-          gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_model: gemini-1.5-flash


### PR DESCRIPTION
The Gemini Code Assist workflow was failing because it referenced a GitHub Action ('google-gemini/code-assist-action') that does not exist. I have updated the workflow to use the official 'google-github-actions/run-gemini-cli' action, provided the required authentication key from secrets, and updated the bot trigger name to '@gemini-cli' to ensure it functions as intended.

Fixes #649

---
*PR created automatically by Jules for task [14382286900700281303](https://jules.google.com/task/14382286900700281303) started by @badMade*