### PR TITLE
Restore Gemini Code Assist workflow action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -13,9 +13,14 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     if: >
       (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_review_comment' &&
@@ -24,9 +29,85 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare Gemini context
+        run: |
+          mkdir -p .gemini
+          jq -n \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg pr "$PR_NUMBER" \
+            --arg event "$GITHUB_EVENT_NAME" \
+            --arg comment "$COMMENT_BODY" \
+            '{repository: $repo, pull_request_number: $pr, event_name: $event, comment_body: $comment}' > .gemini/context.json
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+
       - name: Gemini Code Assist
-        # uses: google-github-actions/code-assist-action@v1
-        run: echo "Gemini Code Assist Disabled due to missing action"
+        uses: google-github-actions/run-gemini-cli@v0.1.22
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GITHUB_TOKEN: ${{ github.token }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION }}
+          gemini_debug: ${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}
+          gemini_model: ${{ vars.GEMINI_MODEL }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          use_gemini_code_assist: ${{ vars.GOOGLE_GENAI_USE_GCA }}
+          use_vertex_ai: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+          gcp_location: ${{ vars.GOOGLE_CLOUD_LOCATION }}
+          gcp_project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+          gcp_workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          upload_artifacts: ${{ vars.UPLOAD_ARTIFACTS }}
+          workflow_name: gemini-code-assist
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          settings: |-
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": []
+              }
+            }
+          extensions: |-
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: |-
+            /pr-code-review
+
+            Use this GitHub Actions context as additional input:
+
+            ```json
+            @{.gemini/context.json}
+            ```


### PR DESCRIPTION
### Motivation

- Re-enable the Gemini review path so PR triggers and `@gemini-code-assist` comments run a real review action instead of an `echo` no-op. 
- Provide the Gemini action with the PR/comment context it needs to read the PR and post review feedback. 
- Improve workflow resiliency by adding concurrency, timeout, and safer checkout settings.

### Description

- Replace the `echo` no-op step with `google-github-actions/run-gemini-cli@v0.1.22` and wire the action inputs (API keys, model/debug flags, and workflow options). 
- Add a `Prepare Gemini context` step that writes `.gemini/context.json` containing `repository`, `pull_request_number`, `event_name`, and `comment_body` for the Gemini CLI to consume. 
- Add workflow-level `concurrency`, a `timeout-minutes` for the job, and set `persist-credentials: false` on checkout to reduce credential exposure. 
- Configure Gemini CLI `settings`, enable the code-review extension, and provide the `prompt` that points the runner at `/pr-code-review`.

### Testing

- Ran `actionlint .github/workflows/gemini-code-assist.yml` and fixed an input compatibility issue by pinning the action to `@v0.1.22`, after which the workflow file validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22651624832085844e12550bc040)