### PR TITLE
Validate GUI batch URLs in PR follow-up

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -23,17 +23,23 @@ if ($BatchFile) {
     Get-Content -LiteralPath $BatchFile | ForEach-Object {
         $url = $_.Trim()
         if (-not [string]::IsNullOrWhiteSpace($url)) {
-            Write-Host "Processing: $url"
-            $argsList = @("--url", "$url", "--outdir", "$outDir")
+            $uriObj = $null
+            if ([System.Uri]::TryCreate($url, [System.UriKind]::Absolute, [ref]$uriObj) -and ($uriObj.Scheme -eq 'http' -or $uriObj.Scheme -eq 'https')) {
+                $safeUrl = $uriObj.AbsoluteUri
+                Write-Host "Processing: $safeUrl"
+                $argsList = @("--url", "$safeUrl", "--outdir", "$outDir")
 
-            if (Test-Path -LiteralPath $venvExe) {
-                & $venvExe $argsList
-            } elseif (Test-Path -LiteralPath $pyScript) {
-                $pyCmd = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "python3" }
-                $argsList = @("$pyScript") + $argsList
-                & $pyCmd $argsList
+                if (Test-Path -LiteralPath $venvExe) {
+                    Start-Process -FilePath $venvExe -ArgumentList $argsList -Wait -NoNewWindow
+                } elseif (Test-Path -LiteralPath $pyScript) {
+                    $pyCmd = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "python3" }
+                    $argsList = @("$pyScript") + $argsList
+                    Start-Process -FilePath $pyCmd -ArgumentList $argsList -Wait -NoNewWindow
+                } else {
+                    Write-Error "Could not find html2md executable or script."
+                }
             } else {
-                Write-Error "Could not find html2md executable or script."
+                Write-Error "Skipping invalid URL: $url"
             }
         }
     }

--- a/tests/test_gui_batch_security.py
+++ b/tests/test_gui_batch_security.py
@@ -1,0 +1,54 @@
+"""Test batch mode URL scheme validation in the GUI wrapper."""
+
+import shutil
+import subprocess
+
+import pytest
+
+
+def get_powershell_command():
+    """Find an available PowerShell executable with hermetic invocation flags."""
+    for exe in ["pwsh", "powershell"]:
+        cmd = [exe, "-NoProfile", "-NonInteractive", "-Command", "'1'"]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return [exe, "-NoProfile", "-NonInteractive"]
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+    return None
+
+
+PS_CMD = get_powershell_command()
+
+
+@pytest.mark.skipif(PS_CMD is None, reason="PowerShell not available on this system")
+def test_batch_mode_rejects_unsupported_schemes(tmp_path):
+    """Batch mode rejects unsupported URL schemes before conversion."""
+    repo_script = "gui-url-convert.ps1"
+    isolated_script = tmp_path / repo_script
+    shutil.copyfile(repo_script, isolated_script)
+
+    batch_file = tmp_path / "batch.txt"
+    batch_file.write_text("file:///etc/passwd\nhttp://example.com\n", encoding="utf-8")
+
+    cmd = [
+        *PS_CMD,
+        "-File",
+        str(isolated_script),
+        "-BatchFile",
+        str(batch_file),
+        "-BatchOutDir",
+        str(tmp_path / "out"),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=30)
+
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "Skipping invalid URL: file:///etc/passwd" in combined_output
+    assert "Processing: http://example.com/" in result.stdout


### PR DESCRIPTION
### Motivation

- Ensure the GUI wrapper's batch mode performs the same URL scheme validation as the interactive GUI to prevent unsupported-scheme abuse (e.g., `file://`) and reduce command-injection risk. 
- Normalize validated URLs before handing them to the converter so downstream processes receive percent-encoded safe URIs.
- Reduce workflow token blast radius by removing an unused `pull-requests: write` permission from the Jules review workflow.

### Description

- Replace the batch-mode loop in `gui-url-convert.ps1` to validate each line with `[System.Uri]::TryCreate`, restrict allowed schemes to `http`/`https`, and use `.AbsoluteUri` for the safe URL before processing. 
- Switch invocation of the packaged exe and Python script to `Start-Process -ArgumentList` with `-Wait -NoNewWindow` to pass arguments safely instead of using the call operator. 
- Add `tests/test_gui_batch_security.py`, a hermetic pytest regression that uses `tmp_path`, UTF-8 file writes, copies the PowerShell script into a temporary directory (avoids untracked `.venv`), and invokes PowerShell with `-NoProfile`/`-NonInteractive` to assert `file://` is skipped and `http://` is processed. 
- Remove the unnecessary `pull-requests: write` permission from `.github/workflows/request-jules-review.yml`, leaving only the `issues: write` permission used to post comments requesting review.

### Testing

- Installed the package editable and test dependencies via `python -m pip install -e . pytest` and ran the new regression test with `python -m pytest -q tests/test_gui_batch_security.py`, which passed. 
- Ran the regression together with existing CLI security tests via `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_gui_batch_security.py tests/test_cli_security.py`, which passed. 
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21ba35508320b2c673f733e6cb12)