### PR TITLE
Restore Gemini Code Assist action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        run: echo "Code assist skipped"
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Restore the Code Assist workflow step so pull request, review-comment, and issue-comment events invoke the `google-gemini/code-assist-action` instead of short-circuiting to a no-op, allowing `@gemini-code-assist` comments and automatic reviews to produce Code Assist responses.

### Description
- In `.github/workflows/gemini-code-assist.yml` replaced the no-op `run: echo "Code assist skipped"` step with `uses: google-gemini/code-assist-action@v1` so the workflow executes the intended action.

### Testing
- Ran repository diff/checks which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22f396908320b6fb166201f68b08)