### PR TITLE
Clarify Gemini PR review context wiring

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -34,6 +34,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
+          # The code-review extension expands PULL_REQUEST_NUMBER, while
+          # run-gemini-cli exposes GH_PR_NUMBER to its own runtime. Keep both
+          # populated from the same event expression for automatic PR and
+          # trusted comment-triggered reviews.
+          GH_PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
@@ -41,6 +46,8 @@ jobs:
           prompt: '/pr-code-review'
           extensions: |
             ["https://github.com/gemini-cli-extensions/code-review"]
+          # Enable the GitHub MCP tools required by the /pr-code-review
+          # extension so Gemini can fetch the diff and submit a pending review.
           settings: |-
             {
               "mcpServers": {


### PR DESCRIPTION
### Motivation
- Ensure the `run-gemini-cli` action runtime and the `/pr-code-review` extension receive the expected PR-number environment so Gemini can load PR context and operate end-to-end. 
- Make explicit in-workflow documentation that the `settings` block enables the GitHub MCP tools required for the code-review extension to fetch diffs and post pending reviews.

### Description
- Export `GH_PR_NUMBER` in the `Gemini Code Assist` step's `env` alongside the existing `PULL_REQUEST_NUMBER`, both populated from the same PR/comment event expression. 
- Add inline comments explaining why both variables are present and that the `settings` block enables the GitHub MCP server/tools used by `/pr-code-review`.
- No behavioural changes to gating/permissions or other steps are made; the change is limited to environment wiring and documentation in the workflow file `.github/workflows/gemini-code-assist.yml`.

### Testing
- Validated the modified workflow is syntactically valid YAML using `python3.12` with `yaml.safe_load(...)`, which succeeded. 
- Ran `git diff --check` to ensure there are no whitespace/format issues in the diff, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccabeaf8c8320930dacae0aa57a84)