### PR TITLE
Ensure Flask health test runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           pip install -e .
-          pip install pytest
+          pip install pytest flask
       - name: Test
         run: pytest -q


### PR DESCRIPTION
### Motivation
- Make the new Flask `/health` endpoint test actually execute in CI by ensuring `flask` is available to the test job without installing the full `deploy` extra (which would pull in `gunicorn` on Windows).

### Description
- Install `flask` alongside `pytest` in the CI install step by changing the command to `pip install pytest flask` in `.github/workflows/ci.yml`.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pip install -e . pytest flask` which completed successfully.
- `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_app.py` passed and exercised the `/health` endpoint test.
- `PYENV_VERSION=3.11.15 python -m pytest -q` (full test suite) encountered an unrelated failure in `tests/test_cli_exceptions.py` due to a test interaction with `open()` and Python `gettext` during `argparse` initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe23c7d09483208b0f362c530275ea)