### PR TITLE
[AI-Assisted] Use portable Python for Claude hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/protect-sensitive-files.py"
+            "command": "/bin/sh -c 'for py in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3 python; do if { [ -x \"$py\" ] || command -v \"$py\" >/dev/null 2>&1; } && \"$py\" -c \"import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)\" >/dev/null 2>&1; then exec \"$py\" .claude/hooks/protect-sensitive-files.py; fi; done; echo \"protect-sensitive-files: BLOCKED \u2014 no Python >= 3.8 interpreter found\" >&2; exit 2'"
           }
         ]
       }

--- a/scripts/lint_ai_pr_guard_workflow.sh
+++ b/scripts/lint_ai_pr_guard_workflow.sh
@@ -28,14 +28,12 @@ WF=".github/workflows/ai-assisted-pr-guard.yml"
 
 # Prefer pyyaml-based parse; fall back to grep checks.
 # Probe candidates and pick the first one that satisfies >= 3.8.
-# `python3`/`python` come first so the lint runs in a developer's normal
-# shell environment. The absolute system paths come next so the lint still
-# runs when the repo's `.python-version` pins a pyenv version that isn't
-# installed (the pyenv shim would otherwise fail before reaching a usable
-# interpreter, and the grep-only path silently downgrades validation).
+# Absolute system paths come first so the lint avoids broken pyenv shims
+# when the repo's `.python-version` pins an uninstalled version. Bare
+# `python3`/`python` remain as fallbacks for normal developer shells.
 have_yaml=0
 PYTHON_BIN=""
-for candidate in python3 python /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+for candidate in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3 python; do
   if [ -x "$candidate" ] || command -v "$candidate" >/dev/null 2>&1; then
     if "$candidate" -c "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)" >/dev/null 2>&1; then
       PYTHON_BIN="$candidate"

--- a/scripts/test_baseline_hook.sh
+++ b/scripts/test_baseline_hook.sh
@@ -24,13 +24,11 @@ HOOK=".claude/hooks/protect-sensitive-files.py"
 [ -f "$HOOK" ] || fail "hook script not found: $HOOK"
 
 # Probe candidates and pick the first one that satisfies >= 3.8.
-# `python3`/`python` come first so the test runs in a developer's normal
-# shell environment. The absolute system paths come next so the test still
-# runs when the repo's `.python-version` pins a pyenv version that isn't
-# installed (the pyenv shim would otherwise fail before reaching a usable
-# interpreter).
+# Absolute system paths come first so the test avoids broken pyenv shims
+# when the repo's `.python-version` pins an uninstalled version. Bare
+# `python3`/`python` remain as fallbacks for normal developer shells.
 PYTHON_BIN=""
-for candidate in python3 python /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+for candidate in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3 python; do
   if [ -x "$candidate" ] || command -v "$candidate" >/dev/null 2>&1; then
     if "$candidate" -c "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)" >/dev/null 2>&1; then
       PYTHON_BIN="$candidate"
@@ -38,7 +36,7 @@ for candidate in python3 python /usr/bin/python3 /opt/homebrew/bin/python3 /usr/
     fi
   fi
 done
-[ -n "$PYTHON_BIN" ] || fail "no python interpreter >= 3.8 found (tried: python3, python, /usr/bin/python3, /opt/homebrew/bin/python3, /usr/local/bin/python3)"
+[ -n "$PYTHON_BIN" ] || fail "no python interpreter >= 3.8 found (tried: /usr/bin/python3, /opt/homebrew/bin/python3, /usr/local/bin/python3, python3, python)"
 
 # Helper: run the hook with a given tool_name and file_path; return its exit code.
 run_hook() {
@@ -56,6 +54,50 @@ run_hook_payload() {
   local payload="$1"
   printf "%s\n" "$payload" | "$PYTHON_BIN" "$HOOK"
 }
+
+# Verify the actual Claude settings command can launch the hook even when a
+# bare `python` on PATH is broken/unusable. This covers pyenv checkouts where
+# `.python-version` points at an uninstalled version and a usable `python3` or
+# system interpreter is still available.
+SETTINGS_HOOK_COMMAND="$("$PYTHON_BIN" - <<'PY'
+import json
+from pathlib import Path
+
+settings = json.loads(Path(".claude/settings.json").read_text(encoding="utf-8"))
+print(settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"])
+PY
+)"
+case "$SETTINGS_HOOK_COMMAND" in
+  "python $HOOK") fail "settings hook command must not rely on bare python only" ;;
+esac
+
+TMP_HOOK_PATH="$(mktemp -d)"
+cleanup_tmp_hook_path() { rm -rf "$TMP_HOOK_PATH"; }
+trap cleanup_tmp_hook_path EXIT
+cat >"$TMP_HOOK_PATH/python" <<'SH'
+#!/usr/bin/env sh
+echo "simulated broken python" >&2
+exit 127
+SH
+chmod +x "$TMP_HOOK_PATH/python"
+PYTHON_EXE="$("$PYTHON_BIN" -c 'import sys; print(sys.executable)')"
+cat >"$TMP_HOOK_PATH/python3" <<SH
+#!/usr/bin/env sh
+exec "$PYTHON_EXE" "\$@"
+SH
+chmod +x "$TMP_HOOK_PATH/python3"
+
+if ! printf '%s\n' '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"README.md"}}' \
+    | PATH="$TMP_HOOK_PATH:$PATH" /bin/sh -c "$SETTINGS_HOOK_COMMAND" >/dev/null 2>&1; then
+  fail "settings hook command should ALLOW normal file when bare python is broken"
+fi
+pass "settings hook command runs with broken bare python"
+
+if printf '%s\n' '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":".env"}}' \
+    | PATH="$TMP_HOOK_PATH:$PATH" /bin/sh -c "$SETTINGS_HOOK_COMMAND" >/dev/null 2>&1; then
+  fail "settings hook command should preserve hook BLOCK result for sensitive files"
+fi
+pass "settings hook command preserves sensitive-file block"
 
 # --- BLOCK cases (expect non-zero exit) ---
 for path in ".env" ".env.local" ".env.production" "config/.env" \


### PR DESCRIPTION
### Motivation
- Prevent a broken `python` (pyenv shim) from blocking the PreToolUse guard so edits are not denied before the hook runs.
- Make smoke/lint scripts and the hook invocation robust across developer environments where `python3`/`python` may be shims or missing.

### Description
- Replace the hook command in `.claude/settings.json` with a `/bin/sh -c 'for py in /usr/bin/python3 ... python3 python; do ...; exec "$py" .claude/hooks/protect-sensitive-files.py; done; ...'` probe that prefers known system interpreters and falls back to `python3`/`python` before failing.
- Update `scripts/test_baseline_hook.sh` to prefer absolute system Python paths first, add a verification that the configured settings command still runs when a bare `python` is broken, and ensure sensitive-file blocking behavior is preserved through the settings command.
- Update `scripts/lint_ai_pr_guard_workflow.sh` to probe interpreters in the same portable order and to use YAML parsing when available via the selected interpreter.
- Files changed: `.claude/settings.json`, `scripts/test_baseline_hook.sh`, `scripts/lint_ai_pr_guard_workflow.sh`.

### Testing
- `scripts/test_baseline_hook.sh` — passed (smoke tests verify blocking of sensitive paths and allowlist behavior, including simulated broken bare `python`).
- `scripts/check_agents_consistency.sh` — passed.
- `scripts/lint_ai_pr_guard_workflow.sh` — passed (YAML parse path used when available).
- `git diff --check` — passed.
- `pytest -q` / `python3 -m pytest -q` — blocked in this environment due to local pyenv configuration (pinned `3.12.5` not installed) and missing `pytest` in the system interpreter.

Originating Claude chat: <CLAUDE_CHAT_URL>

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb4c53c508320b1e2da513eababf6)