### PR TITLE
Keep self-heal logs out of generated PRs

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -57,19 +57,19 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-pre.txt"
 
       - name: Attempt self-heal repairs
         run: |
           set -o pipefail
-          node scripts/self-heal.mjs | tee selfheal-repair.txt
+          node scripts/self-heal.mjs | tee "$RUNNER_TEMP/selfheal-repair.txt"
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-post.txt"
 
       - name: Collect logs
         if: always()
@@ -77,9 +77,9 @@ jobs:
         with:
           name: selfheal-logs
           path: |
-            selfheal-pre.txt
-            selfheal-repair.txt
-            selfheal-post.txt
+            ${{ runner.temp }}/selfheal-pre.txt
+            ${{ runner.temp }}/selfheal-repair.txt
+            ${{ runner.temp }}/selfheal-post.txt
 
       - name: Create PR with fixes
         if: steps.post.outcome == 'success'


### PR DESCRIPTION
### Motivation
- The self-heal job wrote `selfheal-pre.txt`, `selfheal-repair.txt`, and `selfheal-post.txt` into the repository checkout which made `git status --porcelain` non-empty and allowed run logs to be included in auto-generated repair PRs.

### Description
- Write pre/repair/post logs to the runner temp directory by piping to `tee "$RUNNER_TEMP/selfheal-<phase>.txt"` instead of files in the checkout.
- Upload the same temp files from `${{ runner.temp }}` in the `Collect logs` step so diagnostics remain available without polluting PR diffs.

### Testing
- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'`, which succeeded.
- Confirmed the updated log paths are present using `rg -n "selfheal-(pre|repair|post)\.txt|runner\.temp|RUNNER_TEMP" .github/workflows/self-heal.yml`, which found the new entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd451bf30883208f9bb667804e0f5c)