### PR TITLE
Fix PowerShell argument injection in GUI launcher

### DIFF
--- a/run-gui.bat
+++ b/run-gui.bat
@@ -9,11 +9,12 @@ if not exist "%SCRIPT_DIR%gui-url-convert.ps1" (
     exit /b 1
 )
 
-REM Launch PowerShell. Use Set-Location to handle paths with '&'.
+REM Launch PowerShell with -File so batch file paths are passed as arguments,
+REM not interpolated into a PowerShell command string.
 if "%~1"=="" (
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -Command "Set-Location -LiteralPath '%SCRIPT_DIR%'; & '.\gui-url-convert.ps1'"
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File "%SCRIPT_DIR%gui-url-convert.ps1"
 ) else (
     echo [INFO] Batch processing file: "%~1"
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -Command "Set-Location -LiteralPath '%SCRIPT_DIR%'; & '.\gui-url-convert.ps1' -BatchFile '%~1'"
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File "%SCRIPT_DIR%gui-url-convert.ps1" -BatchFile "%~1"
 )
 pause

--- a/tests/test_run_gui_security.py
+++ b/tests/test_run_gui_security.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_GUI = REPO_ROOT / "run-gui.bat"
+
+
+def test_run_gui_passes_batch_file_argument_without_powershell_command_interpolation():
+    contents = RUN_GUI.read_text(encoding="utf-8")
+
+    assert "-File \"%SCRIPT_DIR%gui-url-convert.ps1\" -BatchFile \"%~1\"" in contents
+    assert "-Command" not in contents
+    assert "-BatchFile '%~1'" not in contents


### PR DESCRIPTION
### Motivation
- The existing `run-gui.bat` inserted the caller-controlled `%~1` path directly into a PowerShell `-Command` single-quoted string, allowing a crafted filename containing a single quote and PowerShell separators to inject arbitrary commands. 
- This change removes the string interpolation attack surface while preserving the batch-file/GUI integration and drag-and-drop usage.

### Description
- Replace PowerShell `-Command` invocation in `run-gui.bat` with `-File` so the GUI script is executed by path and the optional batch-file path is passed as a quoted argument instead of being interpolated into a command string. 
- Ensure both no-argument and batch-file branches use `-File "%SCRIPT_DIR%gui-url-convert.ps1"` and pass `-BatchFile "%~1"` when applicable. 
- Add `tests/test_run_gui_security.py` which asserts the launcher uses `-File`, does not contain `-Command`, and does not interpolate `-BatchFile '%~1'` into a PowerShell command string.

### Testing
- Ran the new regression test with `PYENV_VERSION=3.12.13 python -m pytest tests/test_run_gui_security.py`, which passed. 
- Ran the full test suite with `LC_ALL=C LANGUAGE=C PYENV_VERSION=3.12.13 python -m pytest`, which completed successfully (`21 passed`).
- The fix is minimal, preserves intended behavior, and the regression test prevents reintroduction of the vulnerable interpolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc6b22c2483208376f83b8bbeab58)