### PR TITLE
Enable Gemini Code Assist action step

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -27,5 +27,5 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # - name: Gemini Code Assist
-      #   uses: google-gemini/code-assist-action@v1
+      - name: Gemini Code Assist
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- The Gemini Code Assist workflow only checked out the repository because its action step was commented out, so PR and comment-triggered runs were no-ops and reported success without performing code assistance.
- Enabling the action ensures matching triggers run `google-gemini/code-assist-action@v1` to provide the intended code assistance behavior.

### Description
- Uncommented the Gemini Code Assist step in `.github/workflows/gemini-code-assist.yml` so the job now executes `google-gemini/code-assist-action@v1` instead of being a checkout-only no-op.
- The workflow continues to trigger on `pull_request` events and on review/issue comments that contain `@gemini-code-assist`.

### Testing
- Ran `git diff --check` to validate the patch and it completed without errors.
- Loaded the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'ok'"` which printed `ok` indicating the file is valid YAML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e36a2f483208c0fb2a10d928e2a)