### PR TITLE
ci: keep Gemini auth input and move secret check to steps

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,19 +17,31 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      secrets.GEMINI_API_KEY != '' &&
-      ((github.event_name == 'pull_request') ||
-       ((github.event_name == 'pull_request_review_comment' ||
-         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
-        contains(github.event.comment.body, '@gemini-code-assist') &&
-        (github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'COLLABORATOR')))
+      (github.event_name == 'pull_request') ||
+      ((github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+       contains(github.event.comment.body, '@gemini-code-assist') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     steps:
+      - name: Check Gemini API key availability
+        id: gemini-api-key
+        shell: bash
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [ -n "$GEMINI_API_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@v4
+        if: steps.gemini-api-key.outputs.available == 'true'
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
+        if: steps.gemini-api-key.outputs.available == 'true'
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -26,7 +26,7 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR'))
     steps:
       - name: Check Gemini API key availability
-        id: gemini-api-key
+        id: gemini_api_key
         shell: bash
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -37,11 +37,11 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@v4
-        if: steps.gemini-api-key.outputs.available == 'true'
+        if: steps.gemini_api_key.outputs.available == 'true'
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: steps.gemini-api-key.outputs.available == 'true'
+        if: steps.gemini_api_key.outputs.available == 'true'
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
### Motivation
- The workflow previously referenced `secrets.GEMINI_API_KEY` in a job-level `if:`, which is not supported and can make the workflow invalid or leak secrets to the job scope. 
- The Gemini action requires the API key via its `gemini_api_key` input, so the secret should be scoped to the action step rather than set as a job env. 
- Keep the existing event and trusted-author gating for `pull_request` and comment-trigger paths while avoiding invalid `secrets` usage and unnecessary secret exposure.

### Description
- Removed the unsupported `secrets.GEMINI_API_KEY` reference from the job-level `if:` in `.github/workflows/gemini-code-assist.yml`. 
- Added a step `Check Gemini API key availability` that reads the secret into a step-scoped env and emits a boolean output `available`. 
- Conditioned `actions/checkout` and the `google-github-actions/run-gemini-cli` step on `steps.gemini-api-key.outputs.available == 'true'` and continue to pass the secret to the action via `with: gemini_api_key: ${{ secrets.GEMINI_API_KEY }}` so the action receives proper auth. 
- Kept the pinned action reference `google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489` and retained the trusted-author checks for comment-triggered runs.

### Testing
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml')"` and the file loaded successfully. 
- Ran `git diff --check` to ensure no whitespace or merge conflicts were introduced and it reported no issues. 
- Verified repository status with `git status --short --branch` to confirm the change is staged and present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2b52d16c8320886fed02ee4f1c94)