### PR TITLE
Keep Jules review comment failures non-fatal

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -22,7 +22,6 @@ jobs:
           python - <<'PY'
           import json
           import os
-          import sys
           import urllib.error
           import urllib.request
 
@@ -52,6 +51,5 @@ jobs:
                   )
           except urllib.error.HTTPError as error:
               print(f"Could not request review: {error.read().decode('utf-8')}")
-              print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
+              print("Continuing without failing because review comments are best-effort.")
           PY


### PR DESCRIPTION
### Motivation
- Prevent the workflow from failing when the POST to create an issue comment is rejected (e.g., forked or Dependabot PRs using a read-only token), so the review request remains best-effort instead of making valid external PRs fail.

### Description
- Update the embedded Python in `.github/workflows/request-jules-review.yml` to remove the unused `sys` import and replace the `sys.exit(1)` exit with a logged message (`print("Continuing without failing because review comments are best-effort.")`) when `urllib.error.HTTPError` occurs.

### Testing
- Successfully parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/request-jules-review.yml")'`.
- Successfully compiled the embedded Python snippet with `python3` to validate syntax of the inlined script.
- Ran `git diff --check` to ensure no trailing whitespace or other diff-check issues; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e644b848320aa01d7018c6a21e3)