### PR TITLE
Limit Jules review workflow token permissions

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,9 +5,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
-  contents: read
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- The `Request Jules Review` workflow only posts an issue comment via the Issues API, so granting `pull-requests: write` and `contents: read` is unnecessary and broadens the job token more than required.

### Description
- Update `.github/workflows/request-jules-review.yml` to remove `pull-requests: write` and `contents: read`, leaving only `issues: write` for the workflow token.

### Testing
- Ran `git diff --check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe23a752288320b2ca7c818f447160)