### PR TITLE
Restore Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,31 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Restore the deleted workflow that provided the only entry point for Gemini Code Assist so PR open/synchronize/reopen events and `@gemini-code-assist` comment triggers run again.

### Description
- Add `.github/workflows/gemini-code-assist.yml` which registers `pull_request` (opened, synchronize, reopened), `pull_request_review_comment` (created) and `issue_comment` (created) triggers and grants `contents: read`, `pull-requests: write`, and `issues: write` permissions.
- Define a `gemini-code-assist` job that conditionally runs on PR events or when a comment contains `@gemini-code-assist`, checks out the repo, and invokes `google-gemini/code-assist-action@v1`.
- These changes are applied on top of the existing PR that added tests for `get_host_port` so both the workflow restoration and the test additions are present in the branch.

### Testing
- Ran `git diff --cached --check`, which produced no errors.
- Verified presence of the workflow and action with `git grep -n "gemini-code-assist\|code-assist-action" -- .github/workflows/gemini-code-assist.yml`, which found the expected entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22978aec8320b7150f6f6685c187)