### PR TITLE
Follow-up: harden CLI redirect URL validation

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -10,9 +10,17 @@ import sys
 from urllib.parse import unquote, urljoin, urlparse
 
 
+def _has_forbidden_url_chars(url: str) -> bool:
+    """Return True when URL contains chars Requests may reinterpret unsafely."""
+    return any(char == "\\" or ord(char) < 32 or ord(char) == 127 for char in url)
+
+
 def is_safe_url(url: str) -> bool:
     """Check if the URL resolves only to globally reachable IP addresses."""
     try:
+        if _has_forbidden_url_chars(url):
+            return False
+
         parsed = urlparse(url)
         hostname = parsed.hostname
         if not hostname:
@@ -29,8 +37,9 @@ def is_safe_url(url: str) -> bool:
             ip_str = info[4][0]
             ip = ipaddress.ip_address(ip_str)
             # Require globally reachable IPs only, while explicitly rejecting
-            # multicast addresses because Python 3.12 may report them as global.
-            if not ip.is_global or ip.is_multicast:
+            # multicast and reserved ranges that Python may report as global
+            # (for example NAT64 translation prefixes).
+            if not ip.is_global or ip.is_multicast or ip.is_reserved:
                 return False
         return True
     except (socket.gaierror, ValueError):

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,6 +79,7 @@ def test_traversal_like_paths_stay_within_outdir(
         "http://0.0.0.0/",
         "http://[::1]/",
         "http://[ff02::1]/",
+        "http://[64:ff9b::a9fe:a9fe]/",
     ],
 )
 @patch("requests.Session.get")
@@ -106,6 +107,37 @@ def test_is_safe_url_rejects_multicast_dns_results(mock_getaddrinfo, ip_address)
     ]
 
     assert not cli.is_safe_url("http://example.com/")
+
+
+@pytest.mark.parametrize(
+    "ip_address",
+    [
+        "64:ff9b::a9fe:a9fe",
+    ],
+)
+@patch("html2md.cli.socket.getaddrinfo")
+def test_is_safe_url_rejects_reserved_dns_results(mock_getaddrinfo, ip_address):
+    """SSRF protection should reject reserved ranges, including NAT64 prefixes."""
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", (ip_address, 0))
+    ]
+
+    assert not cli.is_safe_url("http://example.com/")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        r"http://127.0.0.1\@example.com/",
+        "http://example.com/evil\\path",
+        "http://example.com/evil\x00path",
+    ],
+)
+@patch("html2md.cli.socket.getaddrinfo")
+def test_is_safe_url_rejects_urls_with_forbidden_characters(mock_getaddrinfo, url):
+    """SSRF protection rejects characters Requests may normalize differently."""
+    assert not cli.is_safe_url(url)
+    mock_getaddrinfo.assert_not_called()
 
 
 @patch("html2md.cli.socket.getaddrinfo")
@@ -155,6 +187,33 @@ def test_process_url_redirect_to_blocked_ip_is_rejected(
 
     assert (
         "Error: URL 'http://127.0.0.1/admin' resolves to a non-public IP address."
+        in outerr.err
+    )
+    mock_get.assert_called_once_with(
+        "http://example.com/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("html2md.cli.socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_process_url_redirect_with_backslash_target_is_rejected(
+    mock_get, mock_getaddrinfo, capsys, tmp_path
+):
+    """Redirect targets with backslashes are rejected before Requests normalizes them."""
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+    ]
+
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {"Location": r"http://127.0.0.1\@example.com/"}
+    mock_get.return_value = redirect_response
+
+    cli.main(["--url", "http://example.com/", "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+
+    assert (
+        r"Error: URL 'http://127.0.0.1\@example.com/' resolves to a non-public IP address."
         in outerr.err
     )
     mock_get.assert_called_once_with(


### PR DESCRIPTION
### Motivation
- Prevent SSRF bypasses where redirect `Location` values are interpreted differently by `urllib.parse` and `requests` (for example `http://127.0.0.1\@example.com/`).
- Close gaps where addresses in reserved ranges (such as NAT64 `64:ff9b::/96`) could be treated as global by Python and allowed through the current checks.

### Description
- Add `_has_forbidden_url_chars(url: str)` and make `is_safe_url(...)` reject URLs containing raw backslashes, control characters, or DEL before parsing or DNS resolution. (`src/html2md/cli.py`).
- Tighten IP checks in `is_safe_url(...)` to reject `ip.is_reserved` in addition to non-global and multicast tests to block NAT64/reserved prefixes. (`src/html2md/cli.py`).
- Add regression tests to `tests/test_cli_security.py` to cover NAT64/reserved addresses, URLs with forbidden characters, and a redirect `Location` containing a backslash that previously could be normalized incorrectly by Requests.

### Testing
- Installed dependencies and test tooling with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest` and ran the focused test suite with `PYENV_VERSION=3.12.13 PYTHONPATH=src python -m pytest -q tests/test_cli_security.py tests/test_cli_exceptions.py tests/test_cli_error.py`.
- All automated tests in the exercised files passed (`... [100%]`).
- Ran `git diff --check` to ensure no whitespace or formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd04d668208320b41dc782be9b3d1d)