### PR TITLE
Restrict Flask skip in app tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,12 +1,11 @@
 import os
-import pytest
 from unittest.mock import patch
 
-try:
-    import flask
-    from html2md.app import app, get_host_port
-except ImportError:
-    pytest.skip("Flask is not installed", allow_module_level=True)
+import pytest
+
+pytest.importorskip("flask")
+
+from html2md.app import DEFAULT_PORT, app, get_host_port
 
 
 @pytest.fixture
@@ -28,7 +27,7 @@ def test_health_endpoint(client):
 def test_get_host_port_defaults():
     host, port = get_host_port()
     assert host == "0.0.0.0"
-    assert port == 10000
+    assert port == DEFAULT_PORT
 
 
 @patch.dict(os.environ, {"HOST": "127.0.0.1", "PORT": "8080"}, clear=True)
@@ -42,7 +41,7 @@ def test_get_host_port_custom():
 def test_get_host_port_invalid_port(capsys):
     host, port = get_host_port()
     assert host == "0.0.0.0"
-    assert port == 10000
+    assert port == DEFAULT_PORT
 
     captured = capsys.readouterr()
     assert "Warning: Invalid PORT environment variable value" in captured.out

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,19 @@
+import importlib
 import os
 from unittest.mock import patch
 
 import pytest
 
-pytest.importorskip("flask")
+
+try:
+    importlib.import_module("flask")
+except ModuleNotFoundError as exc:
+    if exc.name == "flask":
+        pytest.skip(
+            "could not import 'flask': No module named 'flask'",
+            allow_module_level=True,
+        )
+    raise
 
 from html2md.app import DEFAULT_PORT, app, get_host_port
 


### PR DESCRIPTION
### Motivation
- Prevent masking import errors in `html2md.app` by limiting module-level test skipping to the absence of Flask only.
- Remove hard-coded magic numbers in tests by reusing application constants for maintainability.

### Description
- Replace the broad `try/except ImportError` guard with `pytest.importorskip("flask")` so only missing Flask causes the module to be skipped, and import `html2md.app` after that check. (file: `tests/test_app.py`)
- Import `DEFAULT_PORT` from `html2md.app` and replace literal `10000` assertions with `DEFAULT_PORT` to avoid magic numbers. (file: `tests/test_app.py`)
- Ensure the Flask `app` and `get_host_port` are imported only after confirming Flask is present, so application import regressions surface as failures rather than silent skips. (file: `tests/test_app.py`)

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pip install -e '.[deploy]' pytest` which completed successfully and installed `flask` for tests. (succeeded)
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_app.py -q` which executed the new app tests and passed. (succeeded)
- Ran the full suite with `PYENV_VERSION=3.12.13 python -m pytest -q` which exposed an existing unrelated failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by its mocked `open` interfering with `gettext` parsing; this is unrelated to the app test changes. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccb610eb48320b8f2c359d679cee5)