### PR TITLE
Restore Gemini workflow and enforce safe batch URL handling

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,52 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Gemini Code Assist
+        uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          use_gemini_code_assist: ${{ vars.GOOGLE_GENAI_USE_GCA }}
+          use_vertex_ai: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          gcp_location: ${{ vars.GOOGLE_CLOUD_LOCATION }}
+          gcp_project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+          gcp_workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION }}
+          gemini_model: ${{ vars.GEMINI_MODEL }}
+          workflow_name: gemini-code-assist
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          prompt: |
+            You are Gemini Code Assist reviewing this repository.
+            Respond to pull request events and @gemini-code-assist requests with concise, actionable feedback.

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -23,17 +23,23 @@ if ($BatchFile) {
     Get-Content -LiteralPath $BatchFile | ForEach-Object {
         $url = $_.Trim()
         if (-not [string]::IsNullOrWhiteSpace($url)) {
-            Write-Host "Processing: $url"
-            $argsList = @("--url", "$url", "--outdir", "$outDir")
+            $uriObj = $null
+            if ([System.Uri]::TryCreate($url, [System.UriKind]::Absolute, [ref]$uriObj) -and ($uriObj.Scheme -eq 'http' -or $uriObj.Scheme -eq 'https')) {
+                $safeUrl = $uriObj.AbsoluteUri
+                Write-Host "Processing: $safeUrl"
+                $argsList = @("--url", "$safeUrl", "--outdir", "$outDir")
 
-            if (Test-Path -LiteralPath $venvExe) {
-                & $venvExe $argsList
-            } elseif (Test-Path -LiteralPath $pyScript) {
-                $pyCmd = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "python3" }
-                $argsList = @("$pyScript") + $argsList
-                & $pyCmd $argsList
+                if (Test-Path -LiteralPath $venvExe) {
+                    Start-Process -FilePath $venvExe -ArgumentList $argsList -Wait
+                } elseif (Test-Path -LiteralPath $pyScript) {
+                    $pyCmd = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "python3" }
+                    $argsList = @("$pyScript") + $argsList
+                    Start-Process -FilePath $pyCmd -ArgumentList $argsList -Wait
+                } else {
+                    Write-Error "Could not find html2md executable or script."
+                }
             } else {
-                Write-Error "Could not find html2md executable or script."
+                Write-Error "Skipping invalid URL: $url"
             }
         }
     }

--- a/tests/test_gui_batch_security.py
+++ b/tests/test_gui_batch_security.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+import subprocess
+
+import pytest
+
+
+def get_powershell_executable():
+    """Return a usable PowerShell executable, or None when unavailable."""
+    for exe in ("pwsh", "powershell"):
+        path = shutil.which(exe)
+        if not path:
+            continue
+        result = subprocess.run(
+            [path, "-NoProfile", "-NonInteractive", "-Command", "$PSVersionTable.PSVersion"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return path
+    return None
+
+
+PS_EXE = get_powershell_executable()
+
+
+@pytest.mark.skipif(PS_EXE is None, reason="PowerShell not available on this system")
+def test_batch_mode_rejects_unsupported_schemes(tmp_path):
+    """Batch mode should reject unsupported schemes before conversion runs."""
+    source_script = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../gui-url-convert.ps1")
+    )
+    script_path = tmp_path / "gui-url-convert.ps1"
+    shutil.copyfile(source_script, script_path)
+
+    batch_file = tmp_path / "batch.txt"
+    batch_file.write_text("file:///etc/passwd\nhttp://example.com\n", encoding="utf-8")
+
+    cmd = [
+        PS_EXE,
+        "-NoProfile",
+        "-NonInteractive",
+        "-File",
+        str(script_path),
+        "-BatchFile",
+        str(batch_file),
+        "-BatchOutDir",
+        str(tmp_path / "dummy_out"),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    invalid_message = "Skipping invalid URL: file:///etc/passwd"
+    assert invalid_message in result.stderr or invalid_message in result.stdout
+    assert "Processing: http://example.com/" in result.stdout


### PR DESCRIPTION
### Motivation
- Re-enable the Gemini Code Assist workflow triggers that were removed so PR events and `@gemini-code-assist` requests are handled, and fix the batch-mode URL handling gap that left the PowerShell wrapper vulnerable to unsupported schemes and potential command-injection risk.

### Description
- Add `.github/workflows/gemini-code-assist.yml` using `google-github-actions/run-gemini-cli@v0` to restore PR/review-comment/issue-comment triggers for Gemini code assist. 
- Reduce permissions in `.github/workflows/request-jules-review.yml` to only `issues: write` (remove unnecessary `pull-requests: write`).
- Harden `gui-url-convert.ps1` batch loop by using `[System.Uri]::TryCreate` to validate absolute URIs, restrict schemes to `http`/`https`, normalize with `.AbsoluteUri`, and invoke the converter via `Start-Process -ArgumentList` to avoid unsafe argument interpolation; invalid URLs now produce `Skipping invalid URL: $url`.
- Add `tests/test_gui_batch_security.py` which copies the PowerShell script into `tmp_path`, writes a UTF-8 batch file, runs PowerShell with `-NoProfile -NonInteractive`, and asserts that `file://` URLs are rejected while `http://` URLs are processed.

### Testing
- Installed the package with `PYENV_VERSION=3.12.13 python -m pip install -e .` which completed successfully. 
- Running the repository test suite with `PYENV_VERSION=3.12.13 python -m pytest` initially hit a locale/gettext interaction when a test mocked `open`, but re-running with `LC_ALL=C` completed successfully with `20 passed, 1 skipped`. 
- Executing the new test alone with `PYENV_VERSION=3.12.13 python -m pytest tests/test_gui_batch_security.py` was attempted and the test was skipped in this environment because PowerShell is not available. 
- Workflow YAML files were validated via `yaml.safe_load` to ensure syntactic correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21d23c44832089df116e96d8619a)