### PR TITLE
[AI-Assisted] Accept Claude Code transcript URLs

### DIFF
--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -34,6 +34,7 @@ jobs:
           # Body must reference an agent transcript URL for PRs explicitly
           # marked as AI-assisted. Accepted hosts and required path prefixes:
           #   claude.ai/(chat|share)/<id>
+          #   claude.ai/code/session_<id> (Claude Code sessions)
           #   cursor.com/share/<id>
           #   chatgpt.com/codex/<...>
           #   jules.google.com/task/<id>
@@ -49,16 +50,15 @@ jobs:
           # short-circuiting the placeholder check).
           if printf '%s' "$body" | grep -qF '<CLAUDE_CHAT_URL>'; then
             if [[ "${PR_DRAFT:-false}" == "true" ]]; then
-              echo "::warning::Draft PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before marking ready for review."
-              # Don't exit yet — fall through so we still validate that the
-              # draft body has a real URL (drafts can have both during edits).
+              echo "::warning::Draft PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real agent transcript URL before marking ready for review."
+              exit 0
             else
-              echo "::error::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before marking ready for review or merging."
+              echo "::error::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real agent transcript URL before marking ready for review or merging."
               exit 1
             fi
           fi
 
-          # Step 2: require a real transcript URL with a known share/chat
+          # Step 2: require a real transcript URL with a known transcript
           # path prefix per provider.
           # The leading-boundary group `(^|[[:space:]<>(])` requires the URL
           # to start at a real link boundary so that:
@@ -70,13 +70,11 @@ jobs:
           #     https://example.test/redirect/https://claude.ai/chat/fake do
           #     not match (the inner `https?://` is preceded by `/` not a
           #     boundary char).
-          # The trailing class `[^/?[:space:]]` requires at least one
-          # non-slash, non-`?`, non-whitespace path character after the
-          # transcript prefix so an empty `/` doesn't pass.
-          if printf '%s' "$body" | grep -Eqi '(^|[[:space:]<>(])https?://(claude\.ai/(chat|share)|cursor\.com/share|chatgpt\.com/codex|jules\.google\.com/task)/[^/?[:space:]]'; then
-            # If a draft PR has the placeholder AND a real URL, the warning
-            # above is what surfaces; this exit 0 keeps the check green so
-            # drafts can iterate.
+          # Each provider alternative includes the required transcript path
+          # prefix plus at least one non-slash, non-`?`, non-whitespace
+          # character after that prefix so empty paths and query-only root
+          # URLs do not pass.
+          if printf '%s' "$body" | grep -Eqi '(^|[[:space:]<>(])https?://(claude\.ai/(chat|share)/[^/?[:space:]]|claude\.ai/code/session[_/][^/?[:space:]]|cursor\.com/share/[^/?[:space:]]|chatgpt\.com/codex/[^/?[:space:]]|jules\.google\.com/task/[^/?[:space:]])'; then
             echo "OK: PR body contains an agent transcript URL."
             exit 0
           fi
@@ -84,5 +82,5 @@ jobs:
           # No real transcript URL found, and we've already exited 1 if a
           # non-draft body had the placeholder. Anything reaching here is an
           # AI-assisted PR with no transcript link and no placeholder.
-          echo "::error::PR title is tagged [AI-Assisted] but the body does not include an originating agent transcript URL (claude.ai/chat|share, cursor.com/share, chatgpt.com/codex, jules.google.com/task). Add the URL or remove the tag."
+          echo "::error::PR title is tagged [AI-Assisted] but the body does not include an originating agent transcript URL (claude.ai/chat|share|code/session, cursor.com/share, chatgpt.com/codex, jules.google.com/task). Add the URL or remove the tag."
           exit 1


### PR DESCRIPTION
### Motivation
- The AI-assisted PR guard rejected valid Claude Code session links and treated draft placeholder handling inconsistently, causing false CI failures for AI-assisted PRs. 
- The guard's URL matching needed to accept Claude Code session transcripts and to fail/allow draft placeholder cases according to the baseline policy.

### Description
- Updated `.github/workflows/ai-assisted-pr-guard.yml` to accept `https://claude.ai/code/session_<id>` alongside existing `claude.ai/chat` and `claude.ai/share` patterns and to require a real transcript path fragment for each provider.  
- Tightened the regex to require a link boundary and at least one non-slash/non-`?` path character after the provider prefix to avoid false positives from bare hosts, lookalikes, or URL-in-URL embeddings.  
- Changed draft placeholder handling so draft PRs containing `<CLAUDE_CHAT_URL>` now emit a warning and exit 0, while ready/non-draft PRs still fail if the placeholder remains anywhere in the body.  
- Adjusted the user-facing messages to reference an "agent transcript URL" (not only "chat") for clarity.

### Testing
- `scripts/check_agents_consistency.sh`: OK.  
- `scripts/lint_ai_pr_guard_workflow.sh`: OK (YAML parse + structural checks passed).  
- `scripts/test_baseline_hook.sh`: OK (sensitive-file hook smoke tests passed).  
- `git diff --check`: OK.  
- `pytest -q` / `python3 -m pytest -q`: not executed successfully in this environment due to local pyenv / missing `pytest` (environment blocked by missing pyenv Python and pytest not installed).  

Originating Claude chat: https://claude.ai/code/session_01HwWbZfEMDVD2TQgT8ky8rQ

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea709c44c8320a4aea5d0cef3c26e)