### PR TITLE
Restore Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,31 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist
+        uses: google-gemini/gemini-github-actions/code-assist@v2


### PR DESCRIPTION
### Motivation
- Reinstate the removed `.github/workflows/gemini-code-assist.yml` workflow so Gemini Code Assist runs again on PR events and `@gemini-code-assist` comment triggers and to restore missing automation/coverage.

### Description
- Add `./.github/workflows/gemini-code-assist.yml` with `pull_request`, `pull_request_review_comment`, and `issue_comment` triggers, the required `issues: write`/`pull-requests: write`/`contents: read` permissions, and a job that runs `google-gemini/gemini-github-actions/code-assist@v2` after checking out the repo.

### Testing
- Verified the workflow file contains the expected action reference, triggers, and permissions using a small check with `python3` and inspected the `git diff` output showing the new file; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe224f15a08320846e5368faa62f83)