### PR TITLE
Avoid apparent_encoding access after streaming

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from typing import Any, Optional, Set
 from urllib.parse import urlparse, unquote
 
 def main(argv=None):
@@ -54,15 +55,47 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def decode_response_content(response, content_bytes: bytearray) -> str:
-            """Decode streamed bytes using Requests' response.text fallback order."""
-            encoding = response.encoding
-            if not encoding:
-                encoding = response.apparent_encoding
+        def detect_streamed_encoding(
+            content_bytes: bytearray, encoding_detector: Any
+        ) -> Optional[str]:
+            """Guess encoding from buffered streamed bytes without re-reading response."""
+            if not encoding_detector:
+                return None
             try:
-                return bytes(content_bytes).decode(encoding, errors='replace')
-            except (LookupError, TypeError):
-                return bytes(content_bytes).decode(errors='replace')
+                detection = encoding_detector.detect(bytes(content_bytes))
+            except Exception:  # pylint: disable=broad-exception-caught
+                return None
+            if isinstance(detection, dict):
+                encoding = detection.get('encoding')
+                if isinstance(encoding, str):
+                    return encoding
+            return None
+
+        def decode_response_content(
+            content_bytes: bytearray,
+            response_encoding: Optional[str],
+            encoding_detector: Any,
+        ) -> str:
+            """Decode streamed bytes without touching Response.content after streaming."""
+            byte_content = bytes(content_bytes)
+            candidate_encodings = (
+                response_encoding,
+                detect_streamed_encoding(content_bytes, encoding_detector),
+                'utf-8',
+            )
+            attempted: Set[str] = set()
+            for encoding in candidate_encodings:
+                if not encoding:
+                    continue
+                normalized_encoding = encoding.lower()
+                if normalized_encoding in attempted:
+                    continue
+                attempted.add(normalized_encoding)
+                try:
+                    return byte_content.decode(encoding, errors='replace')
+                except (LookupError, TypeError):
+                    continue
+            return byte_content.decode(errors='replace')
 
         def process_url(target_url: str) -> bool:
             """Process a single URL. Return True when conversion succeeds."""
@@ -84,6 +117,10 @@ def main(argv=None):
                 # manager so the connection is released even on errors/early returns.
                 with session.get(target_url, timeout=30, stream=True) as response:
                     response.raise_for_status()
+                    response_encoding = response.encoding
+                    encoding_detector = getattr(
+                        getattr(requests, 'compat', None), 'chardet', None
+                    )
 
                     content_bytes = bytearray()
                     max_size = 10 * 1024 * 1024  # 10 MB limit
@@ -98,7 +135,9 @@ def main(argv=None):
                                 return False
                             content_bytes.extend(chunk)
 
-                    text_content = decode_response_content(response, content_bytes)
+                    text_content = decode_response_content(
+                        content_bytes, response_encoding, encoding_detector
+                    )
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -128,6 +128,9 @@ class TestCliExceptions(unittest.TestCase):
                 )
 
                 with patch(
+                    'requests.compat.chardet.detect',
+                    return_value={'encoding': 'iso-8859-1'},
+                ), patch(
                     'markdownify.markdownify',
                     side_effect=lambda html, **_: html,
                 ) as mock_md:
@@ -137,6 +140,39 @@ class TestCliExceptions(unittest.TestCase):
         mock_md.assert_called_once()
         self.assertIn(word, mock_md.call_args.args[0])
         self.assertIn(word, captured_stdout.getvalue())
+
+    def test_streamed_decode_does_not_read_response_apparent_encoding(self):
+        """Successful streamed downloads must not inspect consumed response content."""
+
+        class StreamResponseWithFailingApparentEncoding:
+            encoding = 'utf-8'
+
+            def __init__(self):
+                self.iter_content = MagicMock(return_value=[b"<p>ok</p>"])
+                self.raise_for_status = MagicMock(return_value=None)
+
+            @property
+            def apparent_encoding(self):
+                raise RuntimeError(
+                    "The content for this response was already consumed"
+                )
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return None
+
+        response = StreamResponseWithFailingApparentEncoding()
+        with patch('requests.Session.get', return_value=response), patch(
+            'markdownify.markdownify',
+            side_effect=lambda html, **_: html,
+        ) as mock_md:
+            result = main(['--url', 'http://example.com'])
+
+        self.assertEqual(result, 0)
+        mock_md.assert_called_once()
+        self.assertIn("ok", mock_md.call_args.args[0])
 
     def test_invalid_charset_label_falls_back_without_failing(self):
         """Invalid charset labels should fall back like response.text."""


### PR DESCRIPTION
### Motivation
- Prevent accessing `response.apparent_encoding` after `iter_content()` has consumed a streamed body, which can raise `RuntimeError` for real `requests.Response` objects. 
- Preserve the existing charset-fallback behavior used when decoding streamed bytes without re-reading `Response.content`.
- Ensure successful streamed downloads remain successful and tests exercise the streaming code path.

### Description
- Capture `response.encoding` before streaming and stop touching `response.apparent_encoding` after the body is consumed by adding `response_encoding = response.encoding` prior to `iter_content()`.
- Add `detect_streamed_encoding()` and a new `decode_response_content(content_bytes, response_encoding, encoding_detector)` to run a buffered encoding detection (via `requests.compat.chardet.detect` when available) and fall back to UTF-8, decoding only from the accumulated bytes.
- Wire an `encoding_detector = getattr(getattr(requests, 'compat', None), 'chardet', None)` and pass it to the new decoder so Requests-style detection is preserved without reading `Response.content`.
- Add a regression test `test_streamed_decode_does_not_read_response_apparent_encoding` and update the charset-fallback test to use `requests.compat.chardet.detect` so the streaming decode path is exercised (`src/html2md/cli.py`, `tests/test_cli_exceptions.py`).

### Testing
- Ran focused tests with `PYENV_VERSION=3.11.15 python -m pytest tests/test_cli_exceptions.py tests/test_cli_error.py tests/test_cli_security.py -q` and all tests passed.
- Ran the full test suite with `PYENV_VERSION=3.11.15 python -m pytest -q` and it completed successfully (all tests passed).
- Verified no style/check issues with `git diff --check` (no warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd055c853c8320870f8a84ec0aafb3)