### PR TITLE
Make sensitive hook smoke test portable

### DIFF
--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
-import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -163,25 +163,39 @@ def test_claude_settings_registers_pre_tool_use_hook():
     ]
 
 
+def registered_hook_command(settings):
+    return settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+
+def hook_path_from_registered_command(settings, project_dir):
+    command = registered_hook_command(settings)
+    expected_command = '"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-sensitive-files.py"'
+    assert command == expected_command
+
+    relative_hook_path = expected_command.strip('"').removeprefix(
+        "$CLAUDE_PROJECT_DIR/"
+    )
+    return project_dir / Path(relative_hook_path)
+
+
+def run_registered_hook(settings, project_dir, payload):
+    return subprocess.run(
+        [sys.executable, str(hook_path_from_registered_command(settings, project_dir))],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def test_registered_hook_command_blocks_sensitive_file():
     repo_root = Path(__file__).resolve().parents[1]
     settings = json.loads(
         (repo_root / ".claude" / "settings.json").read_text(encoding="utf-8")
     )
-    command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-    payload = json.dumps(
-        {"tool_name": "Write", "tool_input": {"file_path": "secrets/.env"}}
-    )
+    payload = {"tool_name": "Write", "tool_input": {"file_path": "secrets/.env"}}
 
-    result = subprocess.run(
-        command,
-        input=payload,
-        text=True,
-        capture_output=True,
-        shell=True,
-        env={**os.environ, "CLAUDE_PROJECT_DIR": str(repo_root)},
-        check=False,
-    )
+    result = run_registered_hook(settings, repo_root, payload)
 
     assert result.returncode == 2
     assert "BLOCKED" in result.stderr
@@ -190,25 +204,14 @@ def test_registered_hook_command_blocks_sensitive_file():
 
 def test_registered_hook_command_handles_project_dir_with_spaces(tmp_path):
     repo_root = Path(__file__).resolve().parents[1]
-    linked_repo = tmp_path / "repo with spaces"
-    linked_repo.symlink_to(repo_root, target_is_directory=True)
+    spaced_repo = tmp_path / "repo with spaces"
+    shutil.copytree(repo_root / ".claude", spaced_repo / ".claude")
     settings = json.loads(
         (repo_root / ".claude" / "settings.json").read_text(encoding="utf-8")
     )
-    command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-    payload = json.dumps(
-        {"tool_name": "Write", "tool_input": {"file_path": "secrets/.env"}}
-    )
+    payload = {"tool_name": "Write", "tool_input": {"file_path": "secrets/.env"}}
 
-    result = subprocess.run(
-        command,
-        input=payload,
-        text=True,
-        capture_output=True,
-        shell=True,
-        env={**os.environ, "CLAUDE_PROJECT_DIR": str(linked_repo)},
-        check=False,
-    )
+    result = run_registered_hook(settings, spaced_repo, payload)
 
     assert result.returncode == 2
     assert "BLOCKED" in result.stderr

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -172,9 +172,11 @@ def hook_path_from_registered_command(settings, project_dir):
     expected_command = '"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-sensitive-files.py"'
     assert command == expected_command
 
-    relative_hook_path = expected_command.strip('"').removeprefix(
-        "$CLAUDE_PROJECT_DIR/"
-    )
+    command_path = expected_command.strip('"')
+    project_dir_prefix = "$CLAUDE_PROJECT_DIR/"
+    assert command_path.startswith(project_dir_prefix)
+
+    relative_hook_path = command_path[len(project_dir_prefix) :]
     return project_dir / Path(relative_hook_path)
 
 

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -167,16 +167,19 @@ def registered_hook_command(settings):
     return settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
 
 
+def strip_claude_project_dir_prefix(command_path):
+    project_dir_prefix = "$CLAUDE_PROJECT_DIR/"
+    assert command_path.startswith(project_dir_prefix)
+    return command_path[len(project_dir_prefix) :]
+
+
 def hook_path_from_registered_command(settings, project_dir):
     command = registered_hook_command(settings)
     expected_command = '"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-sensitive-files.py"'
     assert command == expected_command
 
     command_path = expected_command.strip('"')
-    project_dir_prefix = "$CLAUDE_PROJECT_DIR/"
-    assert command_path.startswith(project_dir_prefix)
-
-    relative_hook_path = command_path[len(project_dir_prefix) :]
+    relative_hook_path = strip_claude_project_dir_prefix(command_path)
     return project_dir / Path(relative_hook_path)
 
 


### PR DESCRIPTION
### Motivation
- The registered-hook smoke tests executed the configured command with `shell=True`, which does not portably expand `"$CLAUDE_PROJECT_DIR/..."` under Windows `cmd.exe` and causes CI failures on `windows-latest` runners.
- The previous spaces-in-path fixture used a directory symlink which is not reliable/available on Windows without elevated permissions, so the test needed a portable alternative.

### Description
- Replace executing the settings `command` via `shell=True` with a portable invocation using `sys.executable` and a resolved `Path` to the hook by adding helper functions `registered_hook_command`, `hook_path_from_registered_command`, and `run_registered_hook` in the test file.
- Change the spaces-in-path fixture from creating a symlink to copying the `.claude` directory with `shutil.copytree` so the test works on Windows where symlink creation may be restricted.
- Update imports in `tests/test_protect_sensitive_files_hook.py` (add `shutil`) and adjust the smoke tests to pass JSON payloads directly to the helper, preserving the original assertions about return code and stderr.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_protect_sensitive_files_hook.py`, which passed.
- Performed editable install with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest`, which completed successfully.
- Ran the full suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, which still fails due to an existing unrelated test (`tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check`) that mocks `builtins.open` and causes a `gettext`/`argparse` initialization error; this is unrelated to the hook test changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca8e89acc8320a35199119cf5549e)