### PR TITLE
Fix PowerShell command injection in GUI launcher

### DIFF
--- a/run-gui.bat
+++ b/run-gui.bat
@@ -9,11 +9,11 @@ if not exist "%SCRIPT_DIR%gui-url-convert.ps1" (
     exit /b 1
 )
 
-REM Launch PowerShell. Use Set-Location to handle paths with '&'.
+REM Launch PowerShell with -File so script and argument paths are data, not code.
 if "%~1"=="" (
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -Command "Set-Location -LiteralPath '%SCRIPT_DIR%'; & '.\gui-url-convert.ps1'"
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File "%SCRIPT_DIR%gui-url-convert.ps1"
 ) else (
     echo [INFO] Batch processing file: "%~1"
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -Command "Set-Location -LiteralPath '%SCRIPT_DIR%'; & '.\gui-url-convert.ps1' -BatchFile '%~1'"
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File "%SCRIPT_DIR%gui-url-convert.ps1" -BatchFile "%~1"
 )
 pause

--- a/tests/test_gui_launcher_security.py
+++ b/tests/test_gui_launcher_security.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_gui_launcher_uses_file_mode_for_paths() -> None:
-    launcher = (ROOT / "run-gui.bat").read_text()
+    launcher = (ROOT / "run-gui.bat").read_text(encoding="utf-8")
 
     assert "-Command" not in launcher
     assert '-File "%SCRIPT_DIR%gui-url-convert.ps1"' in launcher

--- a/tests/test_gui_launcher_security.py
+++ b/tests/test_gui_launcher_security.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_gui_launcher_uses_file_mode_for_paths() -> None:
+    launcher = (ROOT / "run-gui.bat").read_text()
+
+    assert "-Command" not in launcher
+    assert '-File "%SCRIPT_DIR%gui-url-convert.ps1"' in launcher
+    assert "Set-Location -LiteralPath '%SCRIPT_DIR%'" not in launcher


### PR DESCRIPTION
### Motivation
- Prevent a local PowerShell command-injection vector where the launcher interpolated `%SCRIPT_DIR%` into a `-Command` string; the intent is to ensure paths are passed as data rather than reinterpreted as PowerShell code.

### Description
- Replace the `-Command` invocation in `run-gui.bat` with `-File` so the GUI script path and `-BatchFile` argument are passed as arguments instead of embedded code, eliminating single-quote escape issues.
- Add `tests/test_gui_launcher_security.py` to assert `-Command`/`Set-Location` interpolation is not present and that `-File "%SCRIPT_DIR%gui-url-convert.ps1"` is used.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_gui_launcher_security.py` and the new regression test passed (1 passed).
- Ran full test suite with `PYENV_VERSION=3.11.15 python -m pytest`; the suite reported one unrelated failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by a test-time `builtins.open` mock interfering with Python `gettext` during `argparse` initialization, so the failure is not caused by these launcher changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb4d0f2b08320a1e1f1338032612b)