### PR TITLE
Ensure get_host_port tests run in default CI

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -1,12 +1,9 @@
 """Flask application for html2md."""
 
-import os
-
 from flask import Flask, jsonify
 
 from html2md import __version__
-
-DEFAULT_PORT = 10000
+from html2md.config import DEFAULT_PORT, get_host_port
 
 app = Flask(__name__)
 
@@ -15,28 +12,6 @@ app = Flask(__name__)
 def health():
     """Return health status of the application."""
     return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
-
-
-def get_host_port():
-    """Get host and port from environment variables."""
-    default_port = 10000
-    port_str = os.environ.get('PORT')
-    try:
-        if port_str is not None:
-            port_value = int(port_str)
-            if port_value < 1 or port_value > 65535:
-                raise ValueError("Port out of range")
-        else:
-            port_value = DEFAULT_PORT
-    except ValueError:
-        print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
-        )
-        port_value = DEFAULT_PORT
-
-    hostname = os.environ.get('HOST', '0.0.0.0')
-    return hostname, port_value
 
 
 if __name__ == '__main__':

--- a/src/html2md/config.py
+++ b/src/html2md/config.py
@@ -1,0 +1,26 @@
+"""Runtime configuration helpers for html2md."""
+
+import os
+
+DEFAULT_PORT = 10000
+
+
+def get_host_port():
+    """Get host and port from environment variables."""
+    port_str = os.environ.get('PORT')
+    try:
+        if port_str is not None:
+            port_value = int(port_str)
+            if port_value < 1 or port_value > 65535:
+                raise ValueError('Port out of range')
+        else:
+            port_value = DEFAULT_PORT
+    except ValueError:
+        print(
+            f'Warning: Invalid PORT environment variable value '
+            f'{port_str!r}; falling back to default {DEFAULT_PORT}.'
+        )
+        port_value = DEFAULT_PORT
+
+    hostname = os.environ.get('HOST', '0.0.0.0')
+    return hostname, port_value

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,10 @@
 import os
-import pytest
 from unittest.mock import patch
-pytest.importorskip("flask")
-from html2md.app import get_host_port, DEFAULT_PORT
+
+import pytest
+
+from html2md.config import DEFAULT_PORT, get_host_port
+
 
 def test_get_host_port_defaults():
     with patch.dict(os.environ, clear=True):
@@ -10,12 +12,14 @@ def test_get_host_port_defaults():
         assert host == '0.0.0.0'
         assert port == DEFAULT_PORT
 
+
 def test_get_host_port_valid_env():
     env = {'HOST': '127.0.0.1', 'PORT': '8080'}
     with patch.dict(os.environ, env, clear=True):
         host, port = get_host_port()
         assert host == '127.0.0.1'
         assert port == 8080
+
 
 def test_get_host_port_invalid_port_non_numeric(capsys):
     env = {'PORT': 'not_a_number'}
@@ -29,6 +33,7 @@ def test_get_host_port_invalid_port_non_numeric(capsys):
         assert "'not_a_number'" in captured.out
         assert f"falling back to default {DEFAULT_PORT}" in captured.out
 
+
 def test_get_host_port_invalid_port_empty_string(capsys):
     env = {'PORT': ''}
     with patch.dict(os.environ, env, clear=True):
@@ -40,6 +45,7 @@ def test_get_host_port_invalid_port_empty_string(capsys):
         assert "Warning: Invalid PORT environment variable value" in captured.out
         assert "''" in captured.out
         assert f"falling back to default {DEFAULT_PORT}" in captured.out
+
 
 @pytest.mark.parametrize("invalid_port", ["-1", "0", "65536", "100000"])
 def test_get_host_port_out_of_bounds_port(capsys, invalid_port):


### PR DESCRIPTION
### Motivation
- The `get_host_port` logic was hidden behind the Flask module, causing its tests to be skipped in the repository's default CI setup where `flask` is only an optional extra, so the parsing coverage was not exercised by CI.

### Description
- Move `DEFAULT_PORT` and `get_host_port()` into a Flask-free `src/html2md/config.py` so the helper can be imported without installing the optional `deploy` extra.
- Update `src/html2md/app.py` to import `DEFAULT_PORT` and `get_host_port` from `html2md.config` for runtime use.
- Update `tests/test_app.py` to import `get_host_port` and `DEFAULT_PORT` from `html2md.config` and remove the `pytest.importorskip("flask")` skip so the tests run in the default CI environment.
- Preserve the existing port validation (numeric parse, range 1–65535) and fallback warning behavior used when `PORT` is invalid.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_app.py` and the test file completed successfully (`........  [100%]`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` and the suite completed successfully (`............................  [100%]`).
- Verified the new `src/html2md/config.py` is used by `src/html2md/app.py` and that the `get_host_port` tests cover default, valid, non-numeric, empty, and out-of-bounds `PORT` scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe219d702c83208da22e4458b52c38)