### PR TITLE
Stop duplicate Jules review request comments

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -49,10 +49,21 @@ jobs:
                       link_header = list_response.headers.get("Link", "")
               except urllib.error.HTTPError as error:
                   body = error.read().decode("utf-8")
-                  # 403/404 are non-actionable (permissions, missing PR); log and skip
-                  # like the fork guard above. Surface every other failure so a transient
-                  # API error shows up as a red check the maintainer can retry.
-                  if error.code in (403, 404):
+                  # GitHub uses 403 for both permission denials AND rate limit /
+                  # abuse detection, so only log-and-skip when it looks like a
+                  # true permission context. 404 is always non-actionable here.
+                  # Anything else (including rate-limited 403s) raises so the
+                  # maintainer sees a red check they can retry.
+                  permission_skip = error.code == 404
+                  if error.code == 403:
+                      rate_limited = (
+                          error.headers.get("X-RateLimit-Remaining") == "0"
+                          or error.headers.get("Retry-After") is not None
+                          or "rate limit" in body.lower()
+                          or "abuse" in body.lower()
+                      )
+                      permission_skip = not rate_limited
+                  if permission_skip:
                       print(
                           f"Could not list existing comments ({error.code}): {body}"
                       )

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -2,7 +2,7 @@ name: Request Jules Review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened]
 
 permissions:
   issues: write
@@ -32,17 +32,45 @@ jobs:
           repo = os.environ["GITHUB_REPOSITORY"]
           pr_number = os.environ["PR_NUMBER"]
           token = os.environ["GITHUB_TOKEN"]
+          marker = "@google-labs-jules please review this pull request."
+
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+          }
+
+          # Skip if the request comment already exists, so re-runs don't duplicate it.
+          list_url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments?per_page=100"
+          while list_url:
+              list_request = urllib.request.Request(url=list_url, headers=headers)
+              try:
+                  with urllib.request.urlopen(list_request) as list_response:
+                      comments = json.loads(list_response.read().decode("utf-8"))
+                      link_header = list_response.headers.get("Link", "")
+              except urllib.error.HTTPError as error:
+                  body = error.read().decode("utf-8")
+                  print(f"Could not list existing comments: {body}")
+                  comments = []
+                  link_header = ""
+
+              for comment in comments:
+                  if marker in (comment.get("body") or ""):
+                      print(
+                          f"Review request already present on PR #{pr_number}; skipping."
+                      )
+                      sys.exit(0)
+
+              list_url = ""
+              for part in link_header.split(","):
+                  segment = part.strip()
+                  if segment.endswith('rel="next"'):
+                      list_url = segment.split(";", 1)[0].strip()[1:-1]
+                      break
 
           request = urllib.request.Request(
               url=f"{api_url}/repos/{repo}/issues/{pr_number}/comments",
-              data=json.dumps(
-                  {"body": "@google-labs-jules please review this pull request."}
-              ).encode("utf-8"),
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {token}",
-                  "Content-Type": "application/json",
-              },
+              data=json.dumps({"body": marker}).encode("utf-8"),
+              headers={**headers, "Content-Type": "application/json"},
               method="POST",
           )
 

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -50,8 +50,11 @@ jobs:
               except urllib.error.HTTPError as error:
                   body = error.read().decode("utf-8")
                   print(f"Could not list existing comments: {body}")
-                  comments = []
-                  link_header = ""
+                  print(
+                      "Refusing to post review request without verifying it is absent; "
+                      "skipping to avoid duplicate comments."
+                  )
+                  sys.exit(0)
 
               for comment in comments:
                   if marker in (comment.get("body") or ""):

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -69,7 +69,7 @@ jobs:
                   user = comment.get("user") or {}
                   if user.get("login") != "github-actions[bot]":
                       continue
-                  if marker in (comment.get("body") or ""):
+                  if (comment.get("body") or "") == marker:
                       print(
                           f"Review request already present on PR #{pr_number}; skipping."
                       )

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -49,7 +49,7 @@ jobs:
                       link_header = list_response.headers.get("Link", "")
               except urllib.error.HTTPError as error:
                   body = error.read().decode("utf-8")
-                  # 403/404 are non-actionable (permissions, missing PR); skip silently
+                  # 403/404 are non-actionable (permissions, missing PR); log and skip
                   # like the fork guard above. Surface every other failure so a transient
                   # API error shows up as a red check the maintainer can retry.
                   if error.code in (403, 404):

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -2,7 +2,7 @@ name: Request Jules Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   issues: write
@@ -49,14 +49,26 @@ jobs:
                       link_header = list_response.headers.get("Link", "")
               except urllib.error.HTTPError as error:
                   body = error.read().decode("utf-8")
-                  print(f"Could not list existing comments: {body}")
+                  # 403/404 are non-actionable (permissions, missing PR); skip silently
+                  # like the fork guard above. Surface every other failure so a transient
+                  # API error shows up as a red check the maintainer can retry.
+                  if error.code in (403, 404):
+                      print(
+                          f"Could not list existing comments ({error.code}): {body}"
+                      )
+                      print(
+                          "Skipping: token cannot list comments in this PR context."
+                      )
+                      sys.exit(0)
                   print(
-                      "Refusing to post review request without verifying it is absent; "
-                      "skipping to avoid duplicate comments."
+                      f"Failed to list existing comments ({error.code}): {body}"
                   )
-                  sys.exit(0)
+                  raise
 
               for comment in comments:
+                  user = comment.get("user") or {}
+                  if user.get("login") != "github-actions[bot]":
+                      continue
                   if marker in (comment.get("body") or ""):
                       print(
                           f"Review request already present on PR #{pr_number}; skipping."


### PR DESCRIPTION
## Summary

The `Request Jules Review` workflow was firing on `opened`, `reopened`, and `synchronize`, so every push to a PR re-posted the `@google-labs-jules please review this pull request.` comment. This change makes the bot comment appear at most once per PR.

- Drop the `synchronize` trigger so pushes to a PR no longer retrigger the comment. `opened` and `reopened` are kept — `opened` covers the normal case, and `reopened` provides a recovery path for PRs whose initial run was skipped/failed or whose request comment was deleted while the PR was closed.
- Before posting, page through the PR's existing comments and skip if the request marker is already present from `github-actions[bot]`. This makes `reopened` (and any manual rerun) safe by guaranteeing only one such comment exists per PR.
- Differentiate list-API failures: 403/404 log-and-skip (non-actionable, mirrors the fork guard); any other HTTPError raises so transient API issues surface as a red check the maintainer can retry instead of silently going green with no comment posted.

## Test plan

- [ ] Open a new PR against `main` and confirm the bot comment is posted once.
- [ ] Push a follow-up commit to the same PR and confirm no additional comment is posted.
- [ ] Close and reopen a PR and confirm no duplicate comment is posted.
- [ ] Manually re-run the workflow on an existing PR with the request comment already present and confirm the existing-comment check prevents a duplicate.
