### PR TITLE
Tighten auto-merge readiness gates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -158,7 +158,7 @@ jobs:
                 (response) => response.data.check_runs
               );
               const currentRunId = process.env.GITHUB_RUN_ID;
-              let observedGreenSignal = false;
+              let observedExternalCheckRun = false;
               for (const c of runs) {
                 if (!c) continue;
                 // Skip this workflow's own currently running check to avoid self-deadlock.
@@ -168,7 +168,7 @@ jobs:
                   c.details_url &&
                   c.details_url.includes(`/actions/runs/${currentRunId}`)
                 ) continue;
-                observedGreenSignal = true;
+                observedExternalCheckRun = true;
                 if (c.status !== 'completed') return { ok: false, reason: `check "${c.name}" status=${c.status}` };
                 if (!['success', 'neutral', 'skipped'].includes(c.conclusion)) {
                   return { ok: false, reason: `check "${c.name}" conclusion=${c.conclusion}` };
@@ -177,14 +177,12 @@ jobs:
               const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
                 owner, repo, ref: sha,
               });
-              if (combined.statuses.length > 0) {
-                observedGreenSignal = true;
-                if (combined.state !== 'success') {
-                  return { ok: false, reason: `combined status state=${combined.state}` };
-                }
+              const observedCommitStatus = combined.statuses.length > 0;
+              if (observedCommitStatus && combined.state !== 'success') {
+                return { ok: false, reason: `combined status state=${combined.state}` };
               }
-              if (!observedGreenSignal) {
-                return { ok: false, reason: 'no check runs or commit statuses found for head SHA yet' };
+              if (!observedExternalCheckRun && !observedCommitStatus) {
+                return { ok: false, reason: 'no non-self check runs or commit statuses found for head SHA yet' };
               }
               return { ok: true };
             }
@@ -205,6 +203,10 @@ jobs:
 
               if (pr.state !== 'open' || pr.draft || pr.merged) {
                 core.info(`PR #${num}: skip (state=${pr.state}, draft=${pr.draft}, merged=${pr.merged}).`);
+                continue;
+              }
+              if (pr.mergeable === null) {
+                core.info(`PR #${num}: mergeability is still being computed.`);
                 continue;
               }
               if (pr.mergeable === false || pr.mergeable_state === 'dirty') {


### PR DESCRIPTION
### Motivation
- Prevent the auto-merge workflow from treating an empty/no-CI result as a green signal so PRs are not queued or auto-merged before CI runs finish.  
- Avoid attempting to label or enable auto-merge while GitHub is still computing PR mergeability by treating `mergeable === null` as not ready.

### Description
- Update `checksPassing(sha)` in `.github/workflows/auto-merge.yml` to track `observedExternalCheckRun` and `observedCommitStatus` and require at least one non-self check run or commit status before returning success.  
- Make the combined status check fail when any observed commit status is not `success`.  
- Add a guard to skip PRs when `pr.mergeable === null` so the workflow waits for GitHub to finish computing mergeability.  
- These changes are localized to `.github/workflows/auto-merge.yml` to tighten readiness gating before labeling or enabling auto-merge.

### Testing
- Parsed the workflow YAML with `yaml.safe_load` which succeeded.  
- Ran the test suite with `LC_ALL=C PYENV_VERSION=3.12.13 pytest` and observed `20 passed`.  
- Noted `actionlint` was not installed in the environment, so no `actionlint` validation was performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2b5e77388320832c3413b7be19ac)