### PR TITLE
Close streamed responses on oversized URL aborts

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -73,30 +73,33 @@ def main(argv=None):
                 # Security: Use a connect timeout of 5s and read timeout of 30s.
                 # Use stream=True to prevent loading massive files into memory all at once.
                 response = session.get(target_url, timeout=(5, 30), stream=True)
-                response.raise_for_status()
-
-                # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
-                max_size = 10 * 1024 * 1024
-                content_length = response.headers.get('Content-Length')
                 try:
-                    if content_length and int(content_length) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
-                except ValueError:
-                    pass
+                    response.raise_for_status()
 
-                content = b""
-                for chunk in response.iter_content(chunk_size=8192):
-                    content += chunk
-                    if len(content) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
+                    # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
+                    max_size = 10 * 1024 * 1024
+                    content_length = response.headers.get('Content-Length')
+                    try:
+                        if content_length and int(content_length) > max_size:
+                            print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
+                            return 1
+                    except ValueError:
+                        pass
 
-                # Decode the content using the response encoding (or default to utf-8)
-                encoding = response.encoding
-                if not isinstance(encoding, str):
-                    encoding = 'utf-8'
-                text_content = content.decode(encoding, errors='replace')
+                    content = b""
+                    for chunk in response.iter_content(chunk_size=8192):
+                        content += chunk
+                        if len(content) > max_size:
+                            print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
+                            return 1
+
+                    # Decode the content using the response encoding (or default to utf-8)
+                    encoding = response.encoding
+                    if not isinstance(encoding, str):
+                        encoding = 'utf-8'
+                    text_content = content.decode(encoding, errors='replace')
+                finally:
+                    response.close()
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -51,3 +51,53 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
+
+
+class StreamingResponse:
+    """Minimal streamed response test double for CLI download handling."""
+
+    def __init__(self, chunks, headers=None, encoding="utf-8"):
+        self._chunks = chunks
+        self.headers = headers or {}
+        self.encoding = encoding
+        self.closed = False
+
+    def raise_for_status(self):
+        """Simulate a successful response."""
+
+    def iter_content(self, chunk_size=8192):  # pylint: disable=unused-argument
+        """Yield configured response chunks."""
+        yield from self._chunks
+
+    def close(self):
+        """Record that the streamed response was released."""
+        self.closed = True
+
+
+@patch("requests.Session.get")
+def test_header_oversize_response_is_closed(mock_get, capsys):
+    """Header-size aborts must close streamed responses promptly."""
+    response = StreamingResponse(
+        chunks=[],
+        headers={"Content-Length": str((10 * 1024 * 1024) + 1)},
+    )
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://example.com/large"])
+
+    outerr = capsys.readouterr()
+    assert "Content exceeds maximum allowed size" in outerr.err
+    assert response.closed is True
+
+
+@patch("requests.Session.get")
+def test_streaming_oversize_response_is_closed(mock_get, capsys):
+    """Streaming-size aborts must close streamed responses promptly."""
+    response = StreamingResponse(chunks=[b"a" * ((10 * 1024 * 1024) + 1)])
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://example.com/large"])
+
+    outerr = capsys.readouterr()
+    assert "Content exceeds maximum allowed size" in outerr.err
+    assert response.closed is True


### PR DESCRIPTION
### Motivation
- Prevent leaking HTTP connections when `stream=True` is used and early-return paths (Content-Length or streaming size checks) abort processing. 
- Ensure the 10MB download-size guard does not hold sockets open in batch runs or under malicious inputs. 
- Add regression tests to prevent future regressions for both header-based and streaming-size aborts.

### Description
- Wrap the streamed response processing in a `try`/`finally` and call `response.close()` in the `finally` to always release the connection (`src/html2md/cli.py`).
- Keep the existing 10MB size checks (header and incremental read) and preserve the early-return behavior while ensuring cleanup. 
- Add a minimal `StreamingResponse` test double and two tests (`test_header_oversize_response_is_closed` and `test_streaming_oversize_response_is_closed`) that assert `close()` is called on oversized responses (`tests/test_cli_security.py`).

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest` which completed successfully with all tests passing (`22 passed`).
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_cli_security.py -q` which passed and validated the new regression tests. 
- Ran `python -m compileall src tests` which succeeded to ensure files compile cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e96855c83208605e2edb3ae51bf)