### PR TITLE
[AI-Assisted] Scope AI metadata approval rule

### DIFF
--- a/pr-rules/common.md
+++ b/pr-rules/common.md
@@ -12,7 +12,8 @@ rules layer on top in `pr-rules/<lang>.md` and `pr-rules/service-*.md`.
   draft PRs; CI may warn during draft PR checks if it remains unfilled, but
   once the PR is ready for review, CI will fail until the placeholder is
   replaced with the actual link.
-- Reviewers should not approve a PR that lacks the tag or the required link.
+- Reviewers should not approve an AI-authored or substantially AI-edited PR
+  that lacks the tag or the required link.
 
 ## 2. Scope discipline
 


### PR DESCRIPTION
### Motivation
- Avoid blocking reviewers from rejecting fully human-authored PRs by scoping the missing-AI-metadata approval guidance to AI-authored or substantially AI-edited PRs.

### Description
- Update `pr-rules/common.md` to change the reviewer guidance so it applies only to AI-authored or substantially AI-edited PRs (i.e., reviewers should not approve such PRs that lack the `[AI-Assisted]` tag or the required agent transcript link).

### Testing
- Ran `scripts/check_agents_consistency.sh` (passed) and `git diff --check` (passed); `pytest -q` could not be executed because the environment is configured via `pyenv` for Python `3.12.5` which is not installed and `pytest` is unavailable; Originating Claude chat: `<CLAUDE_CHAT_URL>`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea0a8a52483209e59d13038fcf54f)