### PR TITLE
Validate redirect targets for SSRF protection

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,7 +6,7 @@ import os
 import sys
 import socket
 import ipaddress
-from urllib.parse import urlparse, unquote
+from urllib.parse import urlparse, unquote, urljoin
 
 def main(argv=None):
     """Run the CLI."""
@@ -56,25 +56,23 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def process_url(target_url: str) -> None:
-            """Process a single URL."""
-            # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
-
+        def validate_url(target_url: str) -> bool:
+            """Validate a URL before fetching it to reduce SSRF risk."""
             parsed = urlparse(target_url)
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
-                return
+                return False
 
-            # SSRF Protection: Resolve and validate IP against internal/private ranges
             hostname = parsed.hostname
             if not hostname:
                 print("Error: Invalid URL.", file=sys.stderr)
-                return
+                return False
 
             try:
+                # SSRF Protection: Resolve and validate every IP for this host.
+                # This function is called for the original URL and each redirect
+                # target before any request is made to that URL.
                 addr_info = socket.getaddrinfo(hostname, None)
                 for addr in addr_info:
                     ip_obj = ipaddress.ip_address(addr[4][0])
@@ -82,16 +80,50 @@ def main(argv=None):
                         ip_obj.is_link_local or ip_obj.is_unspecified or
                         ip_obj.is_reserved or ip_obj.is_multicast):
                         print(f"Error: Unsafe URL pointing to internal IP '{ip_obj}'.", file=sys.stderr)
-                        return
+                        return False
             except Exception as e:
                 print(f"Error validating hostname: {e}", file=sys.stderr)
-                return
+                return False
+
+            return True
+
+        def fetch_validated_url(target_url: str):
+            """Fetch a URL while validating each redirect target before following."""
+            current_url = target_url
+            max_redirects = 10
+            redirect_statuses = (301, 302, 303, 307, 308)
+
+            for _ in range(max_redirects + 1):
+                if not validate_url(current_url):
+                    return None
+
+                response = session.get(current_url, timeout=30, allow_redirects=False)
+                status_code = getattr(response, 'status_code', None)
+                if status_code not in redirect_statuses:
+                    return response
+
+                location = response.headers.get('Location') if response.headers else None
+                if not location:
+                    return response
+
+                current_url = urljoin(current_url, location)
+
+            print("Error: Too many redirects.", file=sys.stderr)
+            return None
+
+        def process_url(target_url: str) -> None:
+            """Process a single URL."""
+            # Fix common URL typo: trailing slash before query parameters
+            if '/?' in target_url:
+                target_url = target_url.replace('/?', '?')
 
             print(f"Processing URL: {target_url}")
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = fetch_validated_url(target_url)
+                if response is None:
+                    return
                 response.raise_for_status()
 
                 print("Converting to Markdown...")

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,7 @@ import os
 import sys
 import socket
 import ipaddress
+from contextlib import contextmanager
 from urllib.parse import urlparse, unquote, urljoin
 
 def main(argv=None):
@@ -56,36 +57,102 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def validate_url(target_url: str) -> bool:
-            """Validate a URL before fetching it to reduce SSRF risk."""
+        def _url_port(parsed):
+            """Return the explicit or default network port for a parsed URL."""
+            try:
+                if parsed.port is not None:
+                    return parsed.port
+            except ValueError as e:
+                print(f"Error: Invalid URL port: {e}", file=sys.stderr)
+                return None
+
+            if parsed.scheme == 'http':
+                return 80
+            if parsed.scheme == 'https':
+                return 443
+            return None
+
+        def _is_unsafe_ip(ip_obj):
+            """Return whether an IP address should be blocked for SSRF protection."""
+            return (ip_obj.is_private or ip_obj.is_loopback or
+                    ip_obj.is_link_local or ip_obj.is_unspecified or
+                    ip_obj.is_reserved or ip_obj.is_multicast)
+
+        def validate_url(target_url: str):
+            """Validate a URL and return the DNS answers approved for fetching it."""
             parsed = urlparse(target_url)
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
-                return False
+                return None
 
             hostname = parsed.hostname
             if not hostname:
                 print("Error: Invalid URL.", file=sys.stderr)
-                return False
+                return None
+
+            port = _url_port(parsed)
+            if port is None:
+                return None
 
             try:
                 # SSRF Protection: Resolve and validate every IP for this host.
-                # This function is called for the original URL and each redirect
-                # target before any request is made to that URL.
-                addr_info = socket.getaddrinfo(hostname, None)
+                # The approved DNS answers are returned and pinned for the
+                # matching request so a second lookup cannot rebind to an
+                # internal address after validation.
+                addr_info = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+                if not addr_info:
+                    print("Error: Hostname did not resolve to any addresses.", file=sys.stderr)
+                    return None
+
                 for addr in addr_info:
                     ip_obj = ipaddress.ip_address(addr[4][0])
-                    if (ip_obj.is_private or ip_obj.is_loopback or
-                        ip_obj.is_link_local or ip_obj.is_unspecified or
-                        ip_obj.is_reserved or ip_obj.is_multicast):
+                    if _is_unsafe_ip(ip_obj):
                         print(f"Error: Unsafe URL pointing to internal IP '{ip_obj}'.", file=sys.stderr)
-                        return False
+                        return None
             except Exception as e:
                 print(f"Error validating hostname: {e}", file=sys.stderr)
-                return False
+                return None
 
-            return True
+            return hostname, port, addr_info
+
+        @contextmanager
+        def _pin_validated_dns(hostname, port, addr_info):
+            """Pin requests DNS resolution to the already-validated answers."""
+            original_getaddrinfo = socket.getaddrinfo
+            pinned_hostname = hostname.rstrip('.').lower()
+
+            def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
+                if host and host.rstrip('.').lower() == pinned_hostname:
+                    resolved_port = requested_port if requested_port is not None else port
+                    pinned = []
+                    for family_, type_, proto_, canonname, sockaddr in addr_info:
+                        if family and family_ != family:
+                            continue
+                        if type and type_ != type:
+                            continue
+                        if proto and proto_ != proto:
+                            continue
+
+                        if len(sockaddr) == 2:
+                            pinned_sockaddr = (sockaddr[0], resolved_port)
+                        else:
+                            pinned_sockaddr = (sockaddr[0], resolved_port, *sockaddr[2:])
+                        pinned.append((family_, type_, proto_, canonname, pinned_sockaddr))
+
+                    if pinned:
+                        return pinned
+                    raise socket.gaierror(
+                        f"No pinned DNS answers match requested socket parameters for {host}"
+                    )
+
+                return original_getaddrinfo(host, requested_port, family, type, proto, flags)
+
+            socket.getaddrinfo = pinned_getaddrinfo
+            try:
+                yield
+            finally:
+                socket.getaddrinfo = original_getaddrinfo
 
         def fetch_validated_url(target_url: str):
             """Fetch a URL while validating each redirect target before following."""
@@ -94,10 +161,13 @@ def main(argv=None):
             redirect_statuses = (301, 302, 303, 307, 308)
 
             for _ in range(max_redirects + 1):
-                if not validate_url(current_url):
+                validation = validate_url(current_url)
+                if validation is None:
                     return None
+                hostname, port, addr_info = validation
 
-                response = session.get(current_url, timeout=30, allow_redirects=False)
+                with _pin_validated_dns(hostname, port, addr_info):
+                    response = session.get(current_url, timeout=30, allow_redirects=False)
                 status_code = getattr(response, 'status_code', None)
                 if status_code not in redirect_statuses:
                     return response

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -174,7 +174,7 @@ def main(argv=None):
 
                 location = response.headers.get('Location') if response.headers else None
                 if not location:
-                    print("Error: Redirect response missing Location header.", file=sys.stderr)
+                    print(f"Error: Redirect response missing Location header for {current_url}.", file=sys.stderr)
                     return None
 
                 current_url = urljoin(current_url, location)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,6 +1,7 @@
 """Security-focused tests for CLI URL and output path handling."""
 
 from unittest.mock import MagicMock, patch
+import socket
 import pytest
 
 from html2md import cli
@@ -91,6 +92,38 @@ def test_safe_redirect_is_manually_followed(mock_get, mock_getaddrinfo, capsys):
     assert mock_get.call_args_list[0].kwargs["allow_redirects"] is False
     assert mock_get.call_args_list[1].args == ("http://public.example/final",)
     assert mock_get.call_args_list[1].kwargs["allow_redirects"] is False
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_validated_dns_answer_is_pinned_during_fetch(mock_get, mock_getaddrinfo, capsys):
+    """The request uses the DNS answer validated before fetching."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("rebinding.example", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_pinned_dns
+
+    cli.main(["--url", "http://rebinding.example/"])
+
+    outerr = capsys.readouterr()
+    assert "# Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    assert mock_getaddrinfo.call_count == 1
+    mock_get.assert_called_once_with(
+        "http://rebinding.example/", timeout=30, allow_redirects=False
+    )
 
 
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -2,6 +2,7 @@
 
 import socket
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 from html2md import cli

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -42,8 +42,60 @@ def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url):
     mock_get.assert_not_called()
 
 
+@patch("socket.getaddrinfo")
 @patch("requests.Session.get")
-def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
+def test_redirect_to_internal_ip_is_blocked(mock_get, mock_getaddrinfo, capsys):
+    """Redirect targets are validated before a follow-up request is sent."""
+    mock_getaddrinfo.side_effect = [
+        [(None, None, None, None, ("8.8.8.8", 0))],
+        [(None, None, None, None, ("169.254.169.254", 0))],
+    ]
+
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+    mock_get.return_value = redirect_response
+
+    cli.main(["--url", "http://public.example/redirect"])
+
+    outerr = capsys.readouterr()
+    assert "Unsafe URL pointing to internal IP '169.254.169.254'" in outerr.err
+    mock_get.assert_called_once_with(
+        "http://public.example/redirect", timeout=30, allow_redirects=False
+    )
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_safe_redirect_is_manually_followed(mock_get, mock_getaddrinfo, capsys):
+    """Safe redirect targets are validated and then fetched without auto-redirects."""
+    mock_getaddrinfo.return_value = [(None, None, None, None, ("8.8.8.8", 0))]
+
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {"Location": "/final"}
+
+    final_response = MagicMock()
+    final_response.status_code = 200
+    final_response.headers = {}
+    final_response.text = "<h1>Safe</h1>"
+    final_response.raise_for_status.return_value = None
+
+    mock_get.side_effect = [redirect_response, final_response]
+
+    cli.main(["--url", "http://public.example/start"])
+
+    outerr = capsys.readouterr()
+    assert "# Safe" in outerr.out
+    assert mock_get.call_args_list[0].args == ("http://public.example/start",)
+    assert mock_get.call_args_list[0].kwargs["allow_redirects"] is False
+    assert mock_get.call_args_list[1].args == ("http://public.example/final",)
+    assert mock_get.call_args_list[1].kwargs["allow_redirects"] is False
+
+
+@patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
+@patch("requests.Session.get")
+def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""
     outdir = tmp_path / "output"
     outdir.mkdir()


### PR DESCRIPTION
### Motivation

- Prevent SSRF via HTTP redirects by ensuring that every redirect target is validated for internal/private IPs before being fetched.
- The previous validation only checked the original hostname but allowed `requests` to follow redirects automatically, which could cause the client to fetch attacker-controlled redirects to internal addresses.

### Description

- Add a reusable `validate_url` function that resolves hostnames via `socket.getaddrinfo` and rejects addresses that are private, loopback, link-local, unspecified, reserved, or multicast (file `src/html2md/cli.py`).
- Disable automatic redirects and introduce `fetch_validated_url` which calls `session.get(..., allow_redirects=False)` and manually follows up to 10 redirects only after resolving and validating each `Location` (using `urljoin` for relative redirects) (file `src/html2md/cli.py`).
- Update tests to cover redirect behavior by adding assertions that redirects to internal IPs are blocked and safe redirects are validated then fetched manually, and adjust mocking of `socket.getaddrinfo` where appropriate (file `tests/test_cli_security.py`).

### Testing

- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` and the security-focused tests passed (`11 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` and all tests passed (`27 passed`).
- Verified the changed files are `src/html2md/cli.py` and `tests/test_cli_security.py` and that `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca8e7afcc8320bf20f2d5ef1a3f1d)