### PR TITLE
Use Python 3.8-compatible CLI annotations

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import sys
 from urllib.parse import urlparse, unquote
-from typing import Any, Tuple, Callable
+from typing import Any, Callable, Optional, Tuple
 
 
 class DependencyError(Exception):
@@ -65,7 +65,7 @@ def setup_session(requests_module: Any) -> Any:
 
 
 def process_url(
-    target_url: str, session: Any, md: Callable[..., str], outdir: str | None
+    target_url: str, session: Any, md: Callable[..., str], outdir: Optional[str]
 ) -> None:
     """Process a single URL: fetch HTML and convert to Markdown."""
     # Fix common URL typo: trailing slash before query parameters


### PR DESCRIPTION
### Motivation
- Ensure the CLI module remains importable and compatible with the declared minimum Python version (>=3.8) by avoiding PEP 604 union syntax that can break annotation evaluation on 3.8/3.9.

### Description
- Replace the PEP 604 annotation `str | None` with `Optional[str]` on `process_url()` and add `Optional` to the `typing` imports in `src/html2md/cli.py`.

### Testing
- Ran byte-compilation with `python3 -m py_compile src/html2md/cli.py tests/test_cli_refactoring.py`, which succeeded.
- Attempted to run the test suite with `python3 -m pytest -q`, but `pytest` is not installed in the execution environment so full test run could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21e907648320a602fe8fff50e8cd)