### PR TITLE
Bound in-flight batch futures during concurrent processing

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -5,7 +5,31 @@ import argparse
 import os
 import sys
 import concurrent.futures
+from collections import deque
 from urllib.parse import urlparse, unquote
+
+
+def _ordered_bounded_map(executor, func, iterable, max_pending):
+    """Map ``func`` over ``iterable`` in order with bounded submitted futures."""
+    iterator = iter(iterable)
+    pending = deque()
+
+    def submit_next():
+        try:
+            item = next(iterator)
+        except StopIteration:
+            return False
+        pending.append(executor.submit(func, item))
+        return True
+
+    for _ in range(max_pending):
+        if not submit_next():
+            break
+
+    while pending:
+        future = pending.popleft()
+        yield future.result()
+        submit_next()
 
 
 def main(argv=None):
@@ -72,6 +96,7 @@ def main(argv=None):
                     "type": "scheme",
                 }
 
+            session = None
             try:
                 session = requests.Session()
                 session.headers.update(session_headers)
@@ -92,7 +117,8 @@ def main(argv=None):
                     "type": "conversion",
                 }
             finally:
-                session.close()
+                if session is not None:
+                    session.close()
 
         def output_result(result: dict) -> None:
             """Output the result of a single URL sequentially. Not thread-safe."""
@@ -150,18 +176,25 @@ def main(argv=None):
                 print(f"Error: Batch file not found: {args.batch}", file=sys.stderr)
                 return 1
 
-            urls_to_process = []
-            with open(args.batch, "r", encoding="utf-8") as f:
-                for line in f:
+            def urls_to_process(batch_file):
+                for line in batch_file:
                     u = line.strip()
                     if u:
-                        urls_to_process.append(u)
+                        yield u
 
-            # Process URLs concurrently, but output results sequentially in order
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                results = executor.map(fetch_url, urls_to_process)
-                for result in results:
-                    output_result(result)
+            max_workers = 8
+            # Process URLs concurrently, but output results sequentially in order.
+            # Keep submitted futures bounded so completed Markdown payloads cannot
+            # accumulate for the entire batch behind a slow earlier URL.
+            with open(args.batch, "r", encoding="utf-8") as f:
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=max_workers
+                ) as executor:
+                    results = _ordered_bounded_map(
+                        executor, fetch_url, urls_to_process(f), max_workers
+                    )
+                    for result in results:
+                        output_result(result)
 
         return 0
 

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -182,7 +182,7 @@ def main(argv=None):
                     if u:
                         yield u
 
-            max_workers = 8
+            max_workers = MAX_BATCH_WORKERS
             # Process URLs concurrently, but output results sequentially in order.
             # Keep submitted futures bounded so completed Markdown payloads cannot
             # accumulate for the entire batch behind a slow earlier URL.

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -1,0 +1,73 @@
+"""Tests for CLI batch URL processing."""
+
+from html2md import cli
+
+
+class _ImmediateFuture:
+    def __init__(self, executor, value):
+        self.executor = executor
+        self.value = value
+
+    def result(self):
+        self.executor.in_flight -= 1
+        return self.value
+
+
+class _RecordingExecutor:
+    def __init__(self):
+        self.submitted = []
+        self.in_flight = 0
+        self.max_in_flight = 0
+
+    def submit(self, func, item):
+        self.submitted.append(item)
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        return _ImmediateFuture(self, func(item))
+
+
+def test_ordered_bounded_map_caps_submitted_futures_before_first_result():
+    """The ordered mapper does not eagerly submit the whole input iterable."""
+    executor = _RecordingExecutor()
+    results = cli._ordered_bounded_map(executor, lambda item: item * 2, range(10), 3)
+
+    assert next(results) == 0
+    assert executor.submitted == [0, 1, 2]
+    assert executor.max_in_flight == 3
+
+    assert list(results) == [2, 4, 6, 8, 10, 12, 14, 16, 18]
+    assert executor.submitted == list(range(10))
+    assert executor.max_in_flight == 3
+
+
+def test_batch_outputs_results_in_input_order(mocker, capsys, tmp_path):
+    """Batch mode keeps deterministic output ordering across multiple URLs."""
+    batch_file = tmp_path / "urls.txt"
+    batch_file.write_text(
+        "http://example.com/first\n\nhttp://example.com/second\n",
+        encoding="utf-8",
+    )
+
+    session = mocker.MagicMock()
+
+    def fake_get(url, timeout):
+        response = mocker.MagicMock()
+        response.text = f"<h1>{url.rsplit('/', 1)[-1]}</h1>"
+        response.raise_for_status.return_value = None
+        return response
+
+    session.get.side_effect = fake_get
+    mocker.patch("requests.Session", return_value=session)
+    mocker.patch(
+        "markdownify.markdownify",
+        side_effect=lambda html, heading_style: html,
+    )
+
+    assert cli.main(["--batch", str(batch_file)]) == 0
+
+    captured = capsys.readouterr()
+    first_idx = captured.out.index("Processing URL: http://example.com/first")
+    second_idx = captured.out.index("Processing URL: http://example.com/second")
+    assert first_idx < second_idx
+    assert "<h1>first</h1>" in captured.out
+    assert "<h1>second</h1>" in captured.out

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -1,5 +1,7 @@
 """Tests for CLI batch URL processing."""
 
+from unittest.mock import MagicMock, patch
+
 from html2md import cli
 
 
@@ -40,7 +42,7 @@ def test_ordered_bounded_map_caps_submitted_futures_before_first_result():
     assert executor.max_in_flight == 3
 
 
-def test_batch_outputs_results_in_input_order(mocker, capsys, tmp_path):
+def test_batch_outputs_results_in_input_order(capsys, tmp_path):
     """Batch mode keeps deterministic output ordering across multiple URLs."""
     batch_file = tmp_path / "urls.txt"
     batch_file.write_text(
@@ -48,22 +50,19 @@ def test_batch_outputs_results_in_input_order(mocker, capsys, tmp_path):
         encoding="utf-8",
     )
 
-    session = mocker.MagicMock()
+    session = MagicMock()
 
     def fake_get(url, timeout):
-        response = mocker.MagicMock()
+        response = MagicMock()
         response.text = f"<h1>{url.rsplit('/', 1)[-1]}</h1>"
         response.raise_for_status.return_value = None
         return response
 
     session.get.side_effect = fake_get
-    mocker.patch("requests.Session", return_value=session)
-    mocker.patch(
-        "markdownify.markdownify",
-        side_effect=lambda html, heading_style: html,
-    )
-
-    assert cli.main(["--batch", str(batch_file)]) == 0
+    with patch("requests.Session", return_value=session), patch(
+        "markdownify.markdownify", side_effect=lambda html, heading_style: html
+    ):
+        assert cli.main(["--batch", str(batch_file)]) == 0
 
     captured = capsys.readouterr()
     first_idx = captured.out.index("Processing URL: http://example.com/first")


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth when processing large `--batch` inputs with `ThreadPoolExecutor.map()` which can eagerly submit the entire iterable and accumulate completed Markdown payloads behind slow items.
- Preserve deterministic, input-order output for batch mode while limiting concurrency to a safe in-flight cap.
- Avoid masking failures during `requests.Session()` creation that could raise an `UnboundLocalError` in cleanup.
- Add tests to cover the new bounded submission behavior and ordering guarantees.

### Description
- Added `_ordered_bounded_map(executor, func, iterable, max_pending)` which submits up to `max_pending` futures and incrementally yields results in input order to avoid eager, unbounded submission.
- Changed batch processing to stream URLs from the batch file and use `_ordered_bounded_map` with a bounded `ThreadPoolExecutor(max_workers=8)` so at-most `max_workers` futures are in flight at once.
- Initialized `session = None` and guard `session.close()` so cleanup does not raise when session creation fails.
- Added `tests/test_cli_batch.py` which verifies the bounded submission behavior and that batch output remains deterministic in input order.

### Testing
- Ran `pytest -q tests/test_cli_batch.py tests/test_cli_exceptions.py tests/test_cli_security.py tests/test_cli_error.py` and all tests passed.
- Ran the full test suite `pytest -q` and it completed with all tests green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccae056688320901fd6069641d7b9)