### PR TITLE
Restore Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,31 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Reinstate the repository-level Gemini Code Assist workflow so PR events and `@gemini-code-assist` comments continue triggering the `google-gemini/code-assist-action` integration.

### Description
- Added `.github/workflows/gemini-code-assist.yml` which re-enables the workflow listening on `pull_request`, `pull_request_review_comment`, and `issue_comment` events and restores the `google-gemini/code-assist-action@v1` step with appropriate permissions.

### Testing
- Ran `git diff --check` to validate the patch formatting and found no issues (check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2207d2008320ab276a746394d3dc)