### PR TITLE
Preserve deploy-safe host binding defaults

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -1,12 +1,9 @@
 """Flask application for html2md."""
 
-import os
-
 from flask import Flask, jsonify
 
 from html2md import __version__
-
-DEFAULT_PORT = 10000
+from html2md.server_config import get_host_port
 
 app = Flask(__name__)
 
@@ -15,23 +12,6 @@ app = Flask(__name__)
 def health():
     """Return health status of the application."""
     return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
-
-
-def get_host_port():
-    """Get host and port from environment variables."""
-    default_port = 10000
-    port_str = os.environ.get('PORT')
-    try:
-        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
-    except ValueError:
-        print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
-        )
-        port_value = DEFAULT_PORT
-
-    hostname = os.environ.get('HOST', '127.0.0.1')
-    return hostname, port_value
 
 
 if __name__ == '__main__':

--- a/src/html2md/server_config.py
+++ b/src/html2md/server_config.py
@@ -1,0 +1,37 @@
+"""Server configuration helpers for the optional web app."""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_HOST = '127.0.0.1'
+DEPLOY_HOST = '0.0.0.0'
+DEFAULT_PORT = 10000
+
+
+def get_host_port():
+    """Get host and port from environment variables.
+
+    Local runs with neither HOST nor PORT set bind to localhost for a
+    secure-by-default development experience. Managed web hosts commonly set
+    only PORT and expect apps to bind to all interfaces, so preserve that
+    deploy-safe default unless HOST is explicitly set.
+    """
+    port_str = os.environ.get('PORT')
+    try:
+        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
+    except ValueError:
+        print(
+            f'Warning: Invalid PORT environment variable value '
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
+        )
+        port_value = DEFAULT_PORT
+
+    hostname = os.environ.get('HOST')
+    if hostname:
+        return hostname, port_value
+
+    if port_str is not None:
+        return DEPLOY_HOST, port_value
+
+    return DEFAULT_HOST, port_value

--- a/src/html2md/server_config.py
+++ b/src/html2md/server_config.py
@@ -1,4 +1,4 @@
-"""Server configuration helpers for the optional Flask app."""
+"""Server configuration helpers for the optional web app."""
 
 from __future__ import annotations
 

--- a/src/html2md/server_config.py
+++ b/src/html2md/server_config.py
@@ -18,13 +18,13 @@ def get_host_port():
     deploy-safe default unless HOST is explicitly set.
     """
     port_str = os.environ.get('PORT')
-    port_from_env_valid = False
+    port_is_valid = False
     try:
         if port_str is None:
             port_value = DEFAULT_PORT
         else:
             port_value = int(port_str)
-            port_from_env_valid = True
+            port_is_valid = True
     except ValueError:
         print(
             f'Warning: Invalid PORT environment variable value '
@@ -36,7 +36,7 @@ def get_host_port():
     if hostname:
         return hostname, port_value
 
-    if port_from_env_valid:
+    if port_is_valid:
         return DEPLOY_HOST, port_value
 
     return DEFAULT_HOST, port_value

--- a/src/html2md/server_config.py
+++ b/src/html2md/server_config.py
@@ -18,19 +18,20 @@ def get_host_port():
     deploy-safe default unless HOST is explicitly set.
     """
     port_str = os.environ.get('PORT')
-    port_is_valid = False
-    try:
-        if port_str is None:
-            port_value = DEFAULT_PORT
-        else:
+    if port_str is None:
+        port_value = DEFAULT_PORT
+        port_is_valid = False
+    else:
+        try:
             port_value = int(port_str)
             port_is_valid = True
-    except ValueError:
-        print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
-        )
-        port_value = DEFAULT_PORT
+        except ValueError:
+            print(
+                f'Warning: Invalid PORT environment variable value '
+                f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
+            )
+            port_value = DEFAULT_PORT
+            port_is_valid = False
 
     hostname = os.environ.get('HOST')
     if hostname:

--- a/src/html2md/server_config.py
+++ b/src/html2md/server_config.py
@@ -18,26 +18,25 @@ def get_host_port():
     deploy-safe default unless HOST is explicitly set.
     """
     port_str = os.environ.get('PORT')
-    if port_str is None:
+    has_explicit_port = port_str is not None
+    if not has_explicit_port:
         port_value = DEFAULT_PORT
-        port_is_valid = False
     else:
         try:
             port_value = int(port_str)
-            port_is_valid = True
         except ValueError:
             print(
                 f'Warning: Invalid PORT environment variable value '
                 f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
             )
             port_value = DEFAULT_PORT
-            port_is_valid = False
+            has_explicit_port = False
 
     hostname = os.environ.get('HOST')
     if hostname:
         return hostname, port_value
 
-    if port_is_valid:
+    if has_explicit_port:
         return DEPLOY_HOST, port_value
 
     return DEFAULT_HOST, port_value

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,16 +27,6 @@ def test_get_host_port_custom_host(monkeypatch):
     assert port == DEFAULT_PORT
 
 
-def test_get_host_port_empty_host(monkeypatch):
-    """Test get_host_port falls back to localhost when HOST is empty."""
-    monkeypatch.setenv("HOST", "")
-    monkeypatch.delenv("PORT", raising=False)
-
-    hostname, port = get_host_port()
-    assert hostname == DEFAULT_HOST
-    assert port == DEFAULT_PORT
-
-
 def test_get_host_port_port_only_uses_deploy_host(monkeypatch):
     """Bind to all interfaces when a PaaS-style PORT is provided without HOST."""
     monkeypatch.delenv("HOST", raising=False)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,35 +1,63 @@
-import os
-import pytest
+"""Tests for optional web app server configuration."""
 
-# Skip the test module if flask is not installed.
-pytest.importorskip("flask")
+from html2md.server_config import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DEPLOY_HOST,
+    get_host_port,
+)
 
-from html2md.app import get_host_port
 
 def test_get_host_port_default(monkeypatch):
-    """Test get_host_port returns default localhost when HOST is not set."""
-    # Ensure HOST and PORT are not set in the environment
+    """Return localhost and the default port for local runs without env vars."""
     monkeypatch.delenv("HOST", raising=False)
     monkeypatch.delenv("PORT", raising=False)
 
     hostname, port = get_host_port()
-    assert hostname == "127.0.0.1"
-    assert port == 10000
+
+    assert hostname == DEFAULT_HOST
+    assert port == DEFAULT_PORT
+
 
 def test_get_host_port_custom_host(monkeypatch):
-    """Test get_host_port respects the HOST environment variable."""
+    """Respect an explicit HOST environment variable."""
     monkeypatch.setenv("HOST", "0.0.0.0")
     monkeypatch.delenv("PORT", raising=False)
 
     hostname, port = get_host_port()
-    assert hostname == "0.0.0.0"
-    assert port == 10000
 
-def test_get_host_port_custom_port(monkeypatch):
-    """Test get_host_port respects the PORT environment variable."""
+    assert hostname == "0.0.0.0"
+    assert port == DEFAULT_PORT
+
+
+def test_get_host_port_port_only_uses_deploy_host(monkeypatch):
+    """Bind to all interfaces when a PaaS-style PORT is provided without HOST."""
     monkeypatch.delenv("HOST", raising=False)
     monkeypatch.setenv("PORT", "8080")
 
     hostname, port = get_host_port()
-    assert hostname == "127.0.0.1"
+
+    assert hostname == DEPLOY_HOST
     assert port == 8080
+
+
+def test_get_host_port_empty_host_falls_back_to_contextual_default(monkeypatch):
+    """Do not pass an empty HOST through to Flask/Werkzeug."""
+    monkeypatch.setenv("HOST", "")
+    monkeypatch.delenv("PORT", raising=False)
+
+    hostname, port = get_host_port()
+
+    assert hostname == DEFAULT_HOST
+    assert port == DEFAULT_PORT
+
+
+def test_get_host_port_empty_host_with_port_uses_deploy_host(monkeypatch):
+    """Treat an empty HOST like missing HOST for PaaS-style PORT-only launches."""
+    monkeypatch.setenv("HOST", "")
+    monkeypatch.setenv("PORT", "10000")
+
+    hostname, port = get_host_port()
+
+    assert hostname == DEPLOY_HOST
+    assert port == DEFAULT_PORT

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,12 +52,12 @@ def test_get_host_port_empty_host_falls_back_to_contextual_default(monkeypatch):
 def test_get_host_port_empty_host_with_port_uses_deploy_host(monkeypatch):
     """Treat an empty HOST like missing HOST for PaaS-style PORT-only launches."""
     monkeypatch.setenv("HOST", "")
-    monkeypatch.setenv("PORT", "18080")
+    monkeypatch.setenv("PORT", "3000")
 
     hostname, port = get_host_port()
 
     assert hostname == DEPLOY_HOST
-    assert port == 18080
+    assert port == 3000
 
 
 def test_get_host_port_invalid_port_is_treated_as_missing(monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure the host/port resolution logic is importable and testable without requiring the optional `deploy` extra (Flask) so CI can validate the defaults.
- Keep a secure-by-default local behavior (bind to `127.0.0.1`) while preserving PaaS-friendly behavior (bind to `0.0.0.0` when only `PORT` is provided).
- Avoid passing an empty `HOST` environment variable through to Flask/Werkzeug, because an empty string is interpreted as `0.0.0.0` and can unintentionally expose the app.

### Description
- Extracted host/port resolution into a Flask-free helper module `src/html2md/server_config.py` with `DEFAULT_HOST='127.0.0.1'`, `DEPLOY_HOST='0.0.0.0'`, and `DEFAULT_PORT=10000`, and a `get_host_port()` function implementing the contextual defaults and empty-`HOST` handling. 
- Updated `src/html2md/app.py` to consume `get_host_port()` from `html2md.server_config` instead of embedding the logic inline. 
- Reworked `tests/test_app.py` to import `get_host_port` and the constants from `html2md.server_config`, removed the Flask import/skip, and added tests covering: local default, explicit `HOST`, PORT-only (PaaS) binding, empty-`HOST` behavior, and empty-`HOST` with `PORT`.

### Testing
- Ran the focused unit tests with `PYENV_VERSION=3.11.15 pytest tests/test_app.py -q` and they passed. 
- Ran full test suite with `PYENV_VERSION=3.11.15 pytest -q` and observed an unrelated existing test failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by that test mocking `builtins.open` which intercepts Python `gettext` locale loading, not by the server-config changes. 
- Ran `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4d78eef88320843b0c89bdaca1bd)