### PR TITLE
Anchor accepted AI transcript URL domains

### DIFF
--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -31,7 +31,7 @@ jobs:
           # literal placeholder <CLAUDE_CHAT_URL> for drafts (warn only).
           body="${PR_BODY:-}"
 
-          if printf '%s' "$body" | grep -Eqi 'https?://(claude\.ai|cursor\.com|chatgpt\.com/codex|jules\.google\.com)'; then
+          if printf '%s' "$body" | grep -Eqi 'https?://((claude\.ai|cursor\.com|jules\.google\.com)(:[0-9]+)?([/?#]|$)|chatgpt\.com(:[0-9]+)?/codex([/?#]|$))'; then
             echo "OK: PR body contains an agent chat URL."
             exit 0
           fi


### PR DESCRIPTION
### Motivation
- Prevent lookalike hosts (e.g. `claude.ai.evil.example`, `cursor.com.attacker.test`) from satisfying the AI-assisted PR guard by anchoring accepted transcript domains to a valid domain boundary.

### Description
- Tighten the PR-body URL check in `.github/workflows/ai-assisted-pr-guard.yml` by replacing the permissive host alternation with a regex that requires the accepted hosts to end at a domain boundary or be followed by an optional port and a path/query/fragment (affects the `grep -Eqi` pattern).

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ai-assisted-pr-guard.yml")'` which succeeded.
- Ran a shell regex smoke test that confirmed valid transcript URLs are accepted and lookalike host URLs are rejected (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2aeb4f0083209ec1a6a9336c595a)