### PR TITLE
Propagate oversized download failures through CLI status

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,13 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
+SUCCESS = 0
+FAILURE = 1
+MAX_DOWNLOAD_SIZE = 10 * 1024 * 1024
+DOWNLOAD_CHUNK_SIZE = 8192
+REQUEST_TIMEOUT = (5, 30)
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -54,8 +61,8 @@ def main(argv=None):
             'Sec-Fetch-User': '?1',
         })
 
-        def process_url(target_url: str) -> None:
-            """Process a single URL."""
+        def process_url(target_url: str) -> int:
+            """Process a single URL and return a CLI status code."""
             # Fix common URL typo: trailing slash before query parameters
             if '/?' in target_url:
                 target_url = target_url.replace('/?', '?')
@@ -64,39 +71,49 @@ def main(argv=None):
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
-                return
+                return FAILURE
 
             print(f"Processing URL: {target_url}")
 
+            response = None
             try:
                 print("Fetching content...")
                 # Security: Use a connect timeout of 5s and read timeout of 30s.
                 # Use stream=True to prevent loading massive files into memory all at once.
-                response = session.get(target_url, timeout=(5, 30), stream=True)
+                response = session.get(target_url, timeout=REQUEST_TIMEOUT, stream=True)
                 response.raise_for_status()
 
                 # Security: Limit download to 10MB to prevent DoS via memory exhaustion.
-                max_size = 10 * 1024 * 1024
                 content_length = response.headers.get('Content-Length')
                 try:
-                    if content_length and int(content_length) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
+                    if content_length and int(content_length) > MAX_DOWNLOAD_SIZE:
+                        print(
+                            "Error: Content exceeds maximum allowed size (10MB).",
+                            file=sys.stderr,
+                        )
+                        return FAILURE
                 except ValueError:
+                    # Ignore malformed Content-Length and rely on the streaming size check.
                     pass
 
-                content = b""
-                for chunk in response.iter_content(chunk_size=8192):
-                    content += chunk
-                    if len(content) > max_size:
-                        print("Error: Content exceeds maximum allowed size (10MB).", file=sys.stderr)
-                        return 1
+                content = bytearray()
+                for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    content.extend(chunk)
+                    if len(content) > MAX_DOWNLOAD_SIZE:
+                        print(
+                            "Error: Content exceeds maximum allowed size (10MB).",
+                            file=sys.stderr,
+                        )
+                        return FAILURE
 
-                # Decode the content using the response encoding (or default to utf-8)
-                encoding = response.encoding
+                # Decode using Requests' detected encoding, falling back for missing/bad charsets.
+                encoding = response.encoding or response.apparent_encoding
                 if not isinstance(encoding, str):
                     encoding = 'utf-8'
-                text_content = content.decode(encoding, errors='replace')
+                try:
+                    text_content = bytes(content).decode(encoding, errors='replace')
+                except LookupError:
+                    text_content = bytes(content).decode('utf-8', errors='replace')
 
                 print("Converting to Markdown...")
                 md_content = md(text_content, heading_style="ATX")
@@ -123,12 +140,14 @@ def main(argv=None):
                     if os.path.commonpath([real_outdir, real_out_path]) != real_outdir:
                         print("Error: Output path escapes output directory.",
                               file=sys.stderr)
-                        return
+                        return FAILURE
                     with open(out_path, 'w', encoding='utf-8') as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
                     print(md_content)
+
+                return SUCCESS
 
             except requests.RequestException as e:
                 print(f"Network error: {e}", file=sys.stderr)
@@ -136,9 +155,17 @@ def main(argv=None):
                 print(f"File error: {e}", file=sys.stderr)
             except Exception as e:  # pylint: disable=broad-exception-caught
                 print(f"Conversion failed: {e}", file=sys.stderr)
+            finally:
+                if response is not None:
+                    response.close()
+
+            return FAILURE
+
+        exit_status = SUCCESS
 
         if args.url:
-            process_url(args.url)
+            if process_url(args.url) != SUCCESS:
+                exit_status = FAILURE
 
         if args.batch:
             if not os.path.exists(args.batch):
@@ -148,9 +175,10 @@ def main(argv=None):
                 for line in f:
                     u = line.strip()
                     if u:
-                        process_url(u)
+                        if process_url(u) != SUCCESS:
+                            exit_status = FAILURE
 
-        return 0
+        return exit_status
 
     ap.print_help()
     return 0

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -118,6 +118,8 @@ def main(argv=None):
                 # Decode using Requests' detected encoding, falling back for missing/bad charsets.
                 encoding = response.encoding
                 if not isinstance(encoding, str):
+                    encoding = getattr(response, 'apparent_encoding', None)
+                if not isinstance(encoding, str):
                     encoding = 'utf-8'
                 try:
                     text_content = bytes(content).decode(encoding, errors='replace')

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -52,7 +52,10 @@ class TestCliError(unittest.TestCase):
         mock_session = MagicMock()
         mock_requests.Session.return_value = mock_session
         mock_response = MagicMock()
-        mock_response.text = "<html></html>"
+        mock_response.headers = {}
+        mock_response.encoding = 'utf-8'
+        mock_response.apparent_encoding = 'utf-8'
+        mock_response.iter_content.return_value = [b"<html></html>"]
         mock_session.get.return_value = mock_response
 
         mock_markdownify = MagicMock()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -2,8 +2,20 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import io
+import tempfile
 import requests  # type: ignore[import-untyped]
-from html2md.cli import main
+from html2md.cli import FAILURE, MAX_DOWNLOAD_SIZE, main
+
+
+def make_stream_response(body=b"<h1>Hello</h1>", headers=None):
+    """Create a response mock compatible with streamed downloads."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = headers or {}
+    mock_resp.encoding = 'utf-8'
+    mock_resp.apparent_encoding = 'utf-8'
+    mock_resp.iter_content.return_value = [body]
+    return mock_resp
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -30,10 +42,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+                mock_get.return_value = make_stream_response()
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
@@ -52,19 +61,16 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+                mock_get.return_value = make_stream_response()
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
                         import builtins
                         real_open = builtins.open
-                        def custom_open(*args, **kwargs):
-                            if str(args[0]).endswith('.md'):
+                        def custom_open(file, *args, **kwargs):
+                            if str(file).endswith('.md'):
                                 return MagicMock()
-                            return real_open(*args, **kwargs)
+                            return real_open(file, *args, **kwargs)
                         with patch('builtins.open', side_effect=custom_open) as mock_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
@@ -79,3 +85,67 @@ class TestCliExceptions(unittest.TestCase):
                             # Verify open was not called for our expected markdown file
                             for call in mock_open.call_args_list:
                                 self.assertFalse(str(call[0][0]).endswith('.md'))
+
+    def test_oversized_content_length_returns_failure(self):
+        """Test that advertised oversized responses propagate a failing status."""
+        captured_stderr = io.StringIO()
+        with patch('sys.stderr', captured_stderr):
+            with patch('requests.Session.get') as mock_get:
+                mock_resp = make_stream_response(
+                    headers={'Content-Length': str(MAX_DOWNLOAD_SIZE + 1)}
+                )
+                mock_get.return_value = mock_resp
+
+                status = main(['--url', 'http://example.com/large'])
+
+                self.assertEqual(status, FAILURE)
+                self.assertIn(
+                    "Content exceeds maximum allowed size", captured_stderr.getvalue()
+                )
+                mock_resp.close.assert_called_once()
+
+    def test_oversized_stream_returns_failure(self):
+        """Test that streamed oversized responses propagate a failing status."""
+        captured_stderr = io.StringIO()
+        with patch('sys.stderr', captured_stderr):
+            with patch('requests.Session.get') as mock_get:
+                mock_resp = make_stream_response(
+                    body=b'a' * (MAX_DOWNLOAD_SIZE + 1),
+                    headers={'Content-Length': 'not-a-number'},
+                )
+                mock_get.return_value = mock_resp
+
+                status = main(['--url', 'http://example.com/large'])
+
+                self.assertEqual(status, FAILURE)
+                self.assertIn(
+                    "Content exceeds maximum allowed size", captured_stderr.getvalue()
+                )
+                mock_resp.close.assert_called_once()
+
+    def test_batch_aggregates_oversized_url_failure(self):
+        """Test that batch mode returns failure if any URL is oversized."""
+        captured_stderr = io.StringIO()
+        with tempfile.NamedTemporaryFile('w', encoding='utf-8') as batch_file:
+            batch_file.write('http://example.com/small\n')
+            batch_file.write('http://example.com/large\n')
+            batch_file.flush()
+
+            with patch('sys.stderr', captured_stderr):
+                with patch('requests.Session.get') as mock_get:
+                    small_resp = make_stream_response(body=b'<h1>Small</h1>')
+                    large_resp = make_stream_response(
+                        headers={'Content-Length': str(MAX_DOWNLOAD_SIZE + 1)}
+                    )
+                    mock_get.side_effect = [small_resp, large_resp]
+
+                    status = main(['--batch', batch_file.name])
+
+                    self.assertEqual(status, FAILURE)
+                    self.assertIn(
+                        "Content exceeds maximum allowed size",
+                        captured_stderr.getvalue(),
+                    )
+                    self.assertEqual(mock_get.call_count, 2)
+                    small_resp.close.assert_called_once()
+                    large_resp.close.assert_called_once()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -11,7 +11,7 @@ import requests  # type: ignore[import-untyped]
 from html2md.cli import FAILURE, MAX_DOWNLOAD_SIZE, main
 
 
-def mock_response(body=b'<h1>Hello</h1>', *, headers=None, encoding='utf-8'):
+def mock_stream_response(body=b'<h1>Hello</h1>', *, headers=None, encoding='utf-8'):
     """Create a streamed response mock for CLI URL-fetch tests."""
     response = MagicMock()
     response.status_code = 200
@@ -47,7 +47,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_get.return_value = mock_response()
+                mock_get.return_value = mock_stream_response()
 
                 with patch('markdownify.markdownify', return_value='# Hello'):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
@@ -66,7 +66,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_get.return_value = mock_response()
+                mock_get.return_value = mock_stream_response()
 
                 with patch('markdownify.markdownify', return_value='# Hello'):
                     with patch('os.path.exists', return_value=True):
@@ -97,7 +97,7 @@ class TestCliExceptions(unittest.TestCase):
     def test_invalid_charset_falls_back_to_utf8_replacement(self):
         """Invalid charset headers should not crash decoding."""
         with patch('requests.Session.get') as mock_get:
-            mock_get.return_value = mock_response(
+            mock_get.return_value = mock_stream_response(
                 b'<h1>caf\xe9</h1>',
                 encoding='bogus',
             )
@@ -113,7 +113,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = mock_response(
+                mock_resp = mock_stream_response(
                     headers={'Content-Length': str(MAX_DOWNLOAD_SIZE + 1)},
                 )
                 mock_get.return_value = mock_resp
@@ -129,7 +129,7 @@ class TestCliExceptions(unittest.TestCase):
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
             with patch('requests.Session.get') as mock_get:
-                mock_resp = mock_response(
+                mock_resp = mock_stream_response(
                     body=b'a' * (MAX_DOWNLOAD_SIZE + 1),
                     headers={'Content-Length': 'not-a-number'},
                 )
@@ -153,8 +153,8 @@ class TestCliExceptions(unittest.TestCase):
 
             with patch('sys.stderr', captured_stderr):
                 with patch('requests.Session.get') as mock_get:
-                    small_resp = mock_response(body=b'<h1>Small</h1>')
-                    large_resp = mock_response(
+                    small_resp = mock_stream_response(body=b'<h1>Small</h1>')
+                    large_resp = mock_stream_response(
                         headers={'Content-Length': str(MAX_DOWNLOAD_SIZE + 1)},
                     )
                     mock_get.side_effect = [small_resp, large_resp]

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -33,7 +33,10 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     secret_file.write_text("secret content", encoding="utf-8")
 
     response = MagicMock()
-    response.text = "<h1>dummy</h1>"
+    response.headers = {}
+    response.encoding = 'utf-8'
+    response.apparent_encoding = 'utf-8'
+    response.iter_content.return_value = [b"<h1>dummy</h1>"]
     response.raise_for_status.return_value = None
     mock_get.return_value = response
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -7,7 +7,7 @@ import pytest
 from html2md import cli
 
 
-def mock_response(body=b"<h1>dummy</h1>"):
+def mock_stream_response(body=b"<h1>dummy</h1>"):
     """Create a streamed response mock for CLI URL-fetch tests."""
     response = MagicMock()
     response.headers = {}
@@ -44,7 +44,7 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     secret_file = tmp_path / 'secret.txt'
     secret_file.write_text('secret content', encoding='utf-8')
 
-    mock_get.return_value = mock_response()
+    mock_get.return_value = mock_stream_response()
 
     urls = [
         'http://example.com/foo/../..%2Fsecret.txt',


### PR DESCRIPTION
### Motivation
- The CLI silently returned success when `process_url()` aborted on oversized downloads, preventing wrappers/CI from detecting blocked conversions.  
- Streaming responses opened with `stream=True` were not always closed on early-return paths, risking connection leaks.  
- Existing tests and mocks assumed `response.text` and did not exercise the new streaming/size-check logic.

### Description
- Add module-level constants `SUCCESS`, `FAILURE`, `MAX_DOWNLOAD_SIZE`, `DOWNLOAD_CHUNK_SIZE`, and `REQUEST_TIMEOUT`, and make `process_url()` return an `int` status instead of `None`.  
- Enforce the 10MB limit via `Content-Length` and chunked streaming, accumulate bytes with a `bytearray`, and propagate oversize conditions as `FAILURE`.  
- Decode using `response.encoding`/`response.apparent_encoding` with `LookupError` fallback and use `response.close()` in a `finally` block so streamed responses are always released.  
- Aggregate per-URL statuses in `main()` (single `--url` and `--batch`) and return a non-zero exit code when any URL fails.  
- Update and add tests to mock streamed responses (`headers`, `encoding`, `apparent_encoding`, and `iter_content()`), and add regression tests for advertised oversize, streamed oversize, and batch aggregation behaviors.

### Testing
- Ran unit tests with `PYENV_VERSION=3.12.13 pytest -q` and all tests passed.  
- Verified bytecode compilation with `PYENV_VERSION=3.12.13 python -m compileall -q src tests` which succeeded.  
- Ran `git diff --check` to ensure no trailing/format issues and confirmed there were no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e8a3c188320b476a315d1f72d70)