### PR TITLE
Avoid failing Jules review request on comment errors

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -22,7 +22,6 @@ jobs:
           python - <<'PY'
           import json
           import os
-          import sys
           import urllib.error
           import urllib.request
 
@@ -52,6 +51,5 @@ jobs:
                   )
           except urllib.error.HTTPError as error:
               print(f"Could not request review: {error.read().decode('utf-8')}")
-              print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
+              print("Review request comment is advisory; continuing without failing the job.")
           PY


### PR DESCRIPTION
### Motivation
- The step that posts an advisory review comment should not hard-fail the workflow when the runner lacks permission to create issue comments (e.g., forked PRs), because the review request is best-effort and should not produce a red CI run.

### Description
- Update ` .github/workflows/request-jules-review.yml` to catch `urllib.error.HTTPError` and log the failure with a message stating the comment is advisory instead of exiting non-zero, and remove the now-unused `sys` import.

### Testing
- Ran `git diff --check` to validate the change and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdb5294608320991511807a952630)