### PR TITLE
Normalize sensitive-file hook paths for Windows separators

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import fnmatch
 import json
-import os
 import sys
 from typing import Any
 
@@ -41,8 +40,8 @@ def is_sensitive(path: str) -> bool:
     if not path:
         return False
 
-    normalized_path = path.lower()
-    normalized_base = os.path.basename(path).lower()
+    normalized_path = path.replace("\\", "/").lower()
+    normalized_base = normalized_path.rsplit("/", 1)[-1]
 
     for pattern in SENSITIVE_BASENAME_PATTERNS:
         normalized_pattern = pattern.lower()

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -44,6 +44,15 @@ def test_blocks_sensitive_notebook_paths() -> None:
     assert "notebooks/id_rsa" in result.stderr
 
 
+def test_blocks_backslash_separated_sensitive_paths() -> None:
+    """Windows-style paths are normalized before basename matching."""
+    result = run_hook(hook_payload("Write", r"C:\repo\credentials.json"))
+
+    assert result.returncode == 2
+    assert "BLOCKED" in result.stderr
+    assert r"C:\repo\credentials.json" in result.stderr
+
+
 def test_allows_non_sensitive_edit_paths() -> None:
     """Non-sensitive paths are allowed for protected editing tools."""
     result = run_hook(hook_payload("Edit", "src/html2md/cli.py"))


### PR DESCRIPTION
### Motivation
- Prevent Windows-style backslash paths (e.g., `C:\repo\credentials.json`) from bypassing the sensitive-file PreToolUse hook when run on POSIX environments.

### Description
- Normalize backslashes to forward slashes in `.claude/hooks/protect_sensitive_files.py` and compute the basename with `rsplit("/", 1)[-1]` before pattern matching so both `\` and `/` path flavors match sensitive patterns.
- Remove the unused `os` import that was previously used for `os.path.basename` and keep existing fnmatch-based pattern checks intact.
- Add a subprocess test `test_blocks_backslash_separated_sensitive_paths` to `tests/test_protect_sensitive_files_hook.py` that verifies a Windows-style absolute path is blocked by the hook.

### Testing
- Installed package and test deps with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest` which completed successfully.
- Ran targeted tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_protect_sensitive_files_hook.py -q` which passed.
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2a9f13c48320a12585bdb3e437d5)