### PR TITLE
Surface batch worker failures in --batch mode

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -147,7 +147,7 @@ def main(argv=None):
                 with concurrent.futures.ThreadPoolExecutor(
                     max_workers=max_workers
                 ) as executor:
-                    executor.map(process_url, urls_to_process)
+                    list(executor.map(process_url, urls_to_process))
 
         return 0
 

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 import argparse
+import collections
+import functools
 import os
 import sys
 from urllib.parse import urlparse, unquote
@@ -161,13 +163,12 @@ def main(argv=None):
                     max_workers=max_workers
                 ) as executor:
                     if args.outdir:
-                        for _ in executor.map(process_url, urls_to_process):
-                            pass
+                        collections.deque(
+                            executor.map(process_url, urls_to_process), maxlen=0
+                        )
                     else:
                         for stdout_messages, stderr_messages in executor.map(
-                            lambda target_url: process_url(
-                                target_url, emit_output=False
-                            ),
+                            functools.partial(process_url, emit_output=False),
                             urls_to_process,
                         ):
                             for message in stdout_messages:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -66,7 +66,7 @@ def main(argv=None):
         def process_url(
             target_url: str, *, emit_output: bool = True
         ) -> tuple[list[str], list[str]]:
-            """Process a single URL and optionally return captured output."""
+            """Process a URL and return captured (stdout_messages, stderr_messages)."""
             stdout_messages: list[str] = []
             stderr_messages: list[str] = []
 
@@ -163,6 +163,8 @@ def main(argv=None):
                     max_workers=max_workers
                 ) as executor:
                     if args.outdir:
+                        # Consume the iterator to surface worker exceptions without
+                        # materializing all results in memory.
                         collections.deque(
                             executor.map(process_url, urls_to_process), maxlen=0
                         )

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from html2md import cli
 
-SLOW_RESPONSE_DELAY = 0.05
+MOCK_SLOW_URL_DELAY = 0.05
 
 
 def test_batch_stdout_is_emitted_in_input_order(capsys, tmp_path):
@@ -18,7 +18,7 @@ def test_batch_stdout_is_emitted_in_input_order(capsys, tmp_path):
 
     def get_response(url, **_kwargs):
         if url.endswith("/slow"):
-            time.sleep(SLOW_RESPONSE_DELAY)
+            time.sleep(MOCK_SLOW_URL_DELAY)
         response = MagicMock()
         response.text = f"<h1>{url.rsplit('/', 1)[-1]}</h1>"
         response.raise_for_status.return_value = None

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 from html2md import cli
 
+SLOW_RESPONSE_DELAY = 0.05
+
 
 def test_batch_stdout_is_emitted_in_input_order(capsys, tmp_path):
     """Concurrent batch conversion without --outdir prints in batch-file order."""
@@ -16,7 +18,7 @@ def test_batch_stdout_is_emitted_in_input_order(capsys, tmp_path):
 
     def get_response(url, **_kwargs):
         if url.endswith("/slow"):
-            time.sleep(0.05)
+            time.sleep(SLOW_RESPONSE_DELAY)
         response = MagicMock()
         response.text = f"<h1>{url.rsplit('/', 1)[-1]}</h1>"
         response.raise_for_status.return_value = None

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -51,3 +51,12 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+def test_batch_consumes_worker_results_to_surface_failures(tmp_path):
+    """Worker exceptions from batch processing are surfaced to the caller."""
+    batch_file = tmp_path / "urls.txt"
+    batch_file.write_text("http://[\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
+        cli.main(["--batch", str(batch_file)])


### PR DESCRIPTION
### Motivation

- Exceptions raised inside worker threads were not being propagated because the `ThreadPoolExecutor.map` iterator was never consumed, so some malformed batch entries could fail silently.  
- Add a regression test to ensure worker-side errors are observed by the main thread to prevent future regressions.

### Description

- Consume the iterator returned by `executor.map(...)` by wrapping it in `list()` in `src/html2md/cli.py` so worker exceptions propagate to the caller.  
- Add `test_batch_consumes_worker_results_to_surface_failures` to `tests/test_cli_security.py` to assert that a malformed batch URL (e.g. `http://[`) raises `ValueError` when `--batch` is used.  
- Preserve existing batch behavior and `max_workers` caps while improving error visibility.

### Testing

- Ran the test suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, and all tests completed successfully.  
- The new regression test verifies a malformed batch entry raises an exception and therefore fails fast instead of being silently ignored.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4eef4cb88320b69ec78bd74df6d9)