### PR TITLE
Validate self-heal repairs on Windows runner

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -21,7 +21,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 25
     steps:
       - name: Checkout failing revision


### PR DESCRIPTION
### Motivation
- Ensure the self-heal workflow validates repairs on the same runner used by CI so Windows-specific failures are reproduced before an auto-fix PR is created.

### Description
- Update `.github/workflows/self-heal.yml` to run the job on `windows-latest` and add a job-level `defaults.run.shell: bash` so the existing multiline shell steps behave consistently on the Windows hosted runner.

### Testing
- Verified the workflow YAML parses successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/self-heal.yml'); puts 'YAML OK'"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd45d25f34832086adc6f28455ebf6)