### PR TITLE
[AI-Assisted] Allow human PRs through AI guard

### DIFF
--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -23,9 +23,17 @@ jobs:
           set -euo pipefail
           echo "PR title: $PR_TITLE"
 
+          body="${PR_BODY:-}"
+          transcript_url_pattern='(^|[[:space:]<>(])https?://(claude\.ai/(chat|share)/[^/?[:space:]]|claude\.ai/code/session_[^/?[:space:]]|cursor\.com/share/[^/?[:space:]]|chatgpt\.com/codex/[^/?[:space:]]|jules\.google\.com/task/[^/?[:space:]])'
+
           if [[ "$PR_TITLE" != \[AI-Assisted\]* ]]; then
-            echo "::error::PR title must start with [AI-Assisted]."
-            exit 1
+            if printf '%s' "$body" | grep -qF '<CLAUDE_CHAT_URL>' || printf '%s' "$body" | grep -Eqi "$transcript_url_pattern"; then
+              echo "::error::PR appears to include AI-assistance evidence but the title does not start with [AI-Assisted]. Add the marker or remove the AI-assistance evidence."
+              exit 1
+            fi
+
+            echo "OK: Untagged PR has no AI-assistance evidence; skipping transcript checks."
+            exit 0
           fi
 
           # Body must reference an agent transcript URL for PRs explicitly
@@ -39,8 +47,6 @@ jobs:
           # Ready/non-draft PRs fail if the placeholder is anywhere in the
           # body — even alongside a real URL — because the baseline says the
           # placeholder must be replaced before a PR is ready.
-          body="${PR_BODY:-}"
-
           # Step 1: reject the placeholder first for non-draft PRs. This must
           # come before the real-URL check so a PR with both a real URL AND a
           # leftover placeholder still fails (rather than the real URL match
@@ -71,7 +77,7 @@ jobs:
           # Each accepted provider path includes at least one non-slash,
           # non-`?`, non-whitespace character after its required prefix so
           # empty transcript paths don't pass.
-          if printf '%s' "$body" | grep -Eqi '(^|[[:space:]<>(])https?://(claude\.ai/(chat|share)/[^/?[:space:]]|claude\.ai/code/session_[^/?[:space:]]|cursor\.com/share/[^/?[:space:]]|chatgpt\.com/codex/[^/?[:space:]]|jules\.google\.com/task/[^/?[:space:]])'; then
+          if printf '%s' "$body" | grep -Eqi "$transcript_url_pattern"; then
             # If a draft PR has the placeholder AND a real URL, the warning
             # above is what surfaces; this exit 0 keeps the check green so
             # drafts can iterate.

--- a/scripts/lint_ai_pr_guard_workflow.sh
+++ b/scripts/lint_ai_pr_guard_workflow.sh
@@ -50,7 +50,11 @@ fi
 
 if [ "$have_yaml" -eq 1 ]; then
   "$PYTHON_BIN" - "$WF" <<'PY' || exit 1
+import os
+import subprocess
 import sys
+import tempfile
+
 import yaml
 
 path = sys.argv[1]
@@ -88,7 +92,62 @@ if "[AI-Assisted]" not in raw:
 if "claude.ai" not in raw and "CLAUDE_CHAT_URL" not in raw and "Claude chat" not in raw:
     print("FAIL: workflow must reference a Claude chat link check", file=sys.stderr); sys.exit(1)
 
-print(f"OK [yaml-parse]: {path} triggers on pull_request, has {len(jobs)} job(s), checks [AI-Assisted] + Claude chat link")
+run_script = None
+for job in jobs.values():
+    if not isinstance(job, dict):
+        continue
+    for step in job.get("steps", []):
+        if isinstance(step, dict) and step.get("name") == "Inspect PR title and body":
+            run_script = step.get("run")
+            break
+    if run_script is not None:
+        break
+if not isinstance(run_script, str) or not run_script.strip():
+    print("FAIL: workflow must include an executable 'Inspect PR title and body' run block", file=sys.stderr); sys.exit(1)
+
+
+def run_case(name, title, body, draft, expect_code, expect_text):
+    env = os.environ.copy()
+    env.update({"PR_TITLE": title, "PR_BODY": body, "PR_DRAFT": draft})
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".sh", delete=False) as tmp:
+        tmp.write(run_script)
+        tmp_path = tmp.name
+    try:
+        proc = subprocess.run(["bash", tmp_path], env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    finally:
+        os.unlink(tmp_path)
+    output = proc.stdout
+    if proc.returncode != expect_code:
+        print(f"FAIL: {name} exited {proc.returncode}, expected {expect_code}\n{output}", file=sys.stderr); sys.exit(1)
+    if expect_text not in output:
+        print(f"FAIL: {name} output missing {expect_text!r}\n{output}", file=sys.stderr); sys.exit(1)
+
+run_case(
+    "untagged human PR",
+    "Fix typo",
+    "Small documentation typo fix.",
+    "false",
+    0,
+    "skipping transcript checks",
+)
+run_case(
+    "untagged PR with AI evidence",
+    "Fix typo",
+    "Originating Claude chat: https://claude.ai/chat/example",
+    "false",
+    1,
+    "title does not start with [AI-Assisted]",
+)
+run_case(
+    "tagged AI PR with transcript",
+    "[AI-Assisted] Fix typo",
+    "Originating Claude chat: https://claude.ai/chat/example",
+    "false",
+    0,
+    "contains an agent transcript URL",
+)
+
+print(f"OK [yaml-parse]: {path} triggers on pull_request, has {len(jobs)} job(s), checks [AI-Assisted] + Claude chat link, and allows untagged human PRs")
 PY
 else
   # Fallback grep-based checks (no pyyaml available).


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where the AI-PR guard workflow rejected ordinary human-authored PRs whose titles did not start with `[AI-Assisted]`, instead of only enforcing transcript checks when AI-assistance evidence is present.

### Description
- Update `.github/workflows/ai-assisted-pr-guard.yml` to populate `body`, introduce a shared `transcript_url_pattern`, and early-exit 0 for untagged PRs that contain no AI-assistance evidence while still failing untagged PRs that do contain the Claude placeholder or a recognized transcript URL.
- Reuse the `transcript_url_pattern` for both AI-evidence detection and the existing `[AI-Assisted]` transcript validation to keep checks consistent and remove duplicated regex literals.
- Extend `scripts/lint_ai_pr_guard_workflow.sh` to extract and execute the workflow `run` block as smoke tests that cover an untagged human PR, an untagged PR containing AI evidence, and a tagged AI PR with a transcript.

### Testing
- Ran `scripts/lint_ai_pr_guard_workflow.sh` which passed and confirms the workflow now allows untagged human PRs while rejecting untagged PRs that include AI evidence.
- Ran `scripts/check_agents_consistency.sh` which passed.
- Performed an editable install with `python -m pip install -e .` and ran `PYENV_VERSION=3.12.13 LC_ALL=C.UTF-8 LANGUAGE=C pytest -q`, and the test suite completed with all tests green.
- Originating Claude chat: <CLAUDE_CHAT_URL>

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb86387e48320895d1aaeb86a5ff0)