### PR TITLE
Ensure get_host_port tests run without Flask

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,24 +1,11 @@
-import os
+import importlib
 import sys
-import pytest
+from unittest.mock import MagicMock
 
-try:
-    import flask
-except ImportError:
-    from unittest.mock import MagicMock
-
-    sys.modules["flask"] = MagicMock()
-    import flask
-
-    flask_was_missing = True
-else:
-    flask_was_missing = False
-
-pytestmark = pytest.mark.skipif(
-    flask_was_missing, reason="flask is required for tests in test_app.py"
-)
-
-from html2md.app import get_host_port, DEFAULT_PORT
+sys.modules.setdefault("flask", MagicMock())
+app_module = importlib.import_module("html2md.app")
+DEFAULT_PORT = app_module.DEFAULT_PORT
+get_host_port = app_module.get_host_port
 
 
 def test_get_host_port_defaults(monkeypatch):
@@ -30,7 +17,6 @@ def test_get_host_port_defaults(monkeypatch):
 
     assert host == "0.0.0.0"
     assert port == DEFAULT_PORT
-    assert port == 10000
 
 
 def test_get_host_port_custom_values(monkeypatch):
@@ -55,5 +41,8 @@ def test_get_host_port_invalid_port(monkeypatch, capsys):
     assert port == DEFAULT_PORT
 
     captured = capsys.readouterr()
-    expected_warning = "Warning: Invalid PORT environment variable value 'invalid_port'; falling back to default 10000.\n"
+    expected_warning = (
+        "Warning: Invalid PORT environment variable value 'invalid_port'; "
+        f"falling back to default {DEFAULT_PORT}.\n"
+    )
     assert captured.out == expected_warning


### PR DESCRIPTION
### Motivation

- The `get_host_port` tests were skipped in CI because Flask is only in the `deploy` extra, so tests must run under the base install to catch regressions.

### Description

- Mock Flask by inserting a `MagicMock` into `sys.modules` before importing the app and import `html2md.app` via `importlib` so `tests/test_app.py` executes without a real Flask install.
- Remove the module-level skip and unused imports from `tests/test_app.py` and avoid binding an unused `flask` name.
- Replace a hardcoded default-port assertion and the hardcoded warning string with references to `DEFAULT_PORT` so tests stay consistent with the application constant.

### Testing

- Ran `PYENV_VERSION=3.12.13 PYTHONPATH=src python -m pytest -q tests/test_app.py`, which passed (all tests in that module succeeded).
- Ran `PYENV_VERSION=3.12.13 python -m pip install -e . pytest` to install package deps, then `PYENV_VERSION=3.12.13 python -m pytest -q`, which exercised the full suite and reported an unrelated existing failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by a test patch that intercepts `builtins.open` during gettext `.mo` reads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe228471f08320a80956ae57871b99)