### PR TITLE
Fix GUI single-URL branch parse error

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -361,9 +361,6 @@ $ConvertBtn.Add_Click({
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
-    } else {
-        # --- SINGLE URL MODE ---
-        $url = $urlList[0]
         # If Whole Page is unchecked, we add the flag to ignore headers/footers
         $optArg = if (-not $WholePageChk.IsChecked) { " --main-content" } else { "" }
         # Sanitize inputs for single-quoted string interpolation in PowerShell
@@ -379,17 +376,6 @@ $ConvertBtn.Add_Click({
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
             $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
-        }
-        elseif (Test-Path -LiteralPath $pyScript) {
-            $LogBox.AppendText("Found Python script: $pyScript`r`n")
-        if (Test-Path -LiteralPath $venvExe) {
-            $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
-        }
-        elseif (Test-Path -LiteralPath $pyScript) {
-            $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
-        }
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."


### PR DESCRIPTION
### Motivation
- The GUI launcher had a duplicated `else` branch for the single-URL path after `if ($urlList.Count -gt 1)`, which caused a PowerShell parse error and prevented the GUI script from running.

### Description
- Removed the duplicate single-URL `else` block in `gui-url-convert.ps1` and kept the single-URL argument-building logic inside the remaining branch so the `if/else` structure is balanced.
- Cleaned up the duplicated `Test-Path`/argument-construction fragments so the script now uses a single, consistent fallback order for the venv executable and Python script.

### Testing
- Ran `git diff --check` to verify formatting and whitespace issues, which reported no problems.
- Executed `PYTHONPATH=src PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_smoke.py tests/test_log_export.py` and all tests passed (`10 passed`).
- Attempted to run a PowerShell parse check with `pwsh`/`powershell`, but PowerShell was not available in the environment so parsing could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5b8380708320be23d6bc01b3c83d)