### PR TITLE
Harden claude-agent workflow triggers and disable persisted checkout credentials

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: anthropics/claude-code-action@7e002f01d5b4d1b510ebbd44a1a0c0acbf339d4e # v1
         with:

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: anthropics/claude-code-action@7e002f01d5b4d1b510ebbd44a1a0c0acbf339d4e # v1
         with:

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -17,9 +17,7 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR') &&
        (contains(github.event.comment.body, '@claude-agent') ||
         contains(github.event.comment.body, '@claude[bot]') ||
-        contains(github.event.comment.body, '@codex[agent]') ||
-        contains(github.event.comment.body, '@Claude') ||
-        contains(github.event.comment.body, '@claude')))
+        contains(github.event.comment.body, '@codex[agent]')))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: anthropics/claude-code-action@7e002f01d5b4d1b510ebbd44a1a0c0acbf339d4e # v1
         with:

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -11,7 +11,8 @@ jobs:
   run-claude-agent:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      ((github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+      ((github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
        (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR') &&


### PR DESCRIPTION
### Motivation
- The workflow allowed MEMBER/COLLABORATOR/OWNER comments containing the broad `@claude` substring to run a write-capable agent and expose writable tokens and raw comment context.

### Description
- Narrow the issue-comment trigger in `.github/workflows/claude-agent.yml` to explicit agent mentions (`@claude-agent`, `@claude[bot]`, `@codex[agent]`) and set `persist-credentials: false` on the `actions/checkout@v4` step so the workflow token is not left in the repo Git config.

### Testing
- Verified the change with `python3` static assertions to confirm triggers and `persist-credentials: false`, validated the workflow with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/claude-agent.yml`, and checked the agent script syntax with `bash -n .github/scripts/run_claude_agent.sh`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc23241d883208a18bc851ad1b6ef)