### PR TITLE
Fix batch outdir creation race and surface ThreadPoolExecutor errors

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -153,8 +153,8 @@ def main(argv=None):
                         urls_to_process.append(u)
 
             if urls_to_process:
-                from collections import deque  # pylint: disable=import-outside-toplevel
                 import concurrent.futures  # pylint: disable=import-outside-toplevel
+                from collections import deque  # pylint: disable=import-outside-toplevel
                 from functools import partial  # pylint: disable=import-outside-toplevel
 
                 # Cap max_workers to 10 to avoid overwhelming servers

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -153,7 +153,9 @@ def main(argv=None):
                         urls_to_process.append(u)
 
             if urls_to_process:
+                from collections import deque  # pylint: disable=import-outside-toplevel
                 import concurrent.futures  # pylint: disable=import-outside-toplevel
+                from functools import partial  # pylint: disable=import-outside-toplevel
 
                 # Cap max_workers to 10 to avoid overwhelming servers
                 max_workers = min(10, len(urls_to_process))
@@ -161,13 +163,10 @@ def main(argv=None):
                     max_workers=max_workers
                 ) as executor:
                     if args.outdir:
-                        for _ in executor.map(process_url, urls_to_process):
-                            pass
+                        deque(executor.map(process_url, urls_to_process), maxlen=0)
                     else:
                         for stdout_messages, stderr_messages in executor.map(
-                            lambda target_url: process_url(
-                                target_url, emit_output=False
-                            ),
+                            partial(process_url, emit_output=False),
                             urls_to_process,
                         ):
                             for message in stdout_messages:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -87,8 +87,7 @@ def main(argv=None):
                 md_content = md(response.text, heading_style="ATX")
 
                 if args.outdir:
-                    if not os.path.exists(args.outdir):
-                        os.makedirs(args.outdir)
+                    os.makedirs(args.outdir, exist_ok=True)
 
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
@@ -147,7 +146,7 @@ def main(argv=None):
                 with concurrent.futures.ThreadPoolExecutor(
                     max_workers=max_workers
                 ) as executor:
-                    executor.map(process_url, urls_to_process)
+                    list(executor.map(process_url, urls_to_process))
 
         return 0
 

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -88,7 +88,7 @@ def test_batch_stdout_is_emitted_in_input_order(capsys, tmp_path):
         encoding="utf-8",
     )
 
-    def get_response(url, **_kwargs):
+    def get_response(url, **kwargs):
         if url.endswith("/slow"):
             time.sleep(0.05)
         response = MagicMock()

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -1,0 +1,79 @@
+"""Tests for CLI batch processing behavior."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from html2md import cli
+
+
+@patch("requests.Session.get")
+def test_batch_creates_missing_outdir_idempotently(mock_get, monkeypatch, tmp_path):
+    """Parallel batch writes create the output directory without racing."""
+    batch_file = tmp_path / "urls.txt"
+    batch_file.write_text(
+        "http://example.com/posts/first\nhttp://example.com/posts/second\n",
+        encoding="utf-8",
+    )
+    outdir = tmp_path / "output"
+
+    response = MagicMock()
+    response.text = "<h1>Hello</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    real_exists = os.path.exists
+    real_makedirs = os.makedirs
+
+    def stale_outdir_exists(path):
+        if path == str(outdir):
+            return False
+        return real_exists(path)
+
+    def racey_makedirs(path, *args, **kwargs):
+        if (
+            path == str(outdir)
+            and outdir.exists()
+            and not kwargs.get("exist_ok", False)
+        ):
+            raise FileExistsError(path)
+        return real_makedirs(path, *args, **kwargs)
+
+    monkeypatch.setattr(os.path, "exists", stale_outdir_exists)
+    monkeypatch.setattr(os, "makedirs", racey_makedirs)
+
+    cli.main(["--batch", str(batch_file), "--outdir", str(outdir)])
+
+    assert (outdir / "first.md").read_text(encoding="utf-8").strip() == "# Hello"
+    assert (outdir / "second.md").read_text(encoding="utf-8").strip() == "# Hello"
+
+
+def test_batch_consumes_executor_results(monkeypatch, tmp_path):
+    """Batch processing consumes executor results so worker exceptions surface."""
+    batch_file = tmp_path / "urls.txt"
+    batch_file.write_text("http://example.com/posts/first\n", encoding="utf-8")
+
+    class RaisingExecutor:
+        def __init__(self, max_workers):
+            self.max_workers = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def map(self, func, iterable):
+            def results():
+                raise RuntimeError("worker failed")
+                yield  # pragma: no cover
+
+            return results()
+
+    monkeypatch.setattr("concurrent.futures.ThreadPoolExecutor", RaisingExecutor)
+
+    try:
+        cli.main(["--batch", str(batch_file)])
+    except RuntimeError as exc:
+        assert str(exc) == "worker failed"
+    else:
+        raise AssertionError("worker exception was not surfaced")

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from html2md import cli
 
+SLOW_RESPONSE_DELAY = 0.05
+
 
 @patch("requests.Session.get")
 def test_batch_creates_missing_outdir_idempotently(mock_get, monkeypatch, tmp_path):
@@ -90,7 +92,7 @@ def test_batch_stdout_is_emitted_in_input_order(capsys, tmp_path):
 
     def get_response(url, **kwargs):
         if url.endswith("/slow"):
-            time.sleep(0.05)
+            time.sleep(SLOW_RESPONSE_DELAY)
         response = MagicMock()
         response.text = f"<h1>{url.rsplit('/', 1)[-1]}</h1>"
         response.raise_for_status.return_value = None


### PR DESCRIPTION
### Motivation

- Prevent nondeterministic failures when `--batch` spawns concurrent `process_url` workers that race to create the same `--outdir` directory.
- Ensure worker exceptions are propagated to the main thread instead of being silently swallowed by the executor iterator.

### Description

- Replace the non-atomic `if not exists: os.makedirs(...)` with `os.makedirs(args.outdir, exist_ok=True)` to make directory creation idempotent in `src/html2md/cli.py`.
- Consume the iterator returned by `concurrent.futures.ThreadPoolExecutor.map(...)` via `list(...)` so exceptions raised by workers are surfaced to the caller in `src/html2md/cli.py`.
- Add `tests/test_cli_batch.py` with two regression tests: one validating idempotent outdir creation under a simulated race, and one verifying that worker exceptions from the executor are propagated.
- Changes affect `src/html2md/cli.py` and add `tests/test_cli_batch.py`.

### Testing

- Ran the focused batch tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_batch.py tests/test_cli_security.py tests/test_cli_exceptions.py` and observed all targeted tests pass (`9 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` and confirmed success (`22 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4ed84f08832086a99c3f23d70949)