### PR TITLE
Keep Clear enabled for whitespace URL input

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -257,11 +257,15 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
-        $ClearBtn.IsEnabled = $false
-        $ClearBtn.ToolTip = "URL list is already empty"
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+    }
+
+    if ([string]::IsNullOrEmpty($UrlBox.Text)) {
+        $ClearBtn.IsEnabled = $false
+        $ClearBtn.ToolTip = "URL list is already empty"
+    } else {
         $ClearBtn.IsEnabled = $true
         $ClearBtn.ToolTip = "Clear URL list"
     }


### PR DESCRIPTION
### Motivation
- Fix a functional regression where the `Clear` action became disabled when the URL text box contained only whitespace/newlines, preventing users from easily resetting the field.

### Description
- Update the `$UrlBox.Add_TextChanged` handler in `gui-url-convert.ps1` so the `Convert` button still keys off `IsNullOrWhiteSpace` while the `Clear` button now keys off `IsNullOrEmpty`, preserving Clear availability for whitespace-only content and updating the related tooltips.

### Testing
- Ran a small automated assertion that verified the file contains the new `IsNullOrEmpty` check and the existing `Convert` tooltip string, and the assertion succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdb6434e883209271320fc0602d47)