### PR TITLE
Preserve charset fallback for streamed HTML downloads

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -93,15 +93,14 @@ def main(argv=None):
                         return 1
 
                 # Decode using Requests' normal fallback order: explicit encoding,
-                # apparent encoding, then UTF-8 with replacement characters.
+                # apparent encoding, then UTF-8 with replacement characters.  Because
+                # this is a streamed response, derive the apparent encoding from the
+                # bytes we already collected instead of touching response.content via
+                # response.apparent_encoding after iter_content() has consumed it.
                 encoding = response.encoding
                 if not isinstance(encoding, str):
-                    apparent_encoding = response.apparent_encoding
-                    encoding = (
-                        apparent_encoding
-                        if isinstance(apparent_encoding, str)
-                        else 'utf-8'
-                    )
+                    detected = requests.compat.chardet.detect(content).get('encoding')
+                    encoding = detected if isinstance(detected, str) else 'utf-8'
                 try:
                     text_content = content.decode(encoding, errors='replace')
                 except LookupError:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -97,21 +97,23 @@ def main(argv=None):
                     # Decode using Requests' charset choice when available, then
                     # apparent encoding, and finally UTF-8 replacement fallback.
                     apparent_encoding = getattr(response, 'apparent_encoding', None)
+                    content_bytes = bytes(content)
                     encoding = response.encoding
                     if not isinstance(encoding, str):
                         encoding = apparent_encoding
                     if not isinstance(encoding, str):
                         encoding = 'utf-8'
                     try:
-                        text_content = bytes(content).decode(encoding, errors='replace')
+                        text_content = content_bytes.decode(encoding, errors='replace')
                     except LookupError:
+                        text_content = None
                         if isinstance(apparent_encoding, str) and apparent_encoding != encoding:
                             try:
-                                text_content = bytes(content).decode(apparent_encoding, errors='replace')
+                                text_content = content_bytes.decode(apparent_encoding, errors='replace')
                             except LookupError:
-                                text_content = bytes(content).decode('utf-8', errors='replace')
-                        else:
-                            text_content = bytes(content).decode('utf-8', errors='replace')
+                                pass
+                        if text_content is None:
+                            text_content = content_bytes.decode('utf-8', errors='replace')
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -92,11 +92,20 @@ def main(argv=None):
                         print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
                         return 1
 
-                # Decode the content using the response encoding (or default to utf-8)
+                # Decode using Requests' normal fallback order: explicit encoding,
+                # apparent encoding, then UTF-8 with replacement characters.
                 encoding = response.encoding
                 if not isinstance(encoding, str):
-                    encoding = 'utf-8'
-                text_content = content.decode(encoding, errors='replace')
+                    apparent_encoding = response.apparent_encoding
+                    encoding = (
+                        apparent_encoding
+                        if isinstance(apparent_encoding, str)
+                        else 'utf-8'
+                    )
+                try:
+                    text_content = content.decode(encoding, errors='replace')
+                except LookupError:
+                    text_content = content.decode(errors='replace')
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -96,16 +96,16 @@ def main(argv=None):
 
                     # Decode using Requests' charset choice when available, then
                     # apparent encoding, and finally UTF-8 replacement fallback.
+                    apparent_encoding = getattr(response, 'apparent_encoding', None)
                     encoding = response.encoding
                     if not isinstance(encoding, str):
-                        encoding = getattr(response, 'apparent_encoding', None)
+                        encoding = apparent_encoding
                     if not isinstance(encoding, str):
                         encoding = 'utf-8'
                     try:
                         text_content = bytes(content).decode(encoding, errors='replace')
                     except LookupError:
-                        apparent_encoding = getattr(response, 'apparent_encoding', None)
-                        if isinstance(apparent_encoding, str):
+                        if isinstance(apparent_encoding, str) and apparent_encoding != encoding:
                             try:
                                 text_content = bytes(content).decode(apparent_encoding, errors='replace')
                             except LookupError:

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -6,6 +6,17 @@ import requests  # type: ignore[import-untyped]
 from html2md.cli import main
 
 
+def make_stream_response(content: bytes, encoding=None, apparent_encoding=None):
+    """Create a minimal streamed response mock for URL conversion tests."""
+    response = MagicMock()
+    response.headers = {}
+    response.encoding = encoding
+    response.apparent_encoding = apparent_encoding
+    response.iter_content.return_value = [content]
+    response.raise_for_status.return_value = None
+    return response
+
+
 class TestCliExceptions(unittest.TestCase):
     """Unit tests for CLI network, file, and path-containment error handling."""
 
@@ -30,9 +41,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
+                mock_resp = make_stream_response(b"<h1>Hello</h1>", encoding="utf-8")
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
@@ -52,19 +61,17 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
+                mock_resp = make_stream_response(b"<h1>Hello</h1>", encoding="utf-8")
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
                         import builtins
                         real_open = builtins.open
-                        def custom_open(*args, **kwargs):
-                            if str(args[0]).endswith('.md'):
+                        def custom_open(file, *args, **kwargs):
+                            if str(file).endswith('.md'):
                                 return MagicMock()
-                            return real_open(*args, **kwargs)
+                            return real_open(file, *args, **kwargs)
                         with patch('builtins.open', side_effect=custom_open) as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
@@ -79,3 +86,36 @@ class TestCliExceptions(unittest.TestCase):
                             # Verify open was not called for our expected markdown file
                             for call in mock_open.call_args_list:
                                 self.assertFalse(str(call[0][0]).endswith('.md'))
+
+    def test_uses_apparent_encoding_for_streamed_response(self):
+        """Requests' apparent encoding should decode streamed legacy HTML."""
+        with patch('requests.Session.get') as mock_get:
+            mock_get.return_value = make_stream_response(
+                b"<p>\x93Hello\x94</p>",
+                encoding=None,
+                apparent_encoding="Windows-1252",
+            )
+
+            with patch('markdownify.markdownify', return_value="converted") as mock_md:
+                main(['--url', 'http://example.com'])
+
+            mock_md.assert_called_once()
+            html_arg = mock_md.call_args.args[0]
+            self.assertIn("“Hello”", html_arg)
+
+    def test_invalid_response_encoding_falls_back_to_replacement_decode(self):
+        """Malformed charset names should not fail conversion."""
+        captured_stderr = io.StringIO()
+        with patch('sys.stderr', captured_stderr):
+            with patch('requests.Session.get') as mock_get:
+                mock_get.return_value = make_stream_response(
+                    b"<p>\x93Hello\x94</p>",
+                    encoding="bogus-charset",
+                )
+
+                with patch('markdownify.markdownify', return_value="converted") as mock_md:
+                    main(['--url', 'http://example.com'])
+
+        mock_md.assert_called_once()
+        self.assertNotIn("Conversion failed", captured_stderr.getvalue())
+

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -8,13 +8,25 @@ from html2md.cli import main
 
 def make_stream_response(content: bytes, encoding=None, apparent_encoding=None):
     """Create a minimal streamed response mock for URL conversion tests."""
-    response = MagicMock()
-    response.headers = {}
-    response.encoding = encoding
-    response.apparent_encoding = apparent_encoding
-    response.iter_content.return_value = [content]
-    response.raise_for_status.return_value = None
-    return response
+
+    class StreamResponse:
+        """Tiny response stand-in that can fail if apparent_encoding is read."""
+
+        headers = {}
+
+        def __init__(self):
+            self.encoding = encoding
+            self._apparent_encoding = apparent_encoding
+            self.raise_for_status = MagicMock(return_value=None)
+            self.iter_content = MagicMock(return_value=[content])
+
+        @property
+        def apparent_encoding(self):
+            if isinstance(self._apparent_encoding, Exception):
+                raise self._apparent_encoding
+            return self._apparent_encoding
+
+    return StreamResponse()
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -87,17 +99,24 @@ class TestCliExceptions(unittest.TestCase):
                             for call in mock_open.call_args_list:
                                 self.assertFalse(str(call[0][0]).endswith('.md'))
 
-    def test_uses_apparent_encoding_for_streamed_response(self):
-        """Requests' apparent encoding should decode streamed legacy HTML."""
+    def test_uses_detected_encoding_for_streamed_response(self):
+        """Collected bytes should provide the fallback encoding for legacy HTML."""
         with patch('requests.Session.get') as mock_get:
             mock_get.return_value = make_stream_response(
                 b"<p>\x93Hello\x94</p>",
                 encoding=None,
-                apparent_encoding="Windows-1252",
+                apparent_encoding=RuntimeError("stream consumed"),
             )
 
-            with patch('markdownify.markdownify', return_value="converted") as mock_md:
-                main(['--url', 'http://example.com'])
+            with patch(
+                'requests.compat.chardet.detect',
+                return_value={'encoding': 'Windows-1252'},
+            ):
+                with patch(
+                    'markdownify.markdownify',
+                    return_value="converted",
+                ) as mock_md:
+                    main(['--url', 'http://example.com'])
 
             mock_md.assert_called_once()
             html_arg = mock_md.call_args.args[0]


### PR DESCRIPTION
### Motivation

- Ensure streamed HTML bytes are decoded the same way Requests would decode `response.text` to avoid corrupting legacy-encoded pages when `stream=True` is used. 
- Make conversion robust against malformed `charset` headers so malformed headers do not cause the conversion to fail.

### Description

- Change `src/html2md/cli.py` to prefer `response.encoding`, then `response.apparent_encoding`, then UTF-8 with replacement characters for decoding streamed bytes, and catch `LookupError` to fall back to a safe replacement decode. 
- Add a `make_stream_response` helper and update tests in `tests/test_cli_exceptions.py` to mock streamed responses via `iter_content()` instead of relying on `.text`. 
- Harden tests by changing the `custom_open` mock to accept an explicit `file` parameter so keyword/positional `open()` calls are handled safely. 
- Add tests that assert apparent-encoding (Windows-1252) is used for legacy pages and that malformed charset names do not cause conversion failures.

### Testing

- Installed the package in editable mode and ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest`. 
- Result: `22 passed` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4ebeea9c8320a5f99df1af27fbdb)