### PR TITLE
Limit Jules workflow token permissions

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,9 +5,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
-  contents: read
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- Reduce the GitHub Actions workflow token surface area by removing permissions that are not needed to post an Issues API comment from the Jules review request workflow (`.github/workflows/request-jules-review.yml`).

### Description
- Removed `pull-requests: write` and `contents: read` from the workflow `permissions` and left only `issues: write`, which is sufficient for posting the review request via `/repos/{owner}/{repo}/issues/{pr_number}/comments`.

### Testing
- Ran a quick verification script `PYENV_VERSION=3.11.15 python - <<'PY' ...` to assert the file no longer contains `pull-requests: write` or `contents: read` and still contains `issues: write`, which succeeded. 
- Ran `git diff --check` to ensure there are no whitespace/errors, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2382eeec8320a8ff4f78b5acf946)