### PR TITLE
Restore Gemini Code Assist workflow triggers

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,31 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Re-enable the Gemini Code Assist automation that was removed so Gemini reviews are triggered again for PR events and explicit `@gemini-code-assist` comments.

### Description
- Add ` .github/workflows/gemini-code-assist.yml` which restores `pull_request` triggers for `opened`, `synchronize`, and `reopened` events and also listens for `pull_request_review_comment` and `issue_comment` creations.
- Add a `gemini-code-assist` job that runs the `google-gemini/code-assist-action@v1` step when the event conditions or `@gemini-code-assist` mentions match.
- Configure workflow permissions with `contents: read`, `pull-requests: write`, and `issues: write` to allow the action to comment on PRs and respond to triggers.

### Testing
- Ran `rg -n "google-gemini|code-assist|gemini" .github/workflows .github/CODEOWNERS` to confirm the workflow is present and references the code-assist action, which succeeded.
- Verified repository status with `git status --short --branch` to confirm the workflow file exists in the branch, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22a50cdc8320828e9205a0636cf0)