### PR TITLE
Use a dedicated token for self-heal repair PRs

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -98,6 +98,10 @@ jobs:
         if: steps.post.outcome == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
+          # Use a repository secret backed by a PAT or GitHub App token so
+          # workflow events from repair PRs are not suppressed like they are
+          # with the default GITHUB_TOKEN.
+          token: ${{ secrets.SELF_HEAL_TOKEN }}
           path: worktree
           base: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
           commit-message: "chore: auto-fix lint/format and lockfiles"


### PR DESCRIPTION
### Motivation

- Repair PRs created by the self-heal workflow were using the implicit `GITHUB_TOKEN`, which suppresses workflow events and prevents CI from running on the created PRs, so a PAT/GitHub App token is needed to reliably trigger normal CI validation.

### Description

- Add a `token: ${{ secrets.SELF_HEAL_TOKEN }}` input to the `peter-evans/create-pull-request@v6` step in `.github/workflows/self-heal.yml` so the action can use a PAT/GitHub App token when creating repair PRs.
- Add an inline comment documenting that the secret should be backed by a PAT or GitHub App token and why it is required.

### Testing

- Attempted YAML parse with Python (`python -c` using `PyYAML`) failed due to the test environment missing the `yaml` module (known environment issue), so that check did not run successfully.
- Parsed the modified workflow with Ruby (`ruby -e 'require "yaml"; YAML.load_file(...)'`) and the YAML load succeeded.
- Ran `git diff --check` to validate the patch formatting and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24b8f9cc8320b93f9a8745cb190e)