### PR TITLE
Restrict Gemini core tools in CI review

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -42,6 +42,9 @@ jobs:
             ["https://github.com/gemini-cli-extensions/code-review"]
           settings: |-
             {
+              "tools": {
+                "core": []
+              },
               "mcpServers": {
                 "github": {
                   "command": "docker",

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -43,7 +43,7 @@ jobs:
           settings: |-
             {
               "tools": {
-                "core": []
+                "core": ["activate_skill"]
               },
               "mcpServers": {
                 "github": {
@@ -58,6 +58,7 @@ jobs:
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
+                    "get_file_contents",
                     "pull_request_read",
                     "pull_request_review_write"
                   ],


### PR DESCRIPTION
### Motivation
- Prevent Gemini from exposing built-in core tools (shell/file access) during PR reviews by explicitly disabling core tools so only the configured GitHub MCP review tools are available.

### Description
- Add an explicit `"tools": { "core": [] }` entry to the `settings` JSON for the `Gemini Code Assist` step in `.github/workflows/gemini-code-assist.yml` so the workflow uses only the configured MCP tools.

### Testing
- Verified the workflow YAML loads with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'` which succeeded.
- Verified the `settings` value is valid JSON with `ruby -e 'require "yaml"; require "json"; wf = YAML.load_file(".github/workflows/gemini-code-assist.yml"); settings = wf["jobs"]["gemini-code-assist"]["steps"].find { |s| s["name"] == "Gemini Code Assist" }["with"]["settings"]; JSON.parse(settings); puts "settings JSON OK"'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca8e65bd48320bbe6696afa3a5fc4)