### PR TITLE
Normalize IDNA hostnames for validated DNS pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.5,<4",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -28,11 +28,12 @@ def main(argv=None):
 
     if args.url or args.batch:
         try:
+            import idna  # type: ignore  # pylint: disable=import-outside-toplevel
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
             from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
         except ImportError as e:
             print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+                  "Please run: pip install requests markdownify idna", file=sys.stderr)
             return 1
 
         session = requests.Session()
@@ -79,10 +80,27 @@ def main(argv=None):
                     ip_obj.is_reserved or ip_obj.is_multicast)
 
         def _normalize_dns_hostname(hostname):
-            """Return a canonical IDNA DNS hostname for matching pinned lookups."""
+            """Return Requests' canonical IDNA hostname for pinned DNS lookups."""
             if isinstance(hostname, bytes):
                 hostname = hostname.decode('ascii')
-            return hostname.rstrip('.').encode('idna').decode('ascii').lower()
+
+            stripped_hostname = hostname.rstrip('.')
+            try:
+                ipaddress.ip_address(stripped_hostname)
+            except ValueError:
+                pass
+            else:
+                return stripped_hostname.lower()
+
+            try:
+                # Match Requests' PreparedRequest._get_idna_encoded_host(),
+                # which uses the idna package with UTS #46 processing before
+                # opening the socket connection.
+                normalized = idna.encode(stripped_hostname, uts46=True).decode('ascii')
+            except idna.IDNAError as e:
+                raise UnicodeError from e
+
+            return normalized.lower()
 
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -78,6 +78,12 @@ def main(argv=None):
                     ip_obj.is_link_local or ip_obj.is_unspecified or
                     ip_obj.is_reserved or ip_obj.is_multicast)
 
+        def _normalize_dns_hostname(hostname):
+            """Return a canonical IDNA DNS hostname for matching pinned lookups."""
+            if isinstance(hostname, bytes):
+                hostname = hostname.decode('ascii')
+            return hostname.rstrip('.').encode('idna').decode('ascii').lower()
+
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""
             parsed = urlparse(target_url)
@@ -91,6 +97,12 @@ def main(argv=None):
                 print("Error: Invalid URL.", file=sys.stderr)
                 return None
 
+            try:
+                normalized_hostname = _normalize_dns_hostname(hostname)
+            except UnicodeError as e:
+                print(f"Error: Invalid URL hostname: {e}", file=sys.stderr)
+                return None
+
             port = _url_port(parsed)
             if port is None:
                 return None
@@ -100,7 +112,9 @@ def main(argv=None):
                 # The approved DNS answers are returned and pinned for the
                 # matching request so a second lookup cannot rebind to an
                 # internal address after validation.
-                addr_info = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+                addr_info = socket.getaddrinfo(
+                    normalized_hostname, port, type=socket.SOCK_STREAM
+                )
                 if not addr_info:
                     print("Error: Hostname did not resolve to any addresses.", file=sys.stderr)
                     return None
@@ -114,16 +128,21 @@ def main(argv=None):
                 print(f"Error validating hostname: {e}", file=sys.stderr)
                 return None
 
-            return hostname, port, addr_info
+            return normalized_hostname, port, addr_info
 
         @contextmanager
         def _pin_validated_dns(hostname, port, addr_info):
             """Pin requests DNS resolution to the already-validated answers."""
             original_getaddrinfo = socket.getaddrinfo
-            pinned_hostname = hostname.rstrip('.').lower()
+            pinned_hostname = _normalize_dns_hostname(hostname)
 
             def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
-                if host and host.rstrip('.').lower() == pinned_hostname:
+                try:
+                    requested_hostname = _normalize_dns_hostname(host) if host else None
+                except UnicodeError:
+                    requested_hostname = None
+
+                if requested_hostname == pinned_hostname:
                     resolved_port = requested_port if requested_port is not None else port
                     pinned = []
                     for family_, type_, proto_, canonname, sockaddr in addr_info:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -126,6 +126,40 @@ def test_validated_dns_answer_is_pinned_during_fetch(mock_get, mock_getaddrinfo,
     )
 
 
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_idna_hostname_uses_pinned_validated_dns(mock_get, mock_getaddrinfo, capsys):
+    """Unicode hostnames are normalized before validation and pinned lookup matching."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>IDNA pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_idna_hostname(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("xn--tst-qla.example", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_idna_hostname
+
+    cli.main(["--url", "http://täst.example/"])
+
+    outerr = capsys.readouterr()
+    assert "# IDNA pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "xn--tst-qla.example", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://täst.example/", timeout=30, allow_redirects=False
+    )
+
+
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -128,8 +128,10 @@ def test_validated_dns_answer_is_pinned_during_fetch(mock_get, mock_getaddrinfo,
 
 @patch("socket.getaddrinfo")
 @patch("requests.Session.get")
-def test_idna_hostname_uses_pinned_validated_dns(mock_get, mock_getaddrinfo, capsys):
-    """Unicode hostnames are normalized before validation and pinned lookup matching."""
+def test_idna_hostname_uses_requests_idna_pinned_validated_dns(
+    mock_get, mock_getaddrinfo, capsys
+):
+    """Unicode hostnames use Requests' IDNA form for validation and pinning."""
     public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
     rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
     mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
@@ -141,22 +143,22 @@ def test_idna_hostname_uses_pinned_validated_dns(mock_get, mock_getaddrinfo, cap
     response.raise_for_status.return_value = None
 
     def get_with_idna_hostname(*_args, **_kwargs):
-        resolved = socket.getaddrinfo("xn--tst-qla.example", 80, type=socket.SOCK_STREAM)
+        resolved = socket.getaddrinfo("xn--strae-oqa.de", 80, type=socket.SOCK_STREAM)
         assert resolved == public_answer
         return response
 
     mock_get.side_effect = get_with_idna_hostname
 
-    cli.main(["--url", "http://täst.example/"])
+    cli.main(["--url", "http://straße.de/"])
 
     outerr = capsys.readouterr()
     assert "# IDNA pinned" in outerr.out
     assert "169.254.169.254" not in outerr.err
     mock_getaddrinfo.assert_called_once_with(
-        "xn--tst-qla.example", 80, type=socket.SOCK_STREAM
+        "xn--strae-oqa.de", 80, type=socket.SOCK_STREAM
     )
     mock_get.assert_called_once_with(
-        "http://täst.example/", timeout=30, allow_redirects=False
+        "http://straße.de/", timeout=30, allow_redirects=False
     )
 
 


### PR DESCRIPTION
### Motivation

- Prevent a DNS-rebinding/TOCTOU bypass for internationalized hostnames where validation used the Unicode form but `requests` performed the connection using IDNA/punycode, allowing a fresh lookup to escape the pinned, validated answers.

### Description

- Add `_normalize_dns_hostname` to canonicalize hostnames to their IDNA/punycode form and handle byte inputs safely. 
- Use the normalized hostname when calling `socket.getaddrinfo` inside `validate_url` and return the normalized name with `addr_info` so validation and subsequent pinning use the same form. 
- Normalize the requested hostname inside the `_pin_validated_dns` context so the pinned `getaddrinfo` comparator matches `requests`’ prepared punycode hostname and does not fall through to a fresh lookup. 
- Add `test_idna_hostname_uses_pinned_validated_dns` to `tests/test_cli_security.py` to assert that a Unicode hostname is resolved/validated in IDNA form and that the validated answer is reused during the pinned fetch.

### Testing

- Installed the package in editable mode and ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py`, which passed (`13 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest`, which passed (`29 passed`).
- Verified diff-checks and style checks reported no issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc90c403883209da281eaa4ff3827)