### PR TITLE
Gate Gemini comment triggers to trusted users

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -18,10 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
+      ((github.event_name == 'pull_request_review_comment' ||
+        github.event_name == 'issue_comment') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       (github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request) &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- Prevent untrusted commenters from invoking the privileged Gemini Code Assist action via comment triggers in public PRs by matching the guard used in the existing Claude workflow.
- Preserve automatic `pull_request` runs while restricting comment-based triggers to trusted repository members.

### Description
- Updated the `if` condition in `.github/workflows/gemini-code-assist.yml` to require `github.event.comment.author_association` be `MEMBER`, `OWNER`, or `COLLABORATOR` for `pull_request_review_comment` and `issue_comment` events.
- Kept `pull_request` event runs unchanged and ensured `issue_comment` handlers are still scoped to pull requests before checking the comment body for `@gemini-code-assist`.

### Testing
- Ran `actionlint .github/workflows/gemini-code-assist.yml`, which returned no errors.
- Ran `git diff --check` to verify there are no whitespace or diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4872af708320b83ac3afff651d9a)