### PR TITLE
Install Flask in CI and make app tests fail loudly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
+          pip install -e ".[deploy]"
           pip install pytest
       - name: Test
         run: pytest -q

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -19,7 +19,7 @@ def health():
 
 def get_host_port():
     """Get host and port from environment variables."""
-    default_port = 10000
+    default_port = DEFAULT_PORT
     port_str = os.environ.get('PORT')
     try:
         port_value = int(port_str) if port_str is not None else DEFAULT_PORT

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,5 @@
 """Tests for the Flask application module."""
 
-import os
-
-import pytest
-
-pytest.importorskip("flask")
-
 from html2md.app import DEFAULT_PORT, get_host_port
 
 
@@ -46,7 +40,7 @@ def test_get_host_port_invalid_port(monkeypatch, capsys):
         "Warning: Invalid PORT environment variable value 'not-a-number'"
         in captured.out
     )
-    assert "falling back to default 10000" in captured.out
+    assert f"falling back to default {DEFAULT_PORT}" in captured.out
 
 
 def test_get_host_port_only_host(monkeypatch):
@@ -71,11 +65,10 @@ def test_get_host_port_only_port(monkeypatch):
     assert port == 9090
 
 
-def test_health_endpoint(monkeypatch):
+def test_health_endpoint():
     """Test the /health endpoint of the app."""
     from html2md.app import app
 
-    app.testing = True
     client = app.test_client()
 
     response = client.get("/health")


### PR DESCRIPTION
### Motivation
- Ensure the Flask-based tests in `tests/test_app.py` actually run in CI by making Flask available instead of silently skipping the module.
- Improve test maintainability by removing dead imports/fixtures and avoiding hardcoded constants in assertions.
- Keep application messages consistent with the exported default port constant.

### Description
- Update CI install step to install the `deploy` extra so Flask and related dependencies are available: change to `pip install -e ".[deploy]"` in `.github/workflows/ci.yml`.
- Remove the `pytest.importorskip("flask")` gate and the unused `import os` from `tests/test_app.py`, so missing Flask now fails collection instead of skipping tests.
- Replace the hardcoded fallback message check with a reference to `DEFAULT_PORT` in `tests/test_app.py`, and remove the unused `monkeypatch` parameter from `test_health_endpoint`.
- Use the exported `DEFAULT_PORT` constant inside `get_host_port()` for the local `default_port` variable so the printed warning message matches the public constant in `src/html2md/app.py`.

### Testing
- Ran `python -m pip install -e ".[deploy]" pytest` to install editable package with extras; installation completed successfully.
- Ran `python -m pytest -q tests/test_app.py` and the `tests/test_app.py` suite passed (`......`).
- Ran full `python -m pytest -q`; the test run failed due to an existing unrelated test (`tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check`) where a `builtins.open` mock causes Python gettext loading to raise, so the failure is pre-existing and unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22e733a48320a221fda9e8f87b89)