### PR TITLE
Avoid duplicate Jules review request comments

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -30,20 +30,45 @@ jobs:
           pr_number = os.environ["PR_NUMBER"]
           token = os.environ["GITHUB_TOKEN"]
 
-          request = urllib.request.Request(
-              url=f"{api_url}/repos/{repo}/issues/{pr_number}/comments",
-              data=json.dumps(
-                  {"body": "@google-labs-jules please review this pull request."}
-              ).encode("utf-8"),
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {token}",
-                  "Content-Type": "application/json",
-              },
-              method="POST",
-          )
+          comment_body = "@google-labs-jules please review this pull request."
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "Content-Type": "application/json",
+          }
+
+          def urlopen_json(request):
+              with urllib.request.urlopen(request) as response:
+                  return json.loads(response.read().decode("utf-8")), response.status
+
+          comments_url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments"
 
           try:
+              page = 1
+              while True:
+                  check_request = urllib.request.Request(
+                      url=f"{comments_url}?per_page=100&page={page}",
+                      headers=headers,
+                      method="GET",
+                  )
+                  comments, status = urlopen_json(check_request)
+                  if any(comment.get("body") == comment_body for comment in comments):
+                      print(
+                          "Jules review request comment already exists on "
+                          f"PR #{pr_number}; skipping duplicate (status {status})."
+                      )
+                      raise SystemExit(0)
+                  if len(comments) < 100:
+                      break
+                  page += 1
+
+              request = urllib.request.Request(
+                  url=comments_url,
+                  data=json.dumps({"body": comment_body}).encode("utf-8"),
+                  headers=headers,
+                  method="POST",
+              )
+
               with urllib.request.urlopen(request) as response:
                   print(
                       "Requested review from @google-labs-jules via comment on "


### PR DESCRIPTION
### Motivation
- Prevent the workflow from posting the same "@google-labs-jules please review" comment on every `pull_request` `synchronize` run which can spam the PR timeline and retrigger the bot. 
- Keep the workflow tolerant of read-only `GITHUB_TOKEN` scenarios (forks/Dependabot) so that posting failures do not hard-fail the job.

### Description
- Add a reusable `comment_body` and shared `headers` and factor a small `urlopen_json` helper to simplify GET/POST interactions with the Issues comments API. 
- Paginate existing PR comments and exit early without posting when a matching Jules request comment already exists, otherwise post the comment once. 
- Preserve the existing non-fatal handling for `urllib.error.HTTPError` so permission errors remain informational rather than failing the workflow.

### Testing
- Compiled the embedded Python script to ensure it is syntactically valid (`compile(...)`), and the check passed. 
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/request-jules-review.yml')"` and the file parsed successfully. 
- Ran `git diff --check` to ensure no whitespace/patch issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe243a3a908320b819bb047c7e7931)