### PR TITLE
Handle same-repository PR CI failures in self-heal

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -21,6 +21,7 @@ jobs:
         github.event.workflow_run.head_repository.fork == false &&
         (
           github.event.workflow_run.event == 'push' ||
+          github.event.workflow_run.event == 'pull_request' ||
           github.event.workflow_run.event == 'workflow_dispatch'
         )
       )


### PR DESCRIPTION
### Motivation
- The self-heal workflow did not run for failed CI runs originating from same-repository pull requests because `workflow_run.event == 'pull_request'` was not allowed in the job guard, so PR-based CI failures were not automatically entered into the self-heal flow.

### Description
- Allow `workflow_run.event == 'pull_request'` in the `jobs.self-heal.if` condition while keeping the existing same-repository guard `github.event.workflow_run.head_repository.fork == false`, by updating `.github/workflows/self-heal.yml` to include the `pull_request` event.

### Testing
- Parsed the updated workflow with Python/YAML (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/self-heal.yml'))"`) to validate syntax, which succeeded.
- Ran `git diff --check` to ensure no whitespace or diff errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24c38df88320b07cee83cf507567)