### PR TITLE
🧪 Isolate Anthropic upload test mocks

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,15 +1,35 @@
 """Tests for the upload module."""
 
+import importlib
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-# Mock anthropic before importing the module to avoid missing dependencies
-# and strictly prevent any real network access
-mock_anthropic = MagicMock()
-sys.modules["anthropic"] = mock_anthropic
 
-from html2md.upload import upload_file, main  # noqa: E402
+class MockAPIError(Exception):
+    """Mock Anthropic API error type for exception handling tests."""
+
+
+# Mock anthropic only while importing the module to avoid missing dependencies
+# and strictly prevent any real network access without leaking into sys.modules.
+mock_anthropic = MagicMock()
+mock_anthropic.APIError = MockAPIError
+with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
+    upload_module = importlib.import_module("html2md.upload")
+
+upload_file = upload_module.upload_file
+main = upload_module.main
+
+
+@pytest.fixture(autouse=True)
+def reset_anthropic_mock():
+    """Clear shared Anthropic mock state before each test."""
+    mock_anthropic.reset_mock(return_value=True, side_effect=True)
+    mock_anthropic.APIError = MockAPIError
+    yield
+    mock_anthropic.reset_mock(return_value=True, side_effect=True)
+    mock_anthropic.APIError = MockAPIError
 
 
 def test_upload_file_not_found():
@@ -22,7 +42,7 @@ def test_upload_file_success_known_mime(tmp_path):
     """Test successful upload with a known MIME type."""
     # Create a temporary file
     test_file = tmp_path / "test.html"
-    test_file.write_text("<html><body>Test</body></html>")
+    test_file.write_text("<html><body>Test</body></html>", encoding="utf-8")
 
     # Mock the client
     mock_client_instance = MagicMock()
@@ -32,7 +52,8 @@ def test_upload_file_success_known_mime(tmp_path):
     mock_client_instance.beta.files.upload.return_value = mock_result
 
     # Call the function
-    result = upload_file(str(test_file))
+    with patch.object(upload_module.mimetypes, "guess_type", return_value=("text/html", None)):
+        result = upload_file(str(test_file))
 
     # Verify result and client calls
     assert result == mock_result
@@ -52,14 +73,15 @@ def test_upload_file_success_unknown_mime(tmp_path):
     """Test successful upload falls back to application/octet-stream for unknown MIME."""
     # Create a temporary file with an unknown extension
     test_file = tmp_path / "test.unknown_ext"
-    test_file.write_text("Some random data")
+    test_file.write_text("Some random data", encoding="utf-8")
 
     # Mock the client
     mock_client_instance = MagicMock()
     mock_anthropic.Anthropic.return_value = mock_client_instance
 
     # Call the function
-    upload_file(str(test_file))
+    with patch.object(upload_module.mimetypes, "guess_type", return_value=(None, None)):
+        upload_file(str(test_file))
 
     # Verify fallback MIME type
     call_kwargs = mock_client_instance.beta.files.upload.call_args[1]
@@ -70,7 +92,7 @@ def test_upload_file_success_unknown_mime(tmp_path):
 def test_main_success(tmp_path, capsys):
     """Test main CLI function on successful upload."""
     test_file = tmp_path / "test.txt"
-    test_file.write_text("Hello")
+    test_file.write_text("Hello", encoding="utf-8")
 
     mock_client_instance = MagicMock()
     mock_anthropic.Anthropic.return_value = mock_client_instance
@@ -98,16 +120,10 @@ def test_main_file_not_found(capsys):
 def test_main_api_error(tmp_path, capsys):
     """Test main CLI function when Anthropic API raises an error."""
     test_file = tmp_path / "test.txt"
-    test_file.write_text("Hello")
+    test_file.write_text("Hello", encoding="utf-8")
 
     mock_client_instance = MagicMock()
     mock_anthropic.Anthropic.return_value = mock_client_instance
-
-    # Mock APIError
-    class MockAPIError(Exception):
-        pass
-
-    mock_anthropic.APIError = MockAPIError
     mock_client_instance.beta.files.upload.side_effect = MockAPIError("API failure")
 
     # Call main


### PR DESCRIPTION
### Motivation

- Prevent order-dependent failures caused by a module-level `anthropic` MagicMock leaking state across tests.
- Make MIME detection and temporary-file writes deterministic across platforms to reduce flakiness.
- Ensure the `main()` exception handling can be exercised safely by providing a concrete mock `APIError` type.

### Description

- Scope the temporary `anthropic` replacement to import time using `patch.dict(sys.modules, {...})` instead of mutating `sys.modules` permanently. 
- Introduce `MockAPIError` and assign it to `mock_anthropic.APIError` so exception handlers can `except` it safely. 
- Add an `autouse` pytest fixture `reset_anthropic_mock()` to reset the shared mock before and after each test to avoid accumulated call counts. 
- Patch `mimetypes.guess_type` in tests to deterministically exercise known/unknown MIME branches and use `encoding='utf-8'` in `Path.write_text` calls. 

### Testing

- Ran the focused tests with `PYENV_VERSION=3.12.13 PYTHONPATH=src python -m pytest tests/test_upload.py -q`, which passed. 
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, which revealed an unrelated failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by a mocked `open` interfering with gettext `.mo` loading in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2246ce8c83209dfea73abc2fac97)