### PR TITLE
Pin self-heal repair driver to trusted workflow commit

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -35,7 +35,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: self-heal-driver
-          ref: ${{ github.event.repository.default_branch }}
+          # Keep repair scripts on the trusted workflow commit instead of the failing ref.
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Checkout failed ref


### PR DESCRIPTION
### Motivation
- Prevent running untrusted repair scripts from the failing branch by ensuring the self-heal driver is checked out from the trusted workflow commit rather than a mutable branch or the failing ref.

### Description
- Updated `.github/workflows/self-heal.yml` so the trusted driver checkout uses `ref: ${{ github.sha }}` and the failing ref remains checked out separately under `worktree`, ensuring healthcheck and repair execution run from the trusted driver copy.

### Testing
- Verified workflow YAML parses and `ref: ${{ github.sha }}` is present using a `node` assertion and a `ruby -e 'require "yaml"'` load, both succeeding.
- Ran `git diff --check` to ensure no syntax issues and validated the workflow file changes with local checks, which passed; noted `PyYAML` was not available in the local Python environment when attempted there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24e0fd608320821bc9ea7b5a21be)