### PR TITLE
Run self-heal validation on Windows CI runner

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -28,7 +28,10 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 25
     steps:
       - name: Checkout trusted repair driver


### PR DESCRIPTION
### Motivation
- Ensure the self-heal workflow validates repairs on the same OS as the repository CI (which runs on Windows), so Windows-specific path/shell/encoding failures are reproduced by the post-repair healthcheck.

### Description
- Change the `self-heal` job to run on `windows-latest` and set a job-level default shell to Bash so existing `set -euo pipefail` healthcheck and repair commands behave consistently on the Windows runner.

### Testing
- Loaded the modified workflow with `yaml.safe_load` to validate YAML parsing, which succeeded.
- Ran `git diff --check` to verify there are no whitespace or diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24d8e2588320a3fe3152227bf903)