### PR TITLE
Close streamed responses on oversize abort

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from contextlib import closing
 from urllib.parse import urlparse, unquote
 
 def main(argv=None):
@@ -72,31 +73,31 @@ def main(argv=None):
                 print("Fetching content...")
                 # Security: Use a connect timeout of 5s and read timeout of 30s.
                 # Use stream=True to prevent loading massive files into memory all at once.
-                response = session.get(target_url, timeout=(5, 30), stream=True)
-                response.raise_for_status()
+                with closing(session.get(target_url, timeout=(5, 30), stream=True)) as response:
+                    response.raise_for_status()
 
-                # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
-                max_size = 10 * 1024 * 1024
-                content_length = response.headers.get('Content-Length')
-                try:
-                    if content_length and int(content_length) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
-                except ValueError:
-                    pass
+                    # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
+                    max_size = 10 * 1024 * 1024
+                    content_length = response.headers.get('Content-Length')
+                    try:
+                        if content_length and int(content_length) > max_size:
+                            print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
+                            return 1
+                    except ValueError:
+                        pass
 
-                content = b""
-                for chunk in response.iter_content(chunk_size=8192):
-                    content += chunk
-                    if len(content) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
+                    content = b""
+                    for chunk in response.iter_content(chunk_size=8192):
+                        content += chunk
+                        if len(content) > max_size:
+                            print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
+                            return 1
 
-                # Decode the content using the response encoding (or default to utf-8)
-                encoding = response.encoding
-                if not isinstance(encoding, str):
-                    encoding = 'utf-8'
-                text_content = content.decode(encoding, errors='replace')
+                    # Decode the content using the response encoding (or default to utf-8)
+                    encoding = response.encoding
+                    if not isinstance(encoding, str):
+                        encoding = 'utf-8'
+                    text_content = content.decode(encoding, errors='replace')
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -51,3 +51,22 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+@patch("requests.Session.get")
+def test_streaming_oversize_response_is_closed(mock_get, capsys):
+    """Oversized streamed responses are closed on early abort."""
+    response = MagicMock()
+    response.headers = {}
+    response.encoding = "utf-8"
+    response.raise_for_status.return_value = None
+    response.iter_content.return_value = [b"x" * (10 * 1024 * 1024 + 1)]
+    mock_get.return_value = response
+
+    with patch("markdownify.markdownify") as mock_markdownify:
+        cli.main(["--url", "http://example.com/oversized"])
+
+    outerr = capsys.readouterr()
+    assert "Error: Content exceeds maximum allowed size (10MB)." in outerr.err
+    response.close.assert_called_once_with()
+    mock_markdownify.assert_not_called()


### PR DESCRIPTION
### Motivation
- Prevent leaking HTTP connections when a streamed download is aborted early due to the 10MB size limit, which can tie up sockets and exhaust the requests connection pool in batch runs.
- Ensure the oversize/error path always releases network resources so subsequent requests behave predictably.

### Description
- Wrap `session.get(..., stream=True)` in `contextlib.closing(...)` so the response is closed even when the code returns early from size-limit checks in `src/html2md/cli.py`.
- Preserve the existing 10MB `Content-Length` and streaming read checks and the decoding/markdown conversion logic while ensuring the response is released on the early-abort path.
- Add `test_streaming_oversize_response_is_closed` to `tests/test_cli_security.py` which simulates an oversized streamed response, asserts the error message is printed, verifies `response.close()` was called, and ensures `markdownify` is not invoked.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest -q` and the test suite completed successfully with all tests passing.
- The new regression test verifies the oversize abort path and confirms network resources are closed and conversion is skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4eb50aec8320931856808e7dc854)