### PR TITLE
Make app config tests run without Flask

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -1,12 +1,9 @@
 """Flask application for html2md."""
 
-import os
-
 from flask import Flask, jsonify
 
 from html2md import __version__
-
-DEFAULT_PORT = 10000
+from html2md.app_config import DEFAULT_PORT, get_host_port
 
 app = Flask(__name__)
 
@@ -15,23 +12,6 @@ app = Flask(__name__)
 def health():
     """Return health status of the application."""
     return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
-
-
-def get_host_port():
-    """Get host and port from environment variables."""
-    default_port = 10000
-    port_str = os.environ.get('PORT')
-    try:
-        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
-    except ValueError:
-        print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
-        )
-        port_value = DEFAULT_PORT
-
-    hostname = os.environ.get('HOST', '0.0.0.0')
-    return hostname, port_value
 
 
 if __name__ == '__main__':

--- a/src/html2md/app_config.py
+++ b/src/html2md/app_config.py
@@ -1,0 +1,24 @@
+"""Configuration helpers for the html2md web application."""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_HOST = '0.0.0.0'
+DEFAULT_PORT = 10000
+
+
+def get_host_port():
+    """Get host and port from environment variables."""
+    port_str = os.environ.get('PORT')
+    try:
+        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
+    except ValueError:
+        print(
+            f'Warning: Invalid PORT environment variable value '
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
+        )
+        port_value = DEFAULT_PORT
+
+    hostname = os.environ.get('HOST', DEFAULT_HOST)
+    return hostname, port_value

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,19 +1,14 @@
 import os
 from unittest import mock
 
-import pytest
-
-# Tests in tests/test_app.py require the flask library and are skipped automatically if it is not installed
-pytest.importorskip("flask")
-
-from html2md.app import get_host_port
+from html2md.app_config import DEFAULT_HOST, DEFAULT_PORT, get_host_port
 
 
 def test_get_host_port_defaults():
     with mock.patch.dict(os.environ, {}, clear=True):
         host, port = get_host_port()
-        assert host == '0.0.0.0'
-        assert port == 10000
+        assert host == DEFAULT_HOST
+        assert port == DEFAULT_PORT
 
 
 def test_get_host_port_valid_values():
@@ -26,8 +21,8 @@ def test_get_host_port_valid_values():
 def test_get_host_port_invalid_port(capsys):
     with mock.patch.dict(os.environ, {'PORT': 'invalid_port', 'HOST': '0.0.0.0'}, clear=True):
         host, port = get_host_port()
-        assert host == '0.0.0.0'
-        assert port == 10000
+        assert host == DEFAULT_HOST
+        assert port == DEFAULT_PORT
 
         captured = capsys.readouterr()
         assert "Warning: Invalid PORT environment variable value" in captured.out


### PR DESCRIPTION
### Motivation
- Ensure `get_host_port()` parser tests run in the default CI environment where `flask` is not installed by moving the parsing logic out of the Flask-dependent module.
- Avoid skipping the entire test module via `pytest.importorskip("flask")` so parser regressions are caught by CI.

### Description
- Extracted host/port defaults and parsing into a Flask-free module `src/html2md/app_config.py` with `DEFAULT_HOST`, `DEFAULT_PORT`, and `get_host_port()`.
- Updated `src/html2md/app.py` to import `DEFAULT_PORT` and `get_host_port` from `html2md.app_config` so existing callers continue to work while keeping Flask imports separate.
- Modified `tests/test_app.py` to import `DEFAULT_HOST`, `DEFAULT_PORT`, and `get_host_port` from `html2md.app_config` and to remove the module-level `pytest.importorskip("flask")`, and updated assertions to reference the shared defaults instead of hardcoded values.

### Testing
- Ran `python -m pytest tests/test_app.py -q` which passed and exercised the parser tests successfully.
- Ran the full test suite with `LC_ALL=C python -m pytest -q` which passed.
- Running the full test suite without setting `LC_ALL` initially produced a failure in an unrelated test due to a `builtins.open` mock intercepting `gettext` locale file loading, which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4d1b5f44832087bf5cbf0f091a28)