### PR TITLE
Fix self-heal checkout for workflow_run repair PRs

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           path: worktree
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
           persist-credentials: false
 
       - name: Use Node.js


### PR DESCRIPTION
### Motivation
- The self-heal workflow checked out `workflow_run` failures using `head_sha`, which leaves the worktree on a detached commit and prevents `create-pull-request` from operating against the source branch context.

### Description
- Update `.github/workflows/self-heal.yml` to checkout `github.event.workflow_run.head_branch` for `workflow_run` events so the repair worktree is on the failing branch instead of a detached `head_sha`.

### Testing
- Parsed the workflow YAML with `python3` (`yaml.safe_load`) and verified the file changes with `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24aa97448320b99fcaf1c0c693ea)