### PR TITLE
Improve Jules review request and GUI URL launch

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -12,7 +12,7 @@ jobs:
   request-review:
     runs-on: ubuntu-latest
     # Skip forks: the token typically can't write comments there
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Request review from Jules bot
         env:
@@ -56,7 +56,10 @@ jobs:
                   )
           except urllib.error.HTTPError as error:
               if error.code == 403:
-                  print("Skipping: token cannot comment in this PR context (HTTP 403).")
+                  print(
+                      "Warning: token cannot comment in this PR context (HTTP 403); "
+                      "skipping Jules review request."
+                  )
                   sys.exit(0)
               body = error.read().decode("utf-8")
               print(f"Could not request review: {body}")

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -11,10 +11,11 @@ permissions:
 jobs:
   request-review:
     runs-on: ubuntu-latest
-    # Skip forks: the token typically can't write comments there
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Request review from Jules bot
+        # Requesting a Jules review is best-effort; do not block PR checks if
+        # the workflow token cannot write issue comments (common for forks).
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_API_URL: ${{ github.api_url }}
@@ -24,7 +25,6 @@ jobs:
           python - <<'PY'
           import json
           import os
-          import sys
           import urllib.error
           import urllib.request
 
@@ -53,11 +53,17 @@ jobs:
                       f"PR #{pr_number} (status {response.status})"
                   )
           except urllib.error.HTTPError as error:
-              body = error.read().decode("utf-8")
-              print(f"Could not request review: {body}")
-              # Don't fail the entire workflow if GitHub forbids commenting
-              if error.code == 403:
-                  print("Skipping: token cannot comment in this PR context.")
-                  sys.exit(0)
-              raise
+              error_body = error.read().decode("utf-8")
+              print(
+                  "Could not request review from @google-labs-jules; "
+                  "continuing without failing the workflow."
+              )
+              print(f"HTTP {error.code}: {error_body}")
+              print("Ensure the workflow token has permission to comment.")
+          except urllib.error.URLError as error:
+              print(
+                  "Could not request review from @google-labs-jules due to a "
+                  "network error; continuing without failing the workflow."
+              )
+              print(f"Error: {error}")
           PY

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -24,7 +24,6 @@ if ($BatchFile) {
         $url = $_.Trim()
         if (-not [string]::IsNullOrWhiteSpace($url)) {
             Write-Host "Processing: $url"
-            # Default to main content unless BatchWholePage is set
             $argsList = @("--url", "$url", "--outdir", "$outDir", "--all-formats")
             if (-not $BatchWholePage) { $argsList += "--main-content" }
 
@@ -280,17 +279,22 @@ $ConvertBtn.Add_Click({
     }
 
     # --- Security Validation ---
-    try {
-        $uriObj = [System.Uri]$url
-        if ($uriObj.Scheme -notmatch '^https?$') {
-            throw "Invalid scheme"
+    $validatedUrls = @()
+    foreach ($u in $urlList) {
+        try {
+            $uriObj = [System.Uri]$u
+            if ($uriObj.Scheme -notmatch '^https?$') {
+                throw "Invalid scheme"
+            }
+            # AbsoluteUri is properly percent-encoded, preventing quote-based injection
+            $validatedUrls += $uriObj.AbsoluteUri
+        } catch {
+            [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL. Invalid URL: $u", "Invalid URL", "OK", "Error") | Out-Null
+            $ProgressBar.IsIndeterminate = $false
+            return
         }
-        # AbsoluteUri is properly percent-encoded, preventing quote-based injection
-        $url = $uriObj.AbsoluteUri
-    } catch {
-        [System.Windows.MessageBox]::Show("Please enter a valid HTTP/HTTPS URL.","Invalid URL","OK","Error") | Out-Null
-        return
     }
+    $urlList = $validatedUrls
 
     # Reject quotes and other dangerous metacharacters in outdir for defense-in-depth
     if ($outdir -match '[&|;<>^"]' -or $outdir -match '%') {
@@ -316,6 +320,9 @@ $ConvertBtn.Add_Click({
         if ($short) { $scriptDir = $short }
     } catch {}
 
+    $venvExe = Join-Path $scriptDir ".venv\Scripts\html2md.exe"
+    $pyScript = Join-Path $scriptDir "html2md.py"
+
     # Check for Python executable
     $pyCmd = "python"
     if (-not (Get-Command $pyCmd -ErrorAction SilentlyContinue)) {
@@ -329,14 +336,8 @@ $ConvertBtn.Add_Click({
         }
     }
 
-    # Use a robust way to launch the process:
-    # 1. Revert to ProcessStartInfo for precise control over the command line.
-    # 2. Use the "double-quote wrapper" for cmd /c (i.e., /c ""command" args")
-    #    to ensure all internal quotes are preserved and arguments are correctly delimited.
-    # 3. Explicitly quote each argument to prevent metacharacters like & from being interpreted.
     $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = "cmd.exe"
-    $psi.Arguments = "/c `"`"$bat`" --url `"$url`" --outdir `"$outdir`" --all-formats`""
+    $psi.FileName = "powershell.exe"
     $psi.WorkingDirectory = $scriptDir
     $psi.UseShellExecute = $true
 
@@ -371,11 +372,11 @@ $ConvertBtn.Add_Click({
 
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."


### PR DESCRIPTION
### Motivation
- Make the automated Jules review request non-blocking and resilient when the workflow token cannot comment (common for forks) or network errors occur. 
- Harden the Windows GUI launcher to validate and normalize every entered URL to prevent injection/invalid-URL issues. 
- Improve how the GUI finds and launches the converter executable/script so the UI works across different environments and avoids cmd.exe quoting issues.

### Description
- Update `.github/workflows/request-jules-review.yml` to run the review-comment step as best-effort by adding `continue-on-error: true` and replace brittle error handling with tolerant HTTP/URL error logging that does not fail the workflow. 
- Replace single-URL validation in `gui-url-convert.ps1` with per-entry validation that converts each URL to `AbsoluteUri`, rejects invalid schemes, reports the invalid URL via a message box, and uses the validated list for processing. 
- Initialize `venvExe` and `pyScript` paths in the GUI and switch process launches from `cmd.exe` to `powershell.exe`, adding `-ExecutionPolicy Bypass` when invoking the virtualenv executable or the Python script to preserve argument quoting and avoid cmd quoting pitfalls. 

### Testing
- Ran `git diff --check` which reported no whitespace/patch errors and displayed the diff summary (passed). 
- Loaded the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/request-jules-review.yml")'` which succeeded (workflow YAML parsed OK). 
- Attempted `python3 -m pytest` but `pytest` is not installed in the environment so the test suite was not executed (not run). 
- PowerShell parsing check was skipped because `pwsh` is not installed in this environment (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5be52a1c8320bb9cbbc0d9a440e1)