### PR TITLE
Fix Gemini Code Assist workflow action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -18,14 +18,26 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-code-assist'))
+      ((github.event_name == 'pull_request_review_comment' ||
+        github.event_name == 'issue_comment') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       contains(github.event.comment.body, '@gemini-code-assist') &&
+       (github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request))
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+        uses: google-github-actions/run-gemini-cli@v0.1.22
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          use_gemini_code_assist: 'true'
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          prompt: >-
+            Review this pull request and respond to any @gemini-code-assist request
+            in the triggering event.

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   gemini-code-assist:
@@ -36,6 +37,11 @@ jobs:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          gcp_workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          gcp_project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+          gcp_token_format: ${{ vars.SERVICE_ACCOUNT_EMAIL != '' && 'access_token' || '' }}
+          gcp_location: ${{ vars.GOOGLE_CLOUD_LOCATION }}
           use_gemini_code_assist: 'true'
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           prompt: >-


### PR DESCRIPTION
### Motivation
- The existing workflow referenced a non-existent action (`google-gemini/code-assist-action@v1`) which would fail during action resolution and prevent the Code Assist job from running.  
- Comment-triggered invocations previously allowed any commenter to run a job with `pull-requests: write` and `issues: write`, creating a security risk for third-party commenters.  

### Description
- Replace the unavailable action with the supported `google-github-actions/run-gemini-cli@v0.1.22` in `/.github/workflows/gemini-code-assist.yml`.  
- Configure the Gemini CLI step with `GEMINI_CLI_TRUST_WORKSPACE` and `GITHUB_TOKEN`, and pass `use_gemini_code_assist`, `github_pr_number`, and a `prompt` via `with`.  
- Tighten the `if` condition so comment-triggered runs require the commenter to be `MEMBER`, `OWNER`, or `COLLABORATOR`, and ensure `issue_comment` triggers only run for PR-associated issues while preserving automatic `pull_request` runs.  

### Testing
- Validated the workflow YAML parsing with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "yaml ok"'`, which succeeded.  
- Ran `git diff --check` to ensure no whitespace or syntax issues, which reported no problems.  
- Verified the pinned action tag exists with `git ls-remote --exit-code --tags https://github.com/google-github-actions/run-gemini-cli.git refs/tags/v0.1.22 >/dev/null && echo 'tag ok'`, which returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd04d001fc83208f85f274eb55e115)