### PR TITLE
Keep Jules review requests green for fork PRs

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   request-review:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Request review from Jules bot
@@ -22,7 +23,6 @@ jobs:
           python - <<'PY'
           import json
           import os
-          import sys
           import urllib.error
           import urllib.request
 
@@ -53,5 +53,5 @@ jobs:
           except urllib.error.HTTPError as error:
               print(f"Could not request review: {error.read().decode('utf-8')}")
               print("Ensure the workflow token has permission to comment.")
-              sys.exit(1)
+              print("Continuing without requesting Jules review.")
           PY


### PR DESCRIPTION
### Motivation
- Avoid failing the `request-jules-review` workflow on forked pull requests where the `GITHUB_TOKEN` is read-only by skipping the comment-posting job for fork PRs and making comment-posting failures non-fatal.

### Description
- Update `.github/workflows/request-jules-review.yml` to add `if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}` to skip the job for fork PRs and replace `sys.exit(1)` in the HTTP error handler with a `print("Continuing without requesting Jules review.")` so the workflow logs the error but does not return a non-zero exit.

### Testing
- Ran `git diff --check` which passed, and validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/request-jules-review.yml")'`, which parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e1f55f48320a7ef3485481c21cb)