### PR TITLE
Ensure self-heal uses trusted repair scripts

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -31,12 +31,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      # Keep the repair scripts on the trusted default branch. A failed ref can
+      # predate this workflow and therefore lack scripts/healthcheck.mjs or
+      # scripts/self-heal.mjs, so never run those scripts from the worktree.
       - name: Checkout trusted repair driver
         uses: actions/checkout@v4
         with:
           path: self-heal-driver
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+
+      - name: Verify trusted repair driver
+        run: |
+          test -f self-heal-driver/scripts/healthcheck.mjs
+          test -f self-heal-driver/scripts/self-heal.mjs
 
       - name: Checkout failed ref
         uses: actions/checkout@v4

--- a/tests/test_self_heal_workflow.py
+++ b/tests/test_self_heal_workflow.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/self-heal.yml")
+
+
+def workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_self_heal_uses_trusted_driver_for_repo_local_scripts():
+    text = workflow_text()
+
+    assert "path: self-heal-driver" in text
+    assert "ref: ${{ github.event.repository.default_branch }}" in text
+    assert "path: worktree" in text
+
+    assert "node ../self-heal-driver/scripts/healthcheck.mjs" in text
+    assert "node ../self-heal-driver/scripts/self-heal.mjs" in text
+    assert "node scripts/healthcheck.mjs" not in text
+    assert "node scripts/self-heal.mjs" not in text
+
+
+def test_self_heal_verifies_driver_scripts_before_failed_ref_checkout():
+    text = workflow_text()
+
+    verify_step = text.index("- name: Verify trusted repair driver")
+    failed_checkout = text.index("- name: Checkout failed ref")
+
+    assert verify_step < failed_checkout
+    assert "test -f self-heal-driver/scripts/healthcheck.mjs" in text
+    assert "test -f self-heal-driver/scripts/self-heal.mjs" in text


### PR DESCRIPTION
### Motivation

- Prevent the self-heal job from running `scripts/healthcheck.mjs` or `scripts/self-heal.mjs` from the failing worktree which may predate those scripts and cause early failures.  
- Reduce risk of executing attacker-controlled code by keeping the repair driver on the repository's trusted default branch before touching the failed ref.

### Description

- Added a comment and explicit verification step to `.github/workflows/self-heal.yml` to checkout the trusted repair driver at `self-heal-driver` and `test -f` the two driver scripts before checking out the failing ref.  
- Ensures the workflow runs `node ../self-heal-driver/scripts/healthcheck.mjs` and `node ../self-heal-driver/scripts/self-heal.mjs` (not `node scripts/...` from the worktree).  
- Added `tests/test_self_heal_workflow.py` to assert the workflow uses the trusted driver paths and that the `Verify trusted repair driver` step appears before the `Checkout failed ref` step.  
- Updated repository and committed the change with a focused commit message describing the workflow hardening.

### Testing

- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_self_heal_workflow.py -q` and the new tests passed.  
- Validated the workflow YAML by loading it with a YAML parser (`python -c 'yaml.safe_load(...)'`) and that check succeeded.  
- Ran `node --check scripts/self-heal.mjs` and `node --check scripts/healthcheck.mjs` for syntax checks and they succeeded.  
- Ran `git diff --check` and basic repository checks and they reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24ef756c8320be9767e22e72e6c1)