### PR TITLE
Block modern SSH key filenames in sensitive-file hook

### DIFF
--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -26,8 +26,12 @@ SENSITIVE_BASENAME_PATTERNS = (
     "id_rsa.pub",
     "id_ed25519",
     "id_ed25519.pub",
+    "id_ed25519_sk",
+    "id_ed25519_sk.pub",
     "id_ecdsa",
     "id_ecdsa.pub",
+    "id_ecdsa_sk",
+    "id_ecdsa_sk.pub",
     "id_dsa",
     "id_dsa.pub",
 )

--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -24,6 +24,12 @@ SENSITIVE_BASENAME_PATTERNS = (
     "credentials.json",
     "id_rsa",
     "id_rsa.pub",
+    "id_ed25519",
+    "id_ed25519.pub",
+    "id_ecdsa",
+    "id_ecdsa.pub",
+    "id_dsa",
+    "id_dsa.pub",
 )
 
 PROTECTED_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -44,6 +44,9 @@ def test_is_sensitive_matches_secret_basenames():
     assert hook.is_sensitive("config/.env.local")
     assert hook.is_sensitive("keys/service-account.pem")
     assert hook.is_sensitive("nested/credentials.json")
+    assert hook.is_sensitive(".ssh/id_ed25519")
+    assert hook.is_sensitive(".ssh/id_ecdsa")
+    assert hook.is_sensitive(".ssh/id_dsa")
     assert not hook.is_sensitive("docs/env-example.md")
 
 

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -44,9 +44,21 @@ def test_is_sensitive_matches_secret_basenames():
     assert hook.is_sensitive("config/.env.local")
     assert hook.is_sensitive("keys/service-account.pem")
     assert hook.is_sensitive("nested/credentials.json")
-    assert hook.is_sensitive(".ssh/id_ed25519")
-    assert hook.is_sensitive(".ssh/id_ecdsa")
-    assert hook.is_sensitive(".ssh/id_dsa")
+    ssh_key_basenames = (
+        "id_ed25519",
+        "id_ed25519.pub",
+        "id_ed25519_sk",
+        "id_ed25519_sk.pub",
+        "id_ecdsa",
+        "id_ecdsa.pub",
+        "id_ecdsa_sk",
+        "id_ecdsa_sk.pub",
+        "id_dsa",
+        "id_dsa.pub",
+    )
+    for basename in ssh_key_basenames:
+        assert basename in hook.SENSITIVE_BASENAME_PATTERNS
+        assert hook.is_sensitive(f".ssh/{basename}")
     assert not hook.is_sensitive("docs/env-example.md")
 
 


### PR DESCRIPTION
### Motivation
- The sensitive-file hook only matched `id_rsa` names, allowing modern OpenSSH private keys (e.g., `id_ed25519`, `id_ecdsa`, `id_dsa`) to be edited; this change closes that gap.
- Add regression coverage so future edits do not reintroduce the bypass.

### Description
- Add modern OpenSSH key names and their `.pub` variants to `SENSITIVE_BASENAME_PATTERNS` in `.claude/hooks/protect-sensitive-files.py` so basenames like `id_ed25519` are treated as sensitive.
- Extend `tests/test_protect_sensitive_files_hook.py` with assertions that `.ssh/id_ed25519`, `.ssh/id_ecdsa`, and `.ssh/id_dsa` are detected by `is_sensitive`.
- Commit the two-file change to the current branch and prepare a follow-up PR with this fix.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_protect_sensitive_files_hook.py`, which passed.
- Ran `PYENV_VERSION=3.12.13 pytest -q` for the full suite, which failed during collection due to missing `requests` and `html2md` import issues in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2b1d4ba48320b83d87d8bca1f0a3)