### PR TITLE
Restore Gemini automatic pull request trigger

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,8 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -17,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       ((github.event_name == 'pull_request_review_comment' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
         (github.event.comment.author_association == 'MEMBER' ||
@@ -35,7 +39,9 @@ jobs:
         with:
           script: |
             let pr;
-            if (context.eventName === "pull_request_review_comment") {
+            if (context.eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            } else if (context.eventName === "pull_request_review_comment") {
               pr = context.payload.pull_request;
             } else if (context.eventName === "issue_comment" && context.payload.issue?.pull_request) {
               const response = await github.rest.pulls.get({
@@ -47,7 +53,7 @@ jobs:
             }
 
             if (!pr) {
-              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request_review_comment or issue_comment on a pull request.");
+              core.setFailed("Could not resolve pull request from event payload. This workflow requires a pull_request event, pull_request_review_comment, or issue_comment on a pull request.");
               return;
             }
 


### PR DESCRIPTION
### Motivation
- Re-enable automatic Gemini Code Assist runs for same-repository pull requests that were lost when `pull_request` was removed from the workflow triggers. 
- Preserve the safer manual and comment-triggered paths while ensuring same-repo PRs receive the automatic review assist they previously had.

### Description
- Re-added the `pull_request` event with `types: [opened, synchronize, reopened]` to `.github/workflows/gemini-code-assist.yml` so new and updated PRs trigger the workflow.
- Extended the job `if:` guard to allow automatic runs only when `github.event.pull_request.head.repo.full_name == github.repository`, restoring the prior same-repo/fork safety behavior.
- Updated the `Resolve PR head SHA` `actions/github-script` step to handle `pull_request` events directly and adjusted the failure message to include `pull_request` as an accepted event, and continued to expose `head_sha` and `is_same_repo` outputs for checkout and later steps.

### Testing
- Ran `git diff --check` to validate there are no whitespace/format errors and it completed successfully.
- Validated workflow YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'yaml ok'"`, which returned `yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc960109883208a5cba7e11322390)