### PR TITLE
[AI-Assisted] Align Claude review transcript guidance

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -18,12 +18,15 @@ the baseline rule set. Read-only — do not edit files.
 
 1. Run `gh pr view --json number,title,body,headRefName,baseRefName` and
    capture the title and body. Then:
-   - If the title starts with `[AI-Assisted]`, confirm the body contains a
-     Claude chat URL (`claude.ai/chat/...`) and flag the literal placeholder
-     `<CLAUDE_CHAT_URL>` if still present.
+   - If the title starts with `[AI-Assisted]`, confirm the body contains an
+     originating agent transcript URL accepted by the guard workflow, such as
+     `claude.ai/chat/...`, `claude.ai/share/...`,
+     `claude.ai/code/session_...`, `cursor.com/share/...`,
+     `chatgpt.com/codex/...`, or `jules.google.com/task/...`; flag the
+     literal placeholder `<CLAUDE_CHAT_URL>` if still present.
    - If the title does not start with `[AI-Assisted]`, treat the PR as
      non-AI-authored for this check and do not report the missing marker or
-     missing Claude chat URL as a violation.
+     missing agent transcript URL as a violation.
 2. Run `git diff --name-only origin/main...HEAD` to enumerate changed files.
 3. Read `pr-rules/common.md`. For each rule, scan the diff and the changed
    files for violations. Report each violation as:


### PR DESCRIPTION
### Motivation
- Prevent `/review-pr` from falsely flagging valid AI-assisted PRs by aligning the Claude review command with the guard workflow's accepted originating agent transcript URL families.

### Description
- Update `.claude/commands/review-pr.md` so the review step accepts the same transcript URL patterns as the guard (examples: `claude.ai/chat/...`, `claude.ai/share/...`, `claude.ai/code/session_...`, `cursor.com/share/...`, `chatgpt.com/codex/...`, `jules.google.com/task/...`) and reword the non-AI branch to avoid Claude-only phrasing.

### Testing
- Ran `scripts/check_agents_consistency.sh` (OK), `scripts/lint_ai_pr_guard_workflow.sh` (OK), and `git diff --check` (OK); `pytest -q` was blocked by local pyenv configuration (missing Python 3.12.5 / pytest).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb44fafd4832094d13b70744dfab1)