### PR TITLE
Migrate Gemini review triggers to Jules

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -3,21 +3,31 @@ name: Request Jules Review
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:
   request-review:
     runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - name: Request review from Jules bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           python - <<'PY'
           import json


### PR DESCRIPTION
### Motivation

- Ensure callers that still mention `@gemini-code-assist` continue to trigger an automated review after the original Gemini workflow was removed.
- Avoid silently losing review/comment command triggers by routing those comment events to the Jules workflow.

### Description

- Added `pull_request_review_comment` and `issue_comment` events to `.github/workflows/request-jules-review.yml` so the workflow receives review-comment and issue-comment notifications. 
- Added a job-level `if` condition that preserves automatic PR review requests while running on comment events only when the comment body contains `@gemini-code-assist`.
- Updated `PR_NUMBER` resolution to use `${{ github.event.pull_request.number || github.event.issue.number }}` so the workflow can post back for both PR events and issue-comment events. 
- Removed the unused `pull-requests: write` permission and left only `issues: write` since the job only posts issue comments.

### Testing

- Ran `git diff --check` to ensure no whitespace or diff issues and it passed. 
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/request-jules-review.yml")'` to validate YAML syntax and it parsed successfully. 
- Committed the change and created the PR branch (`Migrate Gemini review triggers to Jules`) with the updated workflow file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe233fa4188320bcd37ca69557a602)