### PR TITLE
ci: allow Gemini Code Assist review lifecycle tools

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -96,7 +96,9 @@ jobs:
                     "ghcr.io/github/github-mcp-server@sha256:a1d43076a36638ee24520fd6e83c3905ae41bc9850179081df1de2ba3a7afae0"
                   ],
                   "includeTools": [
+                    "create_pending_pull_request_review",
                     "add_comment_to_pending_review",
+                    "submit_pending_pull_request_review",
                     "pull_request_read",
                     "pull_request_review_write"
                   ],


### PR DESCRIPTION
### Motivation

- Ensure the `/pr-code-review` extension can complete the full review lifecycle and that the Gemini action receives PR context so the extension can target the correct pull request across supported triggers.

### Description

- Add `create_pending_pull_request_review` and `submit_pending_pull_request_review` to the `includeTools` list in `.github/workflows/gemini-code-assist.yml` and verify the action exposes `REPOSITORY` and `PULL_REQUEST_NUMBER` in its `env` so the extension can resolve the PR target.

### Testing

- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'yaml ok'"`, `ruby -rjson -ryaml -e "wf=YAML.load_file('.github/workflows/gemini-code-assist.yml'); settings=wf.fetch('jobs').fetch('gemini-code-assist').fetch('steps').last.fetch('with').fetch('settings'); JSON.parse(settings); puts 'settings json ok'"`, and `git diff --check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd3c8bbb8832083fb6d4e2c172f15)