### PR TITLE
Guard Flask app tests behind optional dependency

### DIFF
--- a/tests/test_app_health.py
+++ b/tests/test_app_health.py
@@ -1,12 +1,13 @@
-import os
 import pytest
-from flask import Flask
-from html2md.app import app, get_host_port, DEFAULT_PORT
+
+pytest.importorskip("flask")
+
+from html2md.app import DEFAULT_PORT, app, get_host_port
 
 
 @pytest.fixture
-def client():
-    app.config["TESTING"] = True
+def client(monkeypatch):
+    monkeypatch.setitem(app.config, "TESTING", True)
     with app.test_client() as client:
         yield client
 


### PR DESCRIPTION
### Motivation
- Default installs (`pip install -e .`) can collect `tests/test_app_health.py` which imports `flask` (via `html2md.app`) even though Flask is only an optional `deploy` extra, causing collection to fail with `ModuleNotFoundError` when Flask is not installed.

### Description
- Add `pytest.importorskip("flask")` before importing `html2md.app`, remove unused `os` and `Flask` imports from `tests/test_app_health.py`, and update the `client` fixture to use `monkeypatch.setitem(app.config, "TESTING", True)` for better fixture isolation.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pip install -e .` which succeeded; running `pytest -q -rs tests/test_app_health.py` without Flask results in the module being skipped as expected; installing extras with `PYENV_VERSION=3.12.13 python -m pip install -e '.[deploy]'` and then `pytest -q tests/test_app_health.py` passed; running the full test suite (`pytest -q`) still fails due to an unrelated existing test (`tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check`) that mocks `builtins.open` and interacts with `gettext/argparse`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe233778d48320a86c3de5034f548e)