### PR TITLE
Configure Gemini Code Assist core tools

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -29,3 +29,10 @@ jobs:
           fetch-depth: 0
       - name: Gemini Code Assist
         uses: google-gemini/code-assist-action@v1
+        with:
+          settings: |-
+            {
+              "tools": {
+                "core": []
+              }
+            }

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -38,3 +38,9 @@ jobs:
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          settings: |-
+            {
+              "tools": {
+                "exclude": ["run_shell_command(rm)"]
+              }
+            }


### PR DESCRIPTION
### Motivation
- Disable the Gemini Code Assist action's built-in core tools by explicitly setting `tools.core` to an empty array in the action `settings` so the runner uses only configured tools.

### Description
- Added a `with: settings` block to the `google-gemini/code-assist-action@v1` step in `.github/workflows/gemini-code-assist.yml` containing JSON `{ "tools": { "core": [] } }`.

### Testing
- Verified the workflow file is valid YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'` and it succeeded.
- Verified the `settings` payload parses as JSON with `ruby -r yaml -r json -e 'data = YAML.load_file(".github/workflows/gemini-code-assist.yml"); step = data.fetch("jobs").fetch("gemini-code-assist").fetch("steps").last; JSON.parse(step.fetch("with").fetch("settings")); puts "settings JSON OK"'` and it succeeded.
- Ran `git diff --check` to ensure no patch/format issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb29721b08320bc4d9aabc3958743)