### PR TITLE
Restore Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,31 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Restore the removed Gemini Code Assist workflow so the repository continues to run Gemini Code Assist on PR open/synchronize/reopen events and on `@gemini-code-assist` review/issue comments.

### Description
- Add `.github/workflows/gemini-code-assist.yml` which configures `on: pull_request`, `pull_request_review_comment`, and `issue_comment`, grants `contents`, `pull-requests`, and `issues` permissions, and defines a `gemini-code-assist` job that checks out the repo and runs `google-gemini/code-assist-action@v1`.

### Testing
- Ran `git diff --check` and `git diff --cached --check` which passed; attempted `pytest` but `pytest -q` failed due to the local `.python-version` selecting an unavailable Python (`3.12.11`) and `PYENV_VERSION=3.12.13 python -m pytest -q` failed during collection because test dependencies were missing (`requests`) and the `html2md` package was not importable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2225757483208acc605985eb006d)