### PR TITLE
ci: remove unnecessary PR write permission from Request Jules Review workflow

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- Limit the `GITHUB_TOKEN` privileges for the Request Jules Review workflow because the job only posts a comment via the Issues API and does not require `pull-requests: write`.

### Description
- Remove the `pull-requests: write` permission from `.github/workflows/request-jules-review.yml`, retaining `issues: write` which is sufficient to post the review-request comment.

### Testing
- Ran `git diff --check` after the change and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccb30bc0083208258c9b2bde1cbed)