### PR TITLE
Quote $CLAUDE_PROJECT_DIR in Claude PreToolUse hook command (handle paths with spaces)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-sensitive-files.py"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-sensitive-files.py"
           }
         ]
       }

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -113,17 +113,21 @@ def test_claude_settings_registers_pre_tool_use_hook():
     assert commands == [
         {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-sensitive-files.py",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-sensitive-files.py",
         }
     ]
 
 
-def test_registered_hook_command_blocks_sensitive_file():
+def test_registered_hook_command_blocks_sensitive_file_from_path_with_spaces(
+    tmp_path,
+):
     repo_root = Path(__file__).resolve().parents[1]
     settings = json.loads(
         (repo_root / ".claude" / "settings.json").read_text(encoding="utf-8")
     )
     command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    project_dir_with_spaces = tmp_path / "project path with spaces"
+    project_dir_with_spaces.symlink_to(repo_root, target_is_directory=True)
     payload = json.dumps(
         {"tool_name": "Write", "tool_input": {"file_path": "secrets/.env"}}
     )
@@ -134,7 +138,7 @@ def test_registered_hook_command_blocks_sensitive_file():
         text=True,
         capture_output=True,
         shell=True,
-        env={**os.environ, "CLAUDE_PROJECT_DIR": str(repo_root)},
+        env={**os.environ, "CLAUDE_PROJECT_DIR": str(project_dir_with_spaces)},
         check=False,
     )
 

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -166,8 +167,6 @@ def test_claude_settings_registers_pre_tool_use_hook():
 def test_registered_hook_command_blocks_sensitive_file_from_path_with_spaces(
     tmp_path,
 ):
-    import shutil
-
     repo_root = Path(__file__).resolve().parents[1]
     hook_src = repo_root / ".claude" / "hooks" / "protect-sensitive-files.py"
     settings = json.loads(


### PR DESCRIPTION
### Motivation
- Ensure the configured Claude `PreToolUse` command preserves repository paths that contain spaces so the hook executable is invoked correctly by the shell.
- Add a regression that verifies the configured command actually runs when `CLAUDE_PROJECT_DIR` contains spaces.

### Description
- Update `.claude/settings.json` to quote `$CLAUDE_PROJECT_DIR` in the registered command: `"$CLAUDE_PROJECT_DIR"/.claude/hooks/protect-sensitive-files.py`.
- Update `tests/test_protect_sensitive_files_hook.py` to expect the quoted command and rename/replace the subprocess-based test with `test_registered_hook_command_blocks_sensitive_file_from_path_with_spaces` which symlinks the repo into a path containing spaces and invokes the configured command.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_protect_sensitive_files_hook.py`, which passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2a76f22483208be154c734f2d266)