### PR TITLE
Limit Jules review workflow permissions

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,9 +5,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
-  contents: read
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- Reduce the GitHub Actions workflow token privileges because the job only posts an issue comment and does not need `pull-requests: write` or `contents: read`.

### Description
- Removed `pull-requests: write` and `contents: read` from `.github/workflows/request-jules-review.yml`, leaving only `issues: write` under `permissions`.

### Testing
- Ran `git diff --check`, which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2399fc648320977dbe90b45bc87b)