### PR TITLE
Fix streamed URL decoding and status handling

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -153,7 +153,7 @@ def main(argv=None):
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
                 print(f"Conversion failed: {e}", file=sys.stderr)
-            return 1
+                return 1
 
         exit_status = 0
 

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -54,8 +54,8 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def process_url(target_url: str) -> None:
-            """Process a single URL."""
+        def process_url(target_url: str) -> int:
+            """Process a single URL and return a process-style status code."""
             # Fix common URL typo: trailing slash before query parameters
             if '/?' in target_url:
                 target_url = target_url.replace('/?', '?')
@@ -64,7 +64,7 @@ def main(argv=None):
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
-                return
+                return 1
 
             print(f"Processing URL: {target_url}")
 
@@ -72,31 +72,38 @@ def main(argv=None):
                 print("Fetching content...")
                 # Security: Use a connect timeout of 5s and read timeout of 30s.
                 # Use stream=True to prevent loading massive files into memory all at once.
-                response = session.get(target_url, timeout=(5, 30), stream=True)
-                response.raise_for_status()
+                with session.get(target_url, timeout=(5, 30), stream=True) as response:
+                    response.raise_for_status()
 
-                # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
-                max_size = 10 * 1024 * 1024
-                content_length = response.headers.get('Content-Length')
-                try:
-                    if content_length and int(content_length) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
-                except ValueError:
-                    pass
+                    # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
+                    max_size = 10 * 1024 * 1024
+                    content_length = response.headers.get('Content-Length')
+                    try:
+                        if content_length and int(content_length) > max_size:
+                            print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
+                            return 1
+                    except ValueError:
+                        # Ignore malformed Content-Length and rely on streamed size checks.
+                        pass
 
-                content = b""
-                for chunk in response.iter_content(chunk_size=8192):
-                    content += chunk
-                    if len(content) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
+                    content = bytearray()
+                    for chunk in response.iter_content(chunk_size=8192):
+                        content.extend(chunk)
+                        if len(content) > max_size:
+                            print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
+                            return 1
 
-                # Decode the content using the response encoding (or default to utf-8)
-                encoding = response.encoding
-                if not isinstance(encoding, str):
-                    encoding = 'utf-8'
-                text_content = content.decode(encoding, errors='replace')
+                    content_bytes = bytes(content)
+                    # Match Requests' text-decoding behavior after enforcing the byte limit.
+                    # This preserves charset detection for legacy pages without a charset header
+                    # and gracefully handles invalid charset values from malformed headers.
+                    response._content = content_bytes  # pylint: disable=protected-access
+                    response._content_consumed = True  # pylint: disable=protected-access
+                    encoding = response.encoding or response.apparent_encoding
+                    try:
+                        text_content = content_bytes.decode(encoding, errors='replace')
+                    except (LookupError, TypeError):
+                        text_content = str(content_bytes, errors='replace')
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")
@@ -123,22 +130,27 @@ def main(argv=None):
                     if os.path.commonpath([real_outdir, real_out_path]) != real_outdir:
                         print("Error: Output path escapes output directory.",
                               file=sys.stderr)
-                        return
+                        return 1
                     with open(out_path, 'w', encoding='utf-8') as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
                     print(md_content)
+                return 0
 
             except requests.RequestException as e:
                 print(f"Network error: {e}", file=sys.stderr)
+                return 1
             except OSError as e:
                 print(f"File error: {e}", file=sys.stderr)
+                return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
                 print(f"Conversion failed: {e}", file=sys.stderr)
+                return 1
 
+        status = 0
         if args.url:
-            process_url(args.url)
+            status = max(status, process_url(args.url))
 
         if args.batch:
             if not os.path.exists(args.batch):
@@ -148,9 +160,9 @@ def main(argv=None):
                 for line in f:
                     u = line.strip()
                     if u:
-                        process_url(u)
+                        status = max(status, process_url(u))
 
-        return 0
+        return status
 
     ap.print_help()
     return 0

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -52,7 +52,13 @@ class TestCliError(unittest.TestCase):
         mock_session = MagicMock()
         mock_requests.Session.return_value = mock_session
         mock_response = MagicMock()
-        mock_response.text = "<html></html>"
+        mock_response.headers = {}
+        mock_response.encoding = "utf-8"
+        mock_response.apparent_encoding = "utf-8"
+        mock_response.iter_content.return_value = [b"<html></html>"]
+        mock_response.raise_for_status.return_value = None
+        mock_response.__enter__.return_value = mock_response
+        mock_response.__exit__.return_value = None
         mock_session.get.return_value = mock_response
 
         mock_markdownify = MagicMock()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -6,6 +6,19 @@ import requests  # type: ignore[import-untyped]
 from html2md.cli import main
 
 
+def mock_stream_response(html=b"<h1>Hello</h1>", encoding="utf-8", headers=None):
+    """Create a context-manager response mock for streamed CLI downloads."""
+    mock_resp = MagicMock()
+    mock_resp.headers = headers or {}
+    mock_resp.encoding = encoding
+    mock_resp.apparent_encoding = encoding or "utf-8"
+    mock_resp.iter_content.return_value = [html]
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = None
+    return mock_resp
+
+
 class TestCliExceptions(unittest.TestCase):
     """Unit tests for CLI network, file, and path-containment error handling."""
 
@@ -30,10 +43,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+                mock_get.return_value = mock_stream_response()
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
@@ -52,19 +62,16 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+                mock_get.return_value = mock_stream_response()
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
                         import builtins
                         real_open = builtins.open
-                        def custom_open(*args, **kwargs):
-                            if str(args[0]).endswith('.md'):
+                        def custom_open(file, *args, **kwargs):
+                            if str(file).endswith('.md'):
                                 return MagicMock()
-                            return real_open(*args, **kwargs)
+                            return real_open(file, *args, **kwargs)
                         with patch('builtins.open', side_effect=custom_open) as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -6,6 +6,19 @@ import pytest
 from html2md import cli
 
 
+def mock_stream_response(html=b"<h1>dummy</h1>", encoding="utf-8", headers=None):
+    """Create a context-manager response mock for streamed CLI downloads."""
+    response = MagicMock()
+    response.headers = headers or {}
+    response.encoding = encoding
+    response.apparent_encoding = encoding or "utf-8"
+    response.iter_content.return_value = [html]
+    response.raise_for_status.return_value = None
+    response.__enter__.return_value = response
+    response.__exit__.return_value = None
+    return response
+
+
 @pytest.mark.parametrize(
     "url, scheme",
     [
@@ -32,10 +45,7 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     secret_file = tmp_path / "secret.txt"
     secret_file.write_text("secret content", encoding="utf-8")
 
-    response = MagicMock()
-    response.text = "<h1>dummy</h1>"
-    response.raise_for_status.return_value = None
-    mock_get.return_value = response
+    mock_get.return_value = mock_stream_response()
 
     urls = [
         "http://example.com/foo/../..%2Fsecret.txt",
@@ -51,3 +61,50 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+@patch("requests.Session.get")
+def test_streamed_response_uses_apparent_encoding(mock_get, capsys):
+    """Legacy pages without charset headers use Requests' detected encoding."""
+    mock_get.return_value = mock_stream_response(
+        b"<p>caf\xe9</p>", encoding=None, headers={}
+    )
+    mock_get.return_value.apparent_encoding = "windows-1252"
+
+    status = cli.main(["--url", "http://example.com/legacy"])
+
+    outerr = capsys.readouterr()
+    assert status == 0
+    assert "café" in outerr.out
+
+
+@patch("requests.Session.get")
+def test_oversized_content_length_returns_nonzero_and_closes(mock_get, capsys):
+    """Oversized responses fail the CLI and release the streamed response."""
+    mock_get.return_value = mock_stream_response(
+        b"", headers={"Content-Length": str(10 * 1024 * 1024 + 1)}
+    )
+
+    status = cli.main(["--url", "http://example.com/huge"])
+
+    outerr = capsys.readouterr()
+    assert status == 1
+    assert "Content exceeds maximum allowed size" in outerr.err
+    mock_get.return_value.__exit__.assert_called_once()
+
+
+@patch("requests.Session.get")
+def test_oversized_stream_returns_nonzero_and_closes(mock_get, capsys):
+    """Responses that exceed the limit while streaming fail and are closed."""
+    mock_get.return_value = mock_stream_response(headers={})
+    mock_get.return_value.iter_content.return_value = [
+        b"x" * (10 * 1024 * 1024),
+        b"x",
+    ]
+
+    status = cli.main(["--url", "http://example.com/huge-stream"])
+
+    outerr = capsys.readouterr()
+    assert status == 1
+    assert "Content exceeds maximum allowed size" in outerr.err
+    mock_get.return_value.__exit__.assert_called_once()


### PR DESCRIPTION
### Motivation
- Recent hardening switched to streamed byte reads but lost Requests' charset detection and returned magic-number status codes while also risking leaked connections and quadratic memory growth when accumulating chunks.
- Preserve correct text decoding for legacy encodings, make early-abort paths release connections, and propagate failures to the CLI exit status so callers and CI can detect blocked conversions.

### Description
- Change `process_url` to return an `int` status and aggregate per-URL statuses in `main` so oversized or failed conversions produce a non-zero exit code. (`src/html2md/cli.py`)
- Wrap `session.get(..., stream=True)` in a context manager to ensure the streamed response is closed on all paths, and replace `content += chunk` with a `bytearray`/`bytes` pattern to keep streaming reads linear-time while enforcing the 10MB limit. (`src/html2md/cli.py`)
- Preserve Requests-style decoding by writing the bounded bytes into `response._content`/`response._content_consumed`, use `response.encoding or response.apparent_encoding`, and catch `LookupError`/`TypeError` to fall back on a replacement decode when headers are malformed. (`src/html2md/cli.py`)
- Update tests and mocks to support streaming/context-manager responses, add tests for legacy `apparent_encoding` handling and oversized responses (both header-based and streaming-based), and make the `open` mock accept an explicit `file` parameter to avoid fragile positional-arg assumptions. (`tests/test_cli_security.py`, `tests/test_cli_exceptions.py`, `tests/test_cli_error.py`)

### Testing
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, which completed successfully (all tests passed).
- Ran `git diff --check` to ensure no whitespace/git-diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4ea350188320b854fd648c49e947)