### PR TITLE
Enforce AI-assisted transcript placeholder replacement

### DIFF
--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -31,7 +31,8 @@ jobs:
           # Accept claude.ai links, cursor.com, codex, jules.google, or the
           # literal placeholder <CLAUDE_CHAT_URL> for drafts (warn only).
           body="${PR_BODY:-}"
-          accepted_url_pattern='https?://(claude\.ai|cursor\.com|jules\.google\.com)([/:?#]|$)|https?://chatgpt\.com/codex([/?#]|$)'
+          url_token_boundary='(^|[^[:alnum:]._~:/?#@!$&*+,;=%-])'
+          accepted_url_pattern="${url_token_boundary}https?://(claude\.ai|cursor\.com|jules\.google\.com)([/?#]|$)|${url_token_boundary}https?://chatgpt\.com/codex([/?#]|$)"
 
           if printf '%s' "$body" | grep -Eqi "$accepted_url_pattern"; then
             echo "OK: PR body contains an agent chat URL."

--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
           echo "PR title: $PR_TITLE"
@@ -30,15 +31,21 @@ jobs:
           # Accept claude.ai links, cursor.com, codex, jules.google, or the
           # literal placeholder <CLAUDE_CHAT_URL> for drafts (warn only).
           body="${PR_BODY:-}"
+          accepted_url_pattern='https?://(claude\.ai|cursor\.com|jules\.google\.com)([/:?#]|$)|https?://chatgpt\.com/codex([/?#]|$)'
 
-          if printf '%s' "$body" | grep -Eqi 'https?://(claude\.ai|cursor\.com|chatgpt\.com/codex|jules\.google\.com)'; then
+          if printf '%s' "$body" | grep -Eqi "$accepted_url_pattern"; then
             echo "OK: PR body contains an agent chat URL."
             exit 0
           fi
 
           if printf '%s' "$body" | grep -qF '<CLAUDE_CHAT_URL>'; then
-            echo "::warning::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before merging."
-            exit 0
+            if [[ "$PR_DRAFT" == "true" ]]; then
+              echo "::warning::Draft PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before marking ready for review."
+              exit 0
+            fi
+
+            echo "::error::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before merging."
+            exit 1
           fi
 
           echo "::error::PR title is tagged [AI-Assisted] but the body does not include a Claude chat URL (or accepted alternative). Add the URL or remove the tag."


### PR DESCRIPTION
### Motivation
- Prevent the AI-assisted guard from blocking ordinary human PRs by skipping checks when the title lacks the `[AI-Assisted]` prefix.
- Ensure draft PRs may temporarily keep the `<CLAUDE_CHAT_URL>` placeholder while requiring a real transcript for ready/non-draft PRs.
- Avoid acceptance of lookalike hosts by anchoring accepted transcript URL matching to approved domains and paths.

### Description
- Updated the workflow ` .github/workflows/ai-assisted-pr-guard.yml` to export `PR_DRAFT` from the pull request event so the script can distinguish draft vs ready PRs.
- Introduced an anchored `accepted_url_pattern` and switched the check to `grep -Eqi "$accepted_url_pattern"` to require approved hosts/paths rather than substring matches.
- Changed placeholder handling so `<CLAUDE_CHAT_URL>` produces a warning and exit 0 for draft PRs but is treated as an error (exit 1) for non-draft PRs.
- Preserved the early no-op for titles that do not start with `[AI-Assisted]` so untagged human PRs are not failed.

### Testing
- Attempted a Python `yaml.safe_load` check which failed due to the environment missing the `yaml` module, so the Python check did not run.
- Verified the workflow YAML parses using Ruby with `YAML.load_file` which succeeded.
- Executed the workflow script under a Ruby harness against five automated cases (untagged, draft-placeholder, ready-placeholder, accepted-URL, lookalike-host) and observed expected exits for all cases: untagged `0`, draft placeholder `0`, ready placeholder `1`, accepted URL `0`, lookalike host `1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2ae025748320b7e1d037dc7e627a)