### PR TITLE
Install deploy extra in CI so Flask-based tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
+          pip install -e ".[deploy]"
           pip install pytest
       - name: Test
         run: pytest -q


### PR DESCRIPTION
### Motivation
- Flask is listed only in the optional `deploy` extra, so CI's current `pip install -e .` caused the new Flask-based tests to be skipped on normal runs; installing the `deploy` extra in CI ensures those tests execute.

### Description
- Update `.github/workflows/ci.yml` Install step to run `pip install -e ".[deploy]"` instead of `pip install -e .` so CI installs `flask` and related extras before running `pytest`.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pip install -e '.[deploy]' pytest && PYENV_VERSION=3.12.13 pytest -q`, which succeeded in installing dependencies but the full test suite failed in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` due to that test’s patched `open` interfering with `gettext`; this is unrelated to the CI install change.  
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_app.py`, which passed and validated the Flask `/health` and `get_host_port()` tests now run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe235459d483209615e225202fac24)