### PR TITLE
Honor batch GUI conversion flags

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -24,7 +24,9 @@ if ($BatchFile) {
         $url = $_.Trim()
         if (-not [string]::IsNullOrWhiteSpace($url)) {
             Write-Host "Processing: $url"
-            $argsList = @("--url", "$url", "--outdir", "$outDir")
+            # Match the GUI button promise and checkbox behavior for every batch URL.
+            $argsList = @("--url", "$url", "--outdir", "$outDir", "--all-formats")
+            if (-not $BatchWholePage) { $argsList += "--main-content" }
 
             if (Test-Path -LiteralPath $venvExe) {
                 & $venvExe $argsList


### PR DESCRIPTION
### Motivation
- Batch mode dropped the GUI-selected flags so multi-URL conversions no longer honored the `_Convert (All Formats)` button or the "Convert Whole Page" checkbox behavior.

### Description
- In `gui-url-convert.ps1` restore `--all-formats` for each URL processed in batch mode and append `--main-content` unless `-BatchWholePage` is supplied, so batch behavior matches the GUI controls.
- Small clarifying comment added above the batch argument construction to explain intent.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran `LC_ALL=C PYENV_VERSION=3.12.13 python -m pytest` and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e28504083208b2176c0c3680637)