### PR TITLE
Restore Gemini review workflow triggers

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,57 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Gemini review
+        uses: google-github-actions/run-gemini-cli@v0.1.22
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gcp_location: ${{ vars.GOOGLE_CLOUD_LOCATION }}
+          gcp_project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+          gcp_workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION }}
+          gemini_debug: ${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}
+          gemini_model: ${{ vars.GEMINI_MODEL }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          use_gemini_code_assist: ${{ vars.GOOGLE_GENAI_USE_GCA }}
+          use_vertex_ai: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+          upload_artifacts: ${{ vars.UPLOAD_ARTIFACTS }}
+          workflow_name: gemini-code-assist
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: /pr-code-review

--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
### Motivation
- Re-enable the repository-defined Gemini review integration so PR lifecycle events and `@gemini-code-assist` comments trigger automated reviews again. 
- Replace a removed/nonexistent action reference with a supported `run-gemini-cli` version and tighten the Jules request workflow permissions to least privilege.

### Description
- Add `.github/workflows/gemini-code-assist.yml` to run Gemini reviews on `pull_request`, `pull_request_review_comment` and `issue_comment` events using `google-github-actions/run-gemini-cli@v0.1.22` and the code-review extension with the `/pr-code-review` prompt. 
- Configure the new workflow with minimal `contents: read` and review-related permissions required by the action. 
- Update `.github/workflows/request-jules-review.yml` to remove the unnecessary `pull-requests: write` permission, keeping only `issues: write` for the bot comment step.

### Testing
- Validated both workflow YAML files parse with `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/gemini-code-assist.yml .github/workflows/request-jules-review.yml`, which succeeded. 
- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/gemini-code-assist.yml .github/workflows/request-jules-review.yml` to lint the workflows, which completed without blocking issues after updating the action version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21c715a4832087f56d4467c56114)