### PR TITLE
Align self-heal Python version with CI

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install Python deps
         working-directory: worktree


### PR DESCRIPTION
### Motivation
- Ensure the self-heal workflow validates repairs against the same Python family used by CI by using a floating `3.x` interpreter instead of pinning `3.11`.

### Description
- Update `.github/workflows/self-heal.yml` to set `python-version: '3.x'` for the repair job's `actions/setup-python` step.

### Testing
- Ran `python3 - <<'PY' ... yaml.safe_load(f)` to parse the workflow YAML and confirm it's valid, which succeeded. 
- Ran `git diff --check` to ensure no trailing whitespace or patch issues, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24cb91448320a6df84a8ed973ac4)