### PR TITLE
Drop unused `pull-requests: write` permission from Jules review workflow

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- The workflow only posts a comment to the issues comments endpoint, so granting `pull-requests: write` is unnecessary and enlarges the `GITHUB_TOKEN` blast radius.

### Description
- Remove the `pull-requests: write` permission from `.github/workflows/request-jules-review.yml` and keep `issues: write` which is sufficient for posting the review-request comment.

### Testing
- Ran `git diff --check` on the modified tree and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4d5de56483209a89f8ff25f33581)