### PR TITLE
Fix self-heal workflow checkout and repo checks

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -24,29 +24,48 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
-      - name: Install deps (best-effort frozen)
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Node deps (best-effort frozen)
         id: install_try_frozen
         run: |
           set -euxo pipefail
-          pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          else
+            pnpm install --lockfile=false
+          fi || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
 
-      - name: Install deps (fallback non-frozen)
+      - name: Install Node deps (fallback non-frozen)
         if: steps.install_try_frozen.outputs.FROZEN_FAILED == '1'
         run: |
           set -euxo pipefail
-          pnpm install
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install
+          else
+            pnpm install --lockfile=false
+          fi
+
+      - name: Install Python deps
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,7 +16,10 @@ jobs:
   self-heal:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+      (
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+
+# Node
+node_modules/

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
-    "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
-    "format": "prettier -w .",
-    "typecheck": "tsc -b",
-    "test": "vitest run"
+    "self:heal": "node scripts/self-heal.mjs"
   }
 }

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -31,7 +31,7 @@ try {
   tryRun("Build", hasScript("build") ? "pnpm run build" : null);
 
   // Native Python project checks.
-  tryRun("Python tests", existsSync("pyproject.toml") && existsSync("tests") ? "python3 -m pytest" : null);
+  tryRun("Python tests", existsSync("pyproject.toml") && existsSync("tests") ? "python -m pytest" : null);
 
   process.exit(0);
 } catch (e) {

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Repository healthcheck used by the self-heal workflow.
+   Run checks only when this repository is configured for them; do not assume
+   a pnpm workspace or a TypeScript project exists.
 */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 
 const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
+const readPackageJson = () => {
+  if (!existsSync("package.json")) return {};
+  return JSON.parse(readFileSync("package.json", "utf8"));
 };
+const packageJson = readPackageJson();
+const scripts = packageJson.scripts ?? {};
+const hasScript = (name) => Object.prototype.hasOwnProperty.call(scripts, name);
+const hasTypeScriptConfig = () => existsSync("tsconfig.json") || existsSync("jsconfig.json");
 
 const tryRun = (name, cmd) => {
   if (!cmd) return;
@@ -23,27 +23,17 @@ const tryRun = (name, cmd) => {
 };
 
 try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+  // JavaScript checks are opt-in and run at the package root. This repository
+  // is not a pnpm workspace, so avoid workspace-only flags such as `-w`.
+  tryRun("Typecheck", hasScript("typecheck") && hasTypeScriptConfig() ? "pnpm run typecheck" : null);
+  tryRun("Lint", hasScript("lint") ? "pnpm run lint" : null);
+  tryRun("Unit tests", hasScript("test") ? "pnpm run test" : null);
+  tryRun("Build", hasScript("build") ? "pnpm run build" : null);
 
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
-    }
-  }
-  process.exit(process.exitCode ?? 0);
+  // Native Python project checks.
+  tryRun("Python tests", existsSync("pyproject.toml") && existsSync("tests") ? "python3 -m pytest" : null);
+
+  process.exit(0);
 } catch (e) {
   console.error(e);
   process.exit(1);

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -3,13 +3,13 @@
    Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
 */
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
-const sh = (cmd, opts={}) => {
+const sh = (cmd, opts = {}) => {
   console.log(`\n$ ${cmd}`);
   return execSync(cmd, { stdio: "inherit", ...opts });
 };
-const trySh = (cmd, opts={}) => {
+const trySh = (cmd, opts = {}) => {
   try { sh(cmd, opts); return true; } catch { return false; }
 };
 const changed = () => {
@@ -19,40 +19,48 @@ const changed = () => {
 const passHealth = () => {
   try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
 };
+const readPackageJson = () => {
+  if (!existsSync("package.json")) return {};
+  return JSON.parse(readFileSync("package.json", "utf8"));
+};
+const scripts = readPackageJson().scripts ?? {};
+const hasScript = (name) => Object.prototype.hasOwnProperty.call(scripts, name);
+const hasTypeScriptConfig = () => existsSync("tsconfig.json") || existsSync("jsconfig.json");
 
 let fixed = false;
 
-// 1) Lint/format
-trySh("pnpm -w run lint --fix");
-trySh("pnpm -w run format");
+// 1) Lint/format. This repository is not a pnpm workspace, so use root package
+// scripts directly when they exist rather than workspace-only `pnpm -w` flags.
+if (hasScript("lint")) trySh("pnpm run lint -- --fix");
+if (hasScript("format")) trySh("pnpm run format");
 if (passHealth()) fixed = fixed || changed();
 
-// 2) Snapshot updates (only if tests fail with snapshots)
-if (!passHealth()) {
-  trySh("pnpm -w exec vitest -u");
+// 2) Snapshot updates (only when a Vitest-backed test script is configured).
+if (!passHealth() && hasScript("test") && /vitest/.test(scripts.test)) {
+  trySh("pnpm exec vitest -u");
   if (passHealth()) fixed = fixed || changed();
 }
 
-// 3) Type acquisition
-if (!passHealth()) {
+// 3) Type acquisition (only for actual TypeScript projects).
+if (!passHealth() && hasScript("typecheck") && hasTypeScriptConfig()) {
   trySh("pnpm dlx typesync --save-dev");
   // In case typesync suggests @types/node et al.
-  trySh("pnpm -w install");
+  trySh("pnpm install");
   if (passHealth()) fixed = fixed || changed();
 }
 
-// 4) Lockfile repair (only if integrity complaints)
-if (!passHealth()) {
-  // Try a clean install + re-resolve
+// 4) Lockfile repair (only when this repository already tracks a pnpm lockfile).
+if (!passHealth() && existsSync("pnpm-lock.yaml")) {
+  // Try a clean install + re-resolve.
   trySh("pnpm install");
   if (!passHealth()) {
-    // Last resort: refresh lockfile (scoped)
-    trySh("pnpm -w up --latest --interactive=false");
+    // Last resort: refresh lockfile (scoped to the root package).
+    trySh("pnpm up --latest --interactive=false");
   }
   if (passHealth()) fixed = fixed || changed();
 }
 
-// 5) Known generators (icons/docs), if present
+// 5) Known generators (icons/docs), if present.
 if (!passHealth()) {
   if (existsSync("scripts/update-icon-docs.mjs")) {
     trySh("node scripts/update-icon-docs.mjs");


### PR DESCRIPTION
### Motivation
- Ensure the self-heal workflow repairs the actual failing commit by checking out the `workflow_run` head SHA instead of the default-branch SHA.  
- Avoid assuming a pnpm workspace or lockfile and prevent pnpm cache/setup ordering from causing the workflow to fail before repairs run.  
- Make the healthcheck and repair scripts safe for a Python repo by running only configured Node tasks and using the repo's Python test runner when present.

### Description
- Update `.github/workflows/self-heal.yml` to checkout the failing run commit via `github.event.workflow_run.head_sha`, remove `setup-node` pnpm cache usage, install pnpm early, and add conditional Node install logic that falls back to `--lockfile=false` when no `pnpm-lock.yaml` is present; also add Python setup and a step to install Python test deps.  
- Rewrite `scripts/healthcheck.mjs` to read `package.json` scripts, only run Node checks when the scripts exist, skip TypeScript checks unless a `tsconfig.json`/`jsconfig.json` is present, and run native Python tests with `python3 -m pytest` when appropriate.  
- Rewrite `scripts/self-heal.mjs` to avoid workspace-only `pnpm -w` flags, gate vitest/type acquisition/lockfile repairs on real config files or lockfile presence, and only attempt lockfile refresh when `pnpm-lock.yaml` exists.  
- Simplify `package.json` to only include the `healthcheck` and `self:heal` entrypoints (remove unsupported `typecheck`/`vitest`/lint/format scripts) and add `node_modules/` to `.gitignore` to avoid accidental diffs from install output.

### Testing
- Ran static syntax checks: `node --check scripts/healthcheck.mjs && node --check scripts/self-heal.mjs` — succeeded.  
- Exercised Node install path: `pnpm install --lockfile=false` — succeeded.  
- Exercised the repo healthcheck (Python path) by installing package test deps and running `node scripts/healthcheck.mjs` under a system Python; the test suite executed but returned non-zero because one pre-existing test failed: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` (19 passed, 1 failed), so the healthcheck currently fails due to that unrelated test failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccaaf4fb0832098d0c73815fbcc9d)