### PR TITLE
Fix CLI containment test open mock

### DIFF
--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -59,8 +59,9 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        # Use mock_open properly to avoid breaking gettext internal file reads
-                        with patch('pathlib.Path.open') as m_open:
+                        # Patch open in the CLI module to observe the actual write path
+                        # without breaking global built-ins used by dependencies.
+                        with patch('html2md.cli.open', create=True) as m_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'


### PR DESCRIPTION
### Motivation
- The outdir containment test previously patched `pathlib.Path.open` which does not intercept the CLI's built-in `open(...)` call, so the assertion could miss a real write outside the output directory.

### Description
- Update `tests/test_cli_exceptions.py` to patch `html2md.cli.open` with `patch('html2md.cli.open', create=True)` so the mock observes the actual write path while avoiding global built-in side effects.

### Testing
- Ran `pytest tests/test_cli_exceptions.py` which passed (`3 passed`), and then ran the full suite with `pytest` which passed (`20 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe226dc37c8320bc5f83f866db9d81)