### PR TITLE
Install deploy extra in CI so Flask-backed tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
+          pip install -e ".[deploy]"
           pip install pytest
       - name: Test
         run: pytest -q


### PR DESCRIPTION
### Motivation
- The CI job installed only the base package, so `flask` (declared in the optional `deploy` extra) was not present and the new Flask-based tests were skipped in CI runs.

### Description
- Update `.github/workflows/ci.yml` to install the package with the `deploy` extra by replacing `pip install -e .` with `pip install -e ".[deploy]"` so Flask is available during the normal CI test job.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_app.py -q` which passed. 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q` which produced a failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by an existing `builtins.open` mock interfering with Python `gettext` during `argparse.ArgumentParser` construction; this is unrelated to the CI dependency change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe236edf8c832081371848412f1c1f)