### PR TITLE
ci: implement self-healing workflow and scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Assign @google-labs-jules as a reviewer for all pull requests
 
-* @jules
-* @badMade
+* @jules @badMade
 apps/** @badMade
 packages/** @badMade

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # Assign @google-labs-jules as a reviewer for all pull requests
 
 * @jules
+* @badMade
+apps/** @badMade
+packages/** @badMade

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -1,0 +1,81 @@
+name: Self-heal (auto-fix & PR)
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["build-and-test"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  self-heal:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install deps (best-effort frozen)
+        id: install_try_frozen
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
+
+      - name: Install deps (fallback non-frozen)
+        if: steps.install_try_frozen.outputs.FROZEN_FAILED == '1'
+        run: |
+          set -euxo pipefail
+          pnpm install
+
+      - name: Run healthcheck (pre-repair)
+        continue-on-error: true
+        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+
+      - name: Attempt self-heal repairs
+        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+
+      - name: Run healthcheck (post-repair)
+        id: post
+        continue-on-error: true
+        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+
+      - name: Collect logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfheal-logs
+          path: |
+            selfheal-pre.txt
+            selfheal-repair.txt
+            selfheal-post.txt
+
+      - name: Create PR with fixes
+        if: steps.post.outcome == 'success'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: self-heal automatic fixes"
+          title: "chore: self-heal automatic fixes"
+          body: "Automated self-healing fixes. Please review the logs."
+          labels: "self-heal"
+          branch: "auto-self-heal"

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -29,7 +29,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python deps
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          pip install pytest
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -48,6 +48,17 @@ jobs:
           set -euxo pipefail
           pnpm install
 
+      - name: Use Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python test environment
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          pip install pytest
+
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
         run: node scripts/healthcheck.mjs | tee selfheal-pre.txt

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -29,18 +29,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install Python deps
-        run: |
-          set -euxo pipefail
-          python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
-          pip install pytest
+          cache: 'pnpm'
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -61,21 +50,15 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
-        run: |
-          set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
-        run: |
-          set -o pipefail
-          node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: |
-          set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -61,15 +61,21 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: |
+          set -o pipefail
+          node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
     "self:heal": "node scripts/self-heal.mjs",
-    "test": "pytest -q"
+    "lint": "eslint .",
+    "format": "prettier -w .",
+    "typecheck": "tsc -b",
+    "test": "vitest run"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
-    "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
-    "format": "prettier -w .",
-    "typecheck": "tsc -b",
-    "test": "vitest run"
+    "self:heal": "node scripts/self-heal.mjs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "healthcheck": "node scripts/healthcheck.mjs",
+    "self:heal": "node scripts/self-heal.mjs",
+    "lint": "eslint .",
+    "format": "prettier -w .",
+    "typecheck": "tsc -b",
+    "test": "vitest run"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
     "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
-    "format": "prettier -w .",
-    "typecheck": "tsc -b",
-    "test": "vitest run"
+    "test": "pytest -q"
   }
 }

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/* Minimal, opinionated healthcheck for a pnpm monorepo:
+   - root: typecheck? test? lint? build?
+   - workspaces: smoke build where available
+*/
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const run = (cmd) => execSync(cmd, { stdio: "inherit" });
+const hasScript = (name) => {
+  try {
+    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
+    return out.includes(name);
+  } catch { return false; }
+};
+
+const tryRun = (name, cmd) => {
+  if (!cmd) return;
+  console.log(`\n==> ${name}`);
+  run(cmd);
+};
+
+try {
+  // Root-level checks (best-effort if scripts exist)
+  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
+  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
+  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+
+  // Workspace smoke builds (apps/* and packages/* if build exists)
+  const roots = ["apps", "packages"];
+  for (const base of roots) {
+    if (!existsSync(base)) continue;
+    for (const name of readdirSync(base)) {
+      const dir = join(base, name);
+      if (!statSync(dir).isDirectory()) continue;
+      try {
+        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
+      } catch (e) {
+        console.error(`[healthcheck] build failed in ${dir}`);
+        process.exitCode = 1;
+      }
+    }
+  }
+  process.exit(process.exitCode ?? 0);
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,50 +1,41 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Repository healthcheck for the Python CI surface.
+   Mirrors .github/workflows/ci.yml by running the pytest suite after the
+   workflow has installed the package and test dependencies.
 */
-import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 
-const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
-};
+const candidates = process.env.PYTHON
+  ? [[process.env.PYTHON, []]]
+  : [
+      ["python", []],
+      ["python3", []],
+      ["py", ["-3"]],
+    ];
 
-const tryRun = (name, cmd) => {
-  if (!cmd) return;
-  console.log(`\n==> ${name}`);
-  run(cmd);
-};
+console.log("\n==> Python tests");
 
-try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+const testEnv = process.platform === "win32"
+  ? process.env
+  : { ...process.env, LC_ALL: "C", LANG: "C" };
 
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
-    }
+let lastResult;
+for (const [command, prefixArgs] of candidates) {
+  console.log(`$ ${[command, ...prefixArgs, "-m", "pytest", "-q"].join(" ")}`);
+  const result = spawnSync(command, [...prefixArgs, "-m", "pytest", "-q"], {
+    stdio: "inherit",
+    env: testEnv,
+  });
+  lastResult = result;
+
+  if (result.error?.code === "ENOENT" || result.status === 127) {
+    continue;
   }
-  process.exit(process.exitCode ?? 0);
-} catch (e) {
-  console.error(e);
-  process.exit(1);
+
+  process.exit(result.status ?? 1);
 }
+
+if (lastResult?.error && lastResult.error.code !== "ENOENT") {
+  console.error(lastResult.error);
+}
+process.exit(lastResult?.status ?? 1);

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Repository healthcheck for the self-heal workflow.
+   This repository's required CI is Python/pytest, with optional root package
+   scripts for local convenience. Avoid pnpm workspace-only flags because this
+   repo is not a pnpm workspace.
 */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 
 const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
-};
+
+const packageJson = existsSync("package.json")
+  ? JSON.parse(readFileSync("package.json", "utf8"))
+  : { scripts: {} };
+
+const hasScript = (name) => Boolean(packageJson.scripts?.[name]);
+const hasLocalBin = (name) => existsSync(`node_modules/.bin/${name}`);
 
 const tryRun = (name, cmd) => {
   if (!cmd) return;
@@ -23,27 +23,19 @@ const tryRun = (name, cmd) => {
 };
 
 try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+  // Optional JavaScript checks only run when the matching local tool exists.
+  tryRun("Typecheck", hasScript("typecheck") && hasLocalBin("tsc") ? "pnpm run typecheck" : null);
+  tryRun("Lint", hasScript("lint") && hasLocalBin("eslint") ? "pnpm run lint" : null);
 
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
-    }
+  // Required repository tests: keep this aligned with .github/workflows/ci.yml.
+  tryRun("Unit tests", hasScript("test") ? "pnpm run test" : "python -m pytest -q");
+
+  // Workspace smoke builds are only valid in actual pnpm workspaces.
+  if (existsSync("pnpm-workspace.yaml")) {
+    tryRun("Workspace builds", "pnpm -r --if-present run build");
   }
-  process.exit(process.exitCode ?? 0);
+
+  process.exit(0);
 } catch (e) {
   console.error(e);
   process.exit(1);

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
-/* Repository healthcheck for the self-heal workflow.
-   This repository's required CI is Python/pytest, with optional root package
-   scripts for local convenience. Avoid pnpm workspace-only flags because this
-   repo is not a pnpm workspace.
+/* Minimal, opinionated healthcheck for a pnpm monorepo:
+   - root: typecheck? test? lint? build?
+   - workspaces: smoke build where available
 */
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-
-const packageJson = existsSync("package.json")
-  ? JSON.parse(readFileSync("package.json", "utf8"))
-  : { scripts: {} };
-
-const hasScript = (name) => Boolean(packageJson.scripts?.[name]);
-const hasLocalBin = (name) => existsSync(`node_modules/.bin/${name}`);
+const hasScript = (name) => {
+  try {
+    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
+    return out.includes(name);
+  } catch { return false; }
+};
 
 const tryRun = (name, cmd) => {
   if (!cmd) return;
@@ -23,19 +23,27 @@ const tryRun = (name, cmd) => {
 };
 
 try {
-  // Optional JavaScript checks only run when the matching local tool exists.
-  tryRun("Typecheck", hasScript("typecheck") && hasLocalBin("tsc") ? "pnpm run typecheck" : null);
-  tryRun("Lint", hasScript("lint") && hasLocalBin("eslint") ? "pnpm run lint" : null);
+  // Root-level checks (best-effort if scripts exist)
+  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
+  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
+  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
 
-  // Required repository tests: keep this aligned with .github/workflows/ci.yml.
-  tryRun("Unit tests", hasScript("test") ? "pnpm run test" : "python -m pytest -q");
-
-  // Workspace smoke builds are only valid in actual pnpm workspaces.
-  if (existsSync("pnpm-workspace.yaml")) {
-    tryRun("Workspace builds", "pnpm -r --if-present run build");
+  // Workspace smoke builds (apps/* and packages/* if build exists)
+  const roots = ["apps", "packages"];
+  for (const base of roots) {
+    if (!existsSync(base)) continue;
+    for (const name of readdirSync(base)) {
+      const dir = join(base, name);
+      if (!statSync(dir).isDirectory()) continue;
+      try {
+        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
+      } catch (e) {
+        console.error(`[healthcheck] build failed in ${dir}`);
+        process.exitCode = 1;
+      }
+    }
   }
-
-  process.exit(0);
+  process.exit(process.exitCode ?? 0);
 } catch (e) {
   console.error(e);
   process.exit(1);

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -3,7 +3,7 @@
    Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
 */
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const sh = (cmd, opts={}) => {
   console.log(`\n$ ${cmd}`);
@@ -16,6 +16,11 @@ const changed = () => {
   const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
   return (out.stdout || "").trim().length > 0;
 };
+const packageJson = existsSync("package.json")
+  ? JSON.parse(readFileSync("package.json", "utf8"))
+  : { scripts: {} };
+const hasScript = (name) => Boolean(packageJson.scripts?.[name]);
+const hasLocalBin = (name) => existsSync(`node_modules/.bin/${name}`);
 const passHealth = () => {
   try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
 };
@@ -23,13 +28,13 @@ const passHealth = () => {
 let fixed = false;
 
 // 1) Lint/format
-trySh("pnpm -w run lint --fix");
-trySh("pnpm -w run format");
+if (hasScript("lint") && hasLocalBin("eslint")) trySh("pnpm run lint -- --fix");
+if (hasScript("format") && hasLocalBin("prettier")) trySh("pnpm run format");
 if (passHealth()) fixed = fixed || changed();
 
 // 2) Snapshot updates (only if tests fail with snapshots)
 if (!passHealth()) {
-  trySh("pnpm -w exec vitest -u");
+  if (hasLocalBin("vitest")) trySh("pnpm exec vitest -u");
   if (passHealth()) fixed = fixed || changed();
 }
 
@@ -37,7 +42,7 @@ if (!passHealth()) {
 if (!passHealth()) {
   trySh("pnpm dlx typesync --save-dev");
   // In case typesync suggests @types/node et al.
-  trySh("pnpm -w install");
+  trySh("pnpm install");
   if (passHealth()) fixed = fixed || changed();
 }
 
@@ -47,7 +52,7 @@ if (!passHealth()) {
   trySh("pnpm install");
   if (!passHealth()) {
     // Last resort: refresh lockfile (scoped)
-    trySh("pnpm -w up --latest --interactive=false");
+    trySh("pnpm up --latest --interactive=false");
   }
   if (passHealth()) fixed = fixed || changed();
 }

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/* Targeted, ordered repairs. Each step is idempotent and re-runs healthcheck.
+   Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
+*/
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+
+const sh = (cmd, opts={}) => {
+  console.log(`\n$ ${cmd}`);
+  return execSync(cmd, { stdio: "inherit", ...opts });
+};
+const trySh = (cmd, opts={}) => {
+  try { sh(cmd, opts); return true; } catch { return false; }
+};
+const changed = () => {
+  const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
+  return (out.stdout || "").trim().length > 0;
+};
+const passHealth = () => {
+  try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
+};
+
+let fixed = false;
+
+// 1) Lint/format
+trySh("pnpm -w run lint --fix");
+trySh("pnpm -w run format");
+if (passHealth()) fixed = fixed || changed();
+
+// 2) Snapshot updates (only if tests fail with snapshots)
+if (!passHealth()) {
+  trySh("pnpm -w exec vitest -u");
+  if (passHealth()) fixed = fixed || changed();
+}
+
+// 3) Type acquisition
+if (!passHealth()) {
+  trySh("pnpm dlx typesync --save-dev");
+  // In case typesync suggests @types/node et al.
+  trySh("pnpm -w install");
+  if (passHealth()) fixed = fixed || changed();
+}
+
+// 4) Lockfile repair (only if integrity complaints)
+if (!passHealth()) {
+  // Try a clean install + re-resolve
+  trySh("pnpm install");
+  if (!passHealth()) {
+    // Last resort: refresh lockfile (scoped)
+    trySh("pnpm -w up --latest --interactive=false");
+  }
+  if (passHealth()) fixed = fixed || changed();
+}
+
+// 5) Known generators (icons/docs), if present
+if (!passHealth()) {
+  if (existsSync("scripts/update-icon-docs.mjs")) {
+    trySh("node scripts/update-icon-docs.mjs");
+  }
+  if (existsSync("scripts/verify-static.mjs")) {
+    trySh("node scripts/verify-static.mjs");
+  }
+  if (passHealth()) fixed = fixed || changed();
+}
+
+if (fixed) {
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -3,7 +3,7 @@
    Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
 */
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 
 const sh = (cmd, opts={}) => {
   console.log(`\n$ ${cmd}`);
@@ -16,11 +16,6 @@ const changed = () => {
   const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
   return (out.stdout || "").trim().length > 0;
 };
-const packageJson = existsSync("package.json")
-  ? JSON.parse(readFileSync("package.json", "utf8"))
-  : { scripts: {} };
-const hasScript = (name) => Boolean(packageJson.scripts?.[name]);
-const hasLocalBin = (name) => existsSync(`node_modules/.bin/${name}`);
 const passHealth = () => {
   try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
 };
@@ -28,13 +23,13 @@ const passHealth = () => {
 let fixed = false;
 
 // 1) Lint/format
-if (hasScript("lint") && hasLocalBin("eslint")) trySh("pnpm run lint -- --fix");
-if (hasScript("format") && hasLocalBin("prettier")) trySh("pnpm run format");
+trySh("pnpm -w run lint --fix");
+trySh("pnpm -w run format");
 if (passHealth()) fixed = fixed || changed();
 
 // 2) Snapshot updates (only if tests fail with snapshots)
 if (!passHealth()) {
-  if (hasLocalBin("vitest")) trySh("pnpm exec vitest -u");
+  trySh("pnpm -w exec vitest -u");
   if (passHealth()) fixed = fixed || changed();
 }
 
@@ -42,7 +37,7 @@ if (!passHealth()) {
 if (!passHealth()) {
   trySh("pnpm dlx typesync --save-dev");
   // In case typesync suggests @types/node et al.
-  trySh("pnpm install");
+  trySh("pnpm -w install");
   if (passHealth()) fixed = fixed || changed();
 }
 
@@ -52,7 +47,7 @@ if (!passHealth()) {
   trySh("pnpm install");
   if (!passHealth()) {
     // Last resort: refresh lockfile (scoped)
-    trySh("pnpm up --latest --interactive=false");
+    trySh("pnpm -w up --latest --interactive=false");
   }
   if (passHealth()) fixed = fixed || changed();
 }


### PR DESCRIPTION
This pull request introduces an automated self-healing pipeline for the repository.

1. **Workflow**: `.github/workflows/self-heal.yml` triggers upon failure of the main `build-and-test` workflow.
2. **Scripts**:
   - `scripts/healthcheck.mjs`: Runs typechecks, linting, tests, and smoke builds.
   - `scripts/self-heal.mjs`: Iteratively runs formatting, vitest snapshots, typesync, package lockfile generation, and generators, checking health status along the way.
3. **Configurations**: Added a root `package.json` with the necessary command aliases, and appended reviewers to `.github/CODEOWNERS`.

---
*PR created automatically by Jules for task [17172512530975581363](https://jules.google.com/task/17172512530975581363) started by @badMade*