### PR TITLE
ci: gate Gemini Code Assist workflow on GEMINI_API_KEY secret

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -61,22 +61,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Prepare prompt context
-        env:
-          REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: |
-          mkdir -p .gemini
-          jq -n \
-            --arg repo "$REPOSITORY" \
-            --arg pr "$PULL_REQUEST_NUMBER" \
-            '{repository: $repo, pull_request_number: $pr}' > .gemini/context.json
       - name: Gemini Code Assist
         uses: google-github-actions/run-gemini-cli@v0.1.22
         env:
           GEMINI_CLI_TRUST_WORKSPACE: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Consumed by the code-review extension's /pr-code-review prompt
+          # template via $REPOSITORY and $PULL_REQUEST_NUMBER expansions.
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_cli_version: "0.41.2"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -48,28 +48,11 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.enabled == 'true'
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        uses: google-gemini/code-assist-action@v1
-
-  gemini-code-assist-fallback:
-    needs: [preflight, gemini-code-assist]
-    if: >
-      always() &&
-      needs.preflight.outputs.enabled == 'true' &&
-      needs.gemini-code-assist.result != 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Gemini Code Assist (run-gemini-cli fallback)
         uses: google-github-actions/run-gemini-cli@v0.1.22
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -53,9 +53,6 @@ jobs:
     if: needs.preflight.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Don't fail the workflow if Gemini's CLI/API is flaky;
-    # surface the failure on the job itself instead.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,6 +65,8 @@ jobs:
         # so wiping it is safe and removes the attack surface.
         run: rm -rf .gemini
       - name: Gemini Code Assist
+        id: gemini
+        continue-on-error: true
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:
           GEMINI_CLI_TRUST_WORKSPACE: "true"
@@ -126,3 +125,24 @@ jobs:
               "https://github.com/gemini-cli-extensions/code-review"
             ]
           prompt: "/pr-code-review"
+      - name: Note Gemini API quota exhaustion
+        if: >
+          steps.gemini.outcome == 'failure' &&
+          (contains(steps.gemini.outputs.gemini_errors, 'TerminalQuotaError') ||
+           contains(steps.gemini.outputs.gemini_errors, 'exhausted your daily quota') ||
+           contains(steps.gemini.outputs.gemini_errors, 'Quota exceeded'))
+        run: |
+          echo "::notice title=Gemini quota exhausted::Skipping Gemini Code Assist because the configured Gemini API key has exhausted its quota."
+          {
+            echo "### Gemini Code Assist"
+            echo
+            echo "Skipped because the configured Gemini API key has exhausted its Gemini API quota."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Note other Gemini failures
+        if: >
+          steps.gemini.outcome == 'failure' &&
+          !(contains(steps.gemini.outputs.gemini_errors, 'TerminalQuotaError') ||
+            contains(steps.gemini.outputs.gemini_errors, 'exhausted your daily quota') ||
+            contains(steps.gemini.outputs.gemini_errors, 'Quota exceeded'))
+        run: |
+          echo "::warning title=Gemini Code Assist failed::Gemini CLI failed, but this workflow is non-blocking."

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -123,6 +123,6 @@ jobs:
             }
           extensions: |
             [
-              "https://github.com/gemini-cli-extensions/code-review#dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04"
+              "https://github.com/gemini-cli-extensions/code-review"
             ]
           prompt: "/pr-code-review"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -111,6 +111,6 @@ jobs:
             }
           extensions: |
             [
-              "https://github.com/gemini-cli-extensions/code-review#<FULL_COMMIT_SHA>"
+              "https://github.com/gemini-cli-extensions/code-review#dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04"
             ]
           prompt: "/pr-code-review"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -103,19 +103,24 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Strip PR-supplied Gemini config
-        # Two distinct attack vectors via PR-authored content:
+        # Three distinct attack vectors via PR-authored content:
         #   1. .gemini/commands/*.toml shadow extension commands in
         #      Gemini CLI's loader (project commands win over extension
         #      commands), so a PR could plant pr-code-review.toml that
         #      hijacks /pr-code-review.
         #   2. GEMINI.md is loaded as project instructional context on
         #      every prompt and could steer the reviewer to suppress,
-        #      soften, or forge feedback.
-        # Neither file is shipped by this repo, so unconditional removal
-        # is safe and eliminates both attack surfaces.
+        #      soften, or forge feedback. Match symlinks too — a
+        #      symlinked GEMINI.md is still followed by the loader.
+        #   3. Gemini CLI auto-loads .env from the working directory.
+        #      PR-authored .env can set GEMINI_SYSTEM_MD or similar to
+        #      override the system prompt from a PR-supplied file.
+        # None of these files are shipped by this repo, so unconditional
+        # removal is safe and eliminates all three attack surfaces.
         run: |
           rm -rf .gemini
-          find . -type f -name 'GEMINI.md' -delete
+          find . \( -type f -o -type l \) -name 'GEMINI.md' -delete
+          find . \( -type f -o -type l \) -name '.env' -delete
       - name: Gemini Code Assist
         id: gemini
         continue-on-error: true

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -30,8 +30,7 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_review_comment' &&
        (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
@@ -46,12 +45,18 @@ jobs:
     outputs:
       enabled: ${{ steps.gate.outputs.enabled }}
     steps:
-      - name: Check for Gemini API key
+      - name: Gate on fork status and Gemini API key
         id: gate
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Only meaningful for pull_request triggers; comment triggers
+          # are already gated on author_association above.
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
-          if [ -n "$GEMINI_API_KEY" ]; then
+          if [ "$IS_FORK_PR" = "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Gemini Code Assist: PR is from a fork; not running secret-backed review against untrusted code."
+          elif [ -n "$GEMINI_API_KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -19,9 +19,15 @@ jobs:
     if: >
       (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_review_comment' &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
        contains(github.event.comment.body, '@gemini-code-assist')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - name: Check for Gemini API key

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -48,6 +48,9 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.enabled == 'true'
     runs-on: ubuntu-latest
+    # Don't fail the workflow if Gemini's CLI/API is flaky;
+    # surface the failure on the job itself instead.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -61,6 +61,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Strip PR-supplied Gemini config
+        # Project-local .gemini/commands/*.toml shadow extension commands
+        # in Gemini CLI's loader, so a PR could plant a pr-code-review.toml
+        # that hijacks /pr-code-review. We don't ship .gemini/ in the repo,
+        # so wiping it is safe and removes the attack surface.
+        run: rm -rf .gemini
       - name: Gemini Code Assist
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:
@@ -106,7 +112,13 @@ jobs:
                 }
               },
               "tools": {
-                "core": []
+                "core": [
+                  "read_file",
+                  "read_many_files",
+                  "list_directory",
+                  "glob",
+                  "grep_search"
+                ]
               }
             }
           extensions: |

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -13,6 +13,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: gemini-code-assist-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   preflight:
     runs-on: ubuntu-latest
@@ -48,6 +52,7 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.enabled == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Don't fail the workflow if Gemini's CLI/API is flaky;
     # surface the failure on the job itself instead.
     continue-on-error: true
@@ -55,8 +60,60 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+      - name: Prepare prompt context
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          mkdir -p .gemini
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg pr "$PULL_REQUEST_NUMBER" \
+            '{repository: $repo, pull_request_number: $pr}' > .gemini/context.json
       - name: Gemini Code Assist
         uses: google-github-actions/run-gemini-cli@v0.1.22
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          prompt: "Review this pull request. Focus on code quality, potential bugs, and suggestions for improvement."
+          gemini_cli_version: "0.41.2"
+          # Resolve PR number for both pull_request and issue_comment events.
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          settings: |-
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": []
+              }
+            }
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: "/pr-code-review"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -119,7 +119,7 @@ jobs:
         # removal is safe and eliminates all three attack surfaces.
         run: |
           rm -rf .gemini
-          find . \( -type f -o -type l \) -name 'GEMINI.md' -delete
+          find . -name 'GEMINI.md' -exec rm -rf -- {} +
           find . \( -type f -o -type l \) -name '.env' -delete
       - name: Pin code-review extension
         # run-gemini-cli@v0.1.22 invokes `gemini extensions install

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -30,7 +30,8 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review_comment' &&
        (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
@@ -65,6 +66,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Explicitly check out the PR's merge commit. For pull_request
+          # events this is already the default, but issue_comment and
+          # pull_request_review_comment runs default to the workflow ref
+          # (the base branch's tip), which would make local read tools
+          # like read_file/glob inspect base-branch code instead of the
+          # PR under review.
+          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
           fetch-depth: 0
           persist-credentials: false
       - name: Strip PR-supplied Gemini config
@@ -127,7 +135,8 @@ jobs:
                   "read_many_files",
                   "list_directory",
                   "glob",
-                  "grep_search"
+                  "grep_search",
+                  "activate_skill"
                 ]
               }
             }

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -8,10 +8,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
+permissions: {}
 
 concurrency:
   # Group by PR number for any PR-related event (pull_request,
@@ -29,6 +26,10 @@ concurrency:
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    permissions:
+      # Read-only: needed for `gh api repos/.../pulls/N` on issue_comment
+      # triggers to look up the PR's head repo for fork detection.
+      pull-requests: read
     if: >
       (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_review_comment' &&
@@ -83,6 +84,12 @@ jobs:
     if: needs.preflight.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # Write scope is needed so the github-mcp-server can create
+      # pending reviews and post inline review comments on the PR.
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -14,7 +14,7 @@ permissions:
   issues: write
 
 jobs:
-  gemini-code-assist:
+  preflight:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request') ||
@@ -29,6 +29,8 @@ jobs:
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR') &&
        contains(github.event.comment.body, '@gemini-code-assist'))
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
     steps:
       - name: Check for Gemini API key
         id: gate
@@ -41,12 +43,16 @@ jobs:
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping Gemini Code Assist: GEMINI_API_KEY secret is not configured."
           fi
-      - if: steps.gate.outputs.enabled == 'true'
-        uses: actions/checkout@v4
+
+  gemini-code-assist:
+    needs: preflight
+    if: needs.preflight.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: steps.gate.outputs.enabled == 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         uses: google-gemini/code-assist-action@v1

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -121,6 +121,19 @@ jobs:
           rm -rf .gemini
           find . \( -type f -o -type l \) -name 'GEMINI.md' -delete
           find . \( -type f -o -type l \) -name '.env' -delete
+      - name: Pin code-review extension
+        # run-gemini-cli@v0.1.22 invokes `gemini extensions install
+        # <url>` without forwarding --ref, and URL fragment syntax
+        # (#sha) is not understood by git clone, so pinning via the
+        # extensions: input is not possible. Check out the extension
+        # at a known-good commit into a sibling directory and install
+        # it from that local path instead.
+        uses: actions/checkout@v4
+        with:
+          repository: gemini-cli-extensions/code-review
+          ref: dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04
+          path: .gemini-extensions/code-review
+          persist-credentials: false
       - name: Gemini Code Assist
         id: gemini
         continue-on-error: true
@@ -182,7 +195,7 @@ jobs:
             }
           extensions: |
             [
-              "https://github.com/gemini-cli-extensions/code-review"
+              "./.gemini-extensions/code-review"
             ]
           prompt: "/pr-code-review"
       - name: Note Gemini API quota exhaustion

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -48,6 +48,7 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.enabled == 'true'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,3 +57,20 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         uses: google-gemini/code-assist-action@v1
+
+  gemini-code-assist-fallback:
+    needs: [preflight, gemini-code-assist]
+    if: >
+      always() &&
+      needs.preflight.outputs.enabled == 'true' &&
+      needs.gemini-code-assist.result != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist (run-gemini-cli fallback)
+        uses: google-github-actions/run-gemini-cli@v0.1.22
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          prompt: "Review this pull request. Focus on code quality, potential bugs, and suggestions for improvement."

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -74,7 +74,10 @@ jobs:
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_cli_version: "0.41.2"
-          # Resolve PR number for both pull_request and issue_comment events.
+          # Resolves the PR number across all three supported triggers:
+          # pull_request, pull_request_review_comment, and issue_comment.
+          # The first two populate github.event.pull_request.number; the
+          # last populates github.event.issue.number.
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           settings: |-
             {

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -96,7 +96,7 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                    "ghcr.io/github/github-mcp-server@sha256:a1d43076a36638ee24520fd6e83c3905ae41bc9850179081df1de2ba3a7afae0"
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -111,6 +111,6 @@ jobs:
             }
           extensions: |
             [
-              "https://github.com/gemini-cli-extensions/code-review"
+              "https://github.com/gemini-cli-extensions/code-review#<FULL_COMMIT_SHA>"
             ]
           prompt: "/pr-code-review"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -49,13 +49,28 @@ jobs:
         id: gate
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Only meaningful for pull_request triggers; comment triggers
-          # are already gated on author_association above.
-          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          # Populated by pull_request and pull_request_review_comment;
+          # empty for issue_comment (we look it up below).
+          PR_HEAD_REPO_FROM_EVENT: ${{ github.event.pull_request.head.repo.full_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
-          if [ "$IS_FORK_PR" = "true" ]; then
+          set -euo pipefail
+          head_repo=""
+          case "$EVENT_NAME" in
+            pull_request|pull_request_review_comment)
+              head_repo="$PR_HEAD_REPO_FROM_EVENT"
+              ;;
+            issue_comment)
+              head_repo=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.repo.full_name)
+              ;;
+          esac
+
+          if [ -n "$head_repo" ] && [ "$head_repo" != "$REPO" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping Gemini Code Assist: PR is from a fork; not running secret-backed review against untrusted code."
+            echo "::notice::Skipping Gemini Code Assist: PR is from a fork ($head_repo); not running secret-backed review against untrusted code."
           elif [ -n "$GEMINI_API_KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
@@ -81,11 +96,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Strip PR-supplied Gemini config
-        # Project-local .gemini/commands/*.toml shadow extension commands
-        # in Gemini CLI's loader, so a PR could plant a pr-code-review.toml
-        # that hijacks /pr-code-review. We don't ship .gemini/ in the repo,
-        # so wiping it is safe and removes the attack surface.
-        run: rm -rf .gemini
+        # Two distinct attack vectors via PR-authored content:
+        #   1. .gemini/commands/*.toml shadow extension commands in
+        #      Gemini CLI's loader (project commands win over extension
+        #      commands), so a PR could plant pr-code-review.toml that
+        #      hijacks /pr-code-review.
+        #   2. GEMINI.md is loaded as project instructional context on
+        #      every prompt and could steer the reviewer to suppress,
+        #      soften, or forge feedback.
+        # Neither file is shipped by this repo, so unconditional removal
+        # is safe and eliminates both attack surfaces.
+        run: |
+          rm -rf .gemini
+          find . -type f -name 'GEMINI.md' -delete
       - name: Gemini Code Assist
         id: gemini
         continue-on-error: true

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -24,8 +24,23 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
-      - uses: actions/checkout@v4
+      - name: Check for Gemini API key
+        id: gate
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [ -n "$GEMINI_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Gemini Code Assist: GEMINI_API_KEY secret is not configured."
+          fi
+      - if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         uses: google-gemini/code-assist-action@v1

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -14,7 +14,16 @@ permissions:
   issues: write
 
 concurrency:
-  group: gemini-code-assist-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Group by PR number for any PR-related event (pull_request,
+  # pull_request_review_comment, or an issue_comment posted on a PR).
+  # Fall back to run_id for non-PR issue_comment events so a comment on
+  # issue #N never collides with — and cancels — a running PR #N workflow.
+  group: >-
+    gemini-code-assist-${{
+      github.event.pull_request.number
+      || (github.event.issue.pull_request && github.event.issue.number)
+      || github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -101,7 +101,9 @@ jobs:
                     "ghcr.io/github/github-mcp-server@sha256:a1d43076a36638ee24520fd6e83c3905ae41bc9850179081df1de2ba3a7afae0"
                   ],
                   "includeTools": [
+                    "create_pending_pull_request_review",
                     "add_comment_to_pending_review",
+                    "submit_pending_pull_request_review",
                     "pull_request_read",
                     "pull_request_review_write"
                   ],


### PR DESCRIPTION
## Summary

- Replace the unresolvable `google-gemini/code-assist-action@v1` reference with `google-github-actions/run-gemini-cli@v0.1.22`, which is the supported Google action for invoking Gemini in CI.
- Add a `preflight` job that gates the main `gemini-code-assist` job on `secrets.GEMINI_API_KEY` being configured. When the secret is missing the preflight emits a `::notice::` and the main job is skipped (not failed), so forks and unconfigured repos no longer fail this workflow.
- **Behavior change (invocation policy):** Comment-triggered runs (`pull_request_review_comment`, `issue_comment` containing `@gemini-code-assist`) now require `author_association` of `OWNER`, `MEMBER`, or `COLLABORATOR`. This prevents anyone with a GitHub account from triggering Gemini API spend by commenting on a PR. PR-event triggers (opened/synchronize/reopened) are unchanged.
- Pass `gemini_api_key` and a review prompt to the action explicitly.

## Test plan

- [x] After merge, confirm the `gemini-code-assist` job is skipped on PRs from forks (no secret access) with a clear notice.
- [x] Confirm the job runs on internal PRs when `GEMINI_API_KEY` is configured.
- [x] Confirm `@gemini-code-assist` from a non-collaborator account does **not** trigger a workflow run.
- [x] Confirm `@gemini-code-assist` from a collaborator/member/owner does trigger a workflow run.
