### PR TITLE
Avoid unsupported whole-page GUI flag

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -6,7 +6,7 @@ WPF GUI for html2md
 - Safe for double-click or PowerShell execution
 #>
 
-param([string]$BatchFile, [string]$BatchOutDir, [switch]$BatchWholePage)
+param([string]$BatchFile, [string]$BatchOutDir)
 
 if ($BatchFile) {
     if (-not (Test-Path -LiteralPath $BatchFile)) {
@@ -25,9 +25,6 @@ if ($BatchFile) {
         if (-not [string]::IsNullOrWhiteSpace($url)) {
             Write-Host "Processing: $url"
             $argsList = @("--url", "$url", "--outdir", "$outDir")
-            if ($BatchWholePage) {
-                $argsList += "--whole-page"
-            }
 
             if (Test-Path -LiteralPath $venvExe) {
                 & $venvExe $argsList
@@ -105,10 +102,6 @@ $xaml = @"
             </StackPanel>
         </StackPanel>
 
-        <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
-                  VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
-
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
@@ -150,7 +143,6 @@ $OpenFolderBtn = $window.FindName("OpenFolderBtn")
 $ConvertBtn = $window.FindName("ConvertBtn")
 $PasteBtn = $window.FindName("PasteBtn")
 $ClearBtn = $window.FindName("ClearBtn")
-$WholePageChk = $window.FindName("WholePageChk")
 $StatusText = $window.FindName("StatusText")
 $ProgressBar = $window.FindName("ProgressBar")
 $LogBox = $window.FindName("LogBox")
@@ -354,9 +346,6 @@ $ConvertBtn.Add_Click({
         # Relaunch this script in batch mode
         # Use single quotes for arguments to avoid variable expansion and allow containing spaces/special chars
         $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File '$safeCommandPath' -BatchFile '$safeTempFile' -BatchOutDir '$safeOutDir'"
-        if ($WholePageChk.IsChecked) {
-            $psi.Arguments += " -BatchWholePage"
-        }
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -6,7 +6,12 @@ WPF GUI for html2md
 - Safe for double-click or PowerShell execution
 #>
 
-param([string]$BatchFile, [string]$BatchOutDir)
+param(
+    [ValidateNotNullOrEmpty()]
+    [string]$BatchFile,
+
+    [string]$BatchOutDir
+)
 
 if ($BatchFile) {
     if (-not (Test-Path -LiteralPath $BatchFile)) {


### PR DESCRIPTION
### Motivation
- The GUI was appending an unsupported `--whole-page`/`-BatchWholePage` flag to every `html2md` invocation in batch mode, causing `argparse` to exit with “unrecognized arguments: --whole-page” and failing multi-URL conversions.
- The GUI also exposed a "Whole Page" checkbox that had no corresponding CLI support, which is misleading to users.

### Description
- Remove the unused `BatchWholePage` parameter from the script header and stop adding the unsupported `--whole-page` argument during batch conversions in `gui-url-convert.ps1`.
- Remove the "Convert Whole Page" checkbox from the XAML UI and drop the stale `$WholePageChk` lookup so the GUI no longer exposes an option the CLI cannot honor.
- Remove the code path that appended `-BatchWholePage` when relaunching the script for batch mode so batch runner builds arguments that match the CLI (`--url` and `--outdir`) only.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues and it passed.
- Ran the new URL-processing test with `PYENV_VERSION=3.12.13 PYTHONPATH=src python -m pytest tests/test_cli_url.py` and it passed (`1 passed`).
- PowerShell parser validation was skipped in this environment because PowerShell is not installed, so no runtime PowerShell execution tests were performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe242eda5083208e399469cccce1ba)