### PR TITLE
Fix Gemini Code Assist PR review workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -23,11 +23,14 @@ jobs:
     timeout-minutes: 10
     if: >
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@gemini-code-assist'))
+      ((github.event_name == 'pull_request_review_comment' ||
+        github.event_name == 'issue_comment') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       contains(github.event.comment.body, '@gemini-code-assist') &&
+       (github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request))
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,6 +59,8 @@ jobs:
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION }}
@@ -81,7 +86,9 @@ jobs:
                     "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "includeTools": [
+                    "create_pending_pull_request_review",
                     "add_comment_to_pending_review",
+                    "submit_pending_pull_request_review",
                     "pull_request_read",
                     "pull_request_review_write"
                   ],

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -13,9 +13,14 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >
       (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_review_comment' &&
@@ -24,8 +29,78 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Gemini Code Assist
-        uses: google-gemini/gemini-cli-action@main
+
+      - name: Prepare review context
+        run: |
+          mkdir -p .gemini
+          jq -n \
+            --arg repository "$REPOSITORY" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg event_name "$EVENT_NAME" \
+            --arg comment_body "$COMMENT_BODY" \
+            '{repository: $repository, pull_request_number: $pr_number, event_name: $event_name, comment_body: $comment_body}' \
+            > .gemini/context.json
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+
+      - name: Gemini Code Assist review
+        id: gemini_review
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION }}
+          gemini_debug: ${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || 'false') }}
+          gemini_model: ${{ vars.GEMINI_MODEL }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          upload_artifacts: ${{ vars.UPLOAD_ARTIFACTS }}
+          workflow_name: gemini-code-assist
+          settings: |
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": []
+              }
+            }
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: |
+            /pr-code-review
+
+            Review pull request ${{ github.event.pull_request.number || github.event.issue.number }} in ${{ github.repository }}.
+            Use the GitHub MCP tools to read the PR diff, create inline comments where appropriate, and submit the pending review with a concise summary.
+            If this was triggered by an @gemini-code-assist comment, incorporate the request from .gemini/context.json.


### PR DESCRIPTION
### Motivation
- The existing workflow invoked an archived/unsupported Gemini CLI action without authentication or review wiring, causing PR/comment triggers to either fail or not produce inline PR reviews.
- The goal is to restore authenticated, review-capable behavior using a maintained Gemini runner and explicit inputs so reviews can post inline comments and summaries.

### Description
- Replaced the bare `google-gemini/gemini-cli-action@main` step with the maintained `google-github-actions/run-gemini-cli` action pinned to commit `f77273f4c914e4bf38440cf36a0369cb64a37489` (v0.1.22) and passed `gemini_api_key` via `secrets.GEMINI_API_KEY`.
- Added a `Prepare review context` step that writes repository, PR number, event name, and comment body into `.gemini/context.json` using `jq` for comment-triggered reviews.
- Configured the action with `GITHUB_TOKEN` and `GEMINI_CLI_TRUST_WORKSPACE`, provided `settings`, `extensions` (the `code-review` extension), and a `/pr-code-review` prompt so Gemini can read the PR diff, create inline comments, and submit a pending review summary.
- Added workflow robustness with `concurrency`, `timeout-minutes: 10`, and a named checkout step for clarity.

### Testing
- Ran a YAML parse smoke test with `python3` to validate the workflow structure, which succeeded.
- Ran `git diff --check` to ensure there were no whitespace/format issues, which succeeded.
- Observed a local `python` invocation fail due to a `pyenv` version mismatch, but the `python3` validation above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe24030b888320854a2353277749ce)