### PR TITLE
ci: gate Gemini action on API key env

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,19 +17,21 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      secrets.GEMINI_API_KEY != '' &&
-      ((github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request') ||
        ((github.event_name == 'pull_request_review_comment' ||
          (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
         contains(github.event.comment.body, '@gemini-code-assist') &&
         (github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'COLLABORATOR')))
+         github.event.comment.author_association == 'COLLABORATOR'))
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
+        if: env.GEMINI_API_KEY != ''
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_api_key: ${{ env.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -25,13 +25,13 @@ jobs:
          github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'COLLABORATOR'))
     env:
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      HAS_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != ''
+        if: env.HAS_GEMINI_API_KEY == 'true'
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
-          gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
### Motivation

- The workflow referenced `secrets.GEMINI_API_KEY` inside a `jobs.<job_id>.if` expression, which is invalid because GitHub does not expose the `secrets` context there. 
- The change ensures fork PRs and untrusted comment triggers do not cause the job to fail or accidentally surface secrets while still allowing trusted runs to use the secret.

### Description

- Remove `secrets.GEMINI_API_KEY` from the job-level `if` and keep the job gate limited to allowed `github` event/comment contexts in ` .github/workflows/gemini-code-assist.yml`. 
- Expose the secret at job scope via `env: GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}` so steps can read it. 
- Gate the Gemini step with `if: env.GEMINI_API_KEY != ''` and pass the credential to the action with `gemini_api_key: ${{ env.GEMINI_API_KEY }}` so only the step is skipped when the key is missing.

### Testing

- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/gemini-code-assist.yml` and the workflow lint passed. 
- Ran `git diff --check` and there were no diff/whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca8ed6dbc8320aa4a26a9af49712c)