### PR TITLE
Drop unused pull-requests permission from Jules review workflow

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- Remove the unnecessary `pull-requests: write` permission from the Jules review workflow (`.github/workflows/request-jules-review.yml`) because the workflow only posts comments via the Issues API and `issues: write` is sufficient, following the principle of least privilege.

### Description
- Deleted the `pull-requests: write` line from the `permissions` block in ` .github/workflows/request-jules-review.yml`, leaving `issues: write` as the retained scope.

### Testing
- Ran `git diff --check` and confirmed via `rg "pull-requests: write" .github/workflows/request-jules-review.yml` that the permission string is removed, then committed the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e0021808320861ea450107e30a2)