### PR TITLE
Normalize IDNA hosts for DNS pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "pillow>=9.0.0",
   "pyyaml>=6.0",
   "anthropic>=0.39.0",
+  "idna>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -90,7 +90,16 @@ def main(argv=None):
             try:
                 return normalized.encode('ascii').decode('ascii')
             except UnicodeEncodeError:
-                import idna  # pylint: disable=import-outside-toplevel
+                try:
+                    import idna  # pylint: disable=import-outside-toplevel
+                except ImportError:
+                    print(
+                        "Error: Missing dependency 'idna' required for "
+                        "internationalized domain names. "
+                        "Please reinstall the package: pip install --upgrade html2md-cli",
+                        file=sys.stderr,
+                    )
+                    raise
 
                 return idna.encode(
                     normalized, strict=True, std3_rules=True

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -78,6 +78,24 @@ def main(argv=None):
                     ip_obj.is_link_local or ip_obj.is_unspecified or
                     ip_obj.is_reserved or ip_obj.is_multicast)
 
+        def _normalize_hostname(hostname):
+            """Return the canonical form used for DNS validation and pinning."""
+            normalized = hostname.rstrip('.').lower()
+            try:
+                ipaddress.ip_address(normalized)
+                return normalized
+            except ValueError:
+                pass
+
+            try:
+                return normalized.encode('ascii').decode('ascii')
+            except UnicodeEncodeError:
+                import idna  # pylint: disable=import-outside-toplevel
+
+                return idna.encode(
+                    normalized, strict=True, std3_rules=True
+                ).decode('ascii')
+
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""
             parsed = urlparse(target_url)
@@ -91,6 +109,12 @@ def main(argv=None):
                 print("Error: Invalid URL.", file=sys.stderr)
                 return None
 
+            try:
+                dns_hostname = _normalize_hostname(hostname)
+            except UnicodeError as e:
+                print(f"Error: Invalid IDNA hostname: {e}", file=sys.stderr)
+                return None
+
             port = _url_port(parsed)
             if port is None:
                 return None
@@ -100,7 +124,7 @@ def main(argv=None):
                 # The approved DNS answers are returned and pinned for the
                 # matching request so a second lookup cannot rebind to an
                 # internal address after validation.
-                addr_info = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+                addr_info = socket.getaddrinfo(dns_hostname, port, type=socket.SOCK_STREAM)
                 if not addr_info:
                     print("Error: Hostname did not resolve to any addresses.", file=sys.stderr)
                     return None
@@ -114,16 +138,20 @@ def main(argv=None):
                 print(f"Error validating hostname: {e}", file=sys.stderr)
                 return None
 
-            return hostname, port, addr_info
+            return dns_hostname, port, addr_info
 
         @contextmanager
         def _pin_validated_dns(hostname, port, addr_info):
             """Pin requests DNS resolution to the already-validated answers."""
             original_getaddrinfo = socket.getaddrinfo
-            pinned_hostname = hostname.rstrip('.').lower()
+            pinned_hostname = _normalize_hostname(hostname)
 
             def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
-                if host and host.rstrip('.').lower() == pinned_hostname:
+                try:
+                    requested_hostname = _normalize_hostname(host) if host else None
+                except UnicodeError:
+                    requested_hostname = host.rstrip('.').lower() if host else None
+                if requested_hostname == pinned_hostname:
                     resolved_port = requested_port if requested_port is not None else port
                     pinned = []
                     for family_, type_, proto_, canonname, sockaddr in addr_info:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -126,6 +126,42 @@ def test_validated_dns_answer_is_pinned_during_fetch(mock_get, mock_getaddrinfo,
     )
 
 
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_idna_hostname_is_normalized_for_dns_pinning(mock_get, mock_getaddrinfo, capsys):
+    """Unicode hostnames are pinned with the same IDNA form used by requests."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>IDNA Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_idna_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo(
+            "xn--fa-hia.example", 80, type=socket.SOCK_STREAM
+        )
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_idna_pinned_dns
+
+    cli.main(["--url", "http://faß.example/"])
+
+    outerr = capsys.readouterr()
+    assert "# IDNA Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "xn--fa-hia.example", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://faß.example/", timeout=30, allow_redirects=False
+    )
+
+
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):


### PR DESCRIPTION
### Motivation

- Prevent an SSRF bypass where an internationalized (non-ASCII) hostname could be validated in its Unicode form but resolved by `requests` in its IDNA/punycode form, allowing a DNS rebind between validation and connection.
- Ensure the same canonical hostname form is used for both validation lookups and pinned lookups so validated DNS answers cannot be bypassed by IDN encoding differences.

### Description

- Add `_normalize_hostname` helper that canonicalizes hostnames to a lowercase ASCII or IDNA/punycode form and preserves IP literals unchanged (file `src/html2md/cli.py`).
- Use the normalized `dns_hostname` for `socket.getaddrinfo` during validation and return `dns_hostname` so downstream DNS pinning compares and pins the same form used by `requests` (file `src/html2md/cli.py`).
- Update the DNS-pinning context to normalize incoming `host` values before comparing against the pinned hostname and handle Unicode/IDNA errors robustly (file `src/html2md/cli.py`).
- Add a regression test that verifies an IDN hostname (e.g., `faß.example`) is normalized to its `requests`/IDNA form and that the validated DNS answers are pinned and used during fetch (file `tests/test_cli_security.py`).

### Testing

- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` and the security tests passed (`13 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` and all tests passed (`29 passed`).
- Ran `git diff --check` equivalent validations during the run and no check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccabb98688320bdd3dd5d73472e1e)