### PR TITLE
Block non-global URL resolutions in SSRF guard

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -71,12 +71,17 @@ def main(argv=None):
             hostname = parsed.hostname
             if hostname:
                 try:
-                    ip = socket.gethostbyname(hostname)
-                    ip_obj = ipaddress.ip_address(ip)
-                    if (ip_obj.is_private or ip_obj.is_loopback or
-                        ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_reserved):
-                        print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
+                    addrinfo = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+                    resolved_ips = {result[4][0] for result in addrinfo}
+                    if not resolved_ips:
+                        print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
                         return
+
+                    for ip in resolved_ips:
+                        ip_obj = ipaddress.ip_address(ip)
+                        if not ip_obj.is_global:
+                            print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
+                            return
                 except (socket.gaierror, ValueError):
                     print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
                     return

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -8,6 +8,17 @@ import socket
 import ipaddress
 from urllib.parse import urlparse, unquote
 
+
+def _is_allowed_public_ip(ip: str) -> bool:
+    """Return whether an IP is safe for outbound URL fetches."""
+    ip_obj = ipaddress.ip_address(ip)
+
+    if isinstance(ip_obj, ipaddress.IPv6Address) and ip_obj.ipv4_mapped:
+        ip_obj = ip_obj.ipv4_mapped
+
+    return ip_obj.is_global and not ip_obj.is_multicast and not ip_obj.is_reserved
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -78,8 +89,7 @@ def main(argv=None):
                         return
 
                     for ip in resolved_ips:
-                        ip_obj = ipaddress.ip_address(ip)
-                        if not ip_obj.is_global:
+                        if not _is_allowed_public_ip(ip):
                             print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
                             return
                 except (socket.gaierror, ValueError):

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -8,6 +8,16 @@ import pytest
 from html2md import cli
 
 
+def _addrinfo_for(*ips):
+    """Build getaddrinfo-style results for resolved IP addresses."""
+    results = []
+    for ip in ips:
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        sockaddr = (ip, 0, 0, 0) if family == socket.AF_INET6 else (ip, 0)
+        results.append((family, socket.SOCK_STREAM, 6, "", sockaddr))
+    return results
+
+
 @pytest.mark.parametrize(
     "url, scheme",
     [
@@ -33,6 +43,11 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
         ("http://192.168.1.1/config", "192.168.1.1"),
         ("http://10.0.0.5/", "10.0.0.5"),
         ("http://100.64.0.1/", "100.64.0.1"),
+        ("http://multicast.test/", "224.0.0.1"),
+        ("http://ipv6-multicast.test/", "ff02::1"),
+        ("http://nat64-reserved.test/", "64:ff9b::7f00:1"),
+        ("http://mapped-cgnat.test/", "::ffff:100.64.0.1"),
+        ("http://mapped-multicast.test/", "::ffff:224.0.0.1"),
     ],
 )
 @patch("requests.Session.get")
@@ -40,12 +55,32 @@ def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, resolved_i
     """Ensure that non-global IPs are blocked to prevent SSRF."""
     with patch(
         "html2md.cli.socket.getaddrinfo",
-        return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", (resolved_ip, 0))],
+        return_value=_addrinfo_for(resolved_ip),
     ):
         cli.main(["--url", url, "--outdir", str(tmp_path)])
     outerr = capsys.readouterr()
     assert "Error: URL resolves to a restricted/private network address." in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_allows_ipv4_mapped_ipv6_for_global_address(mock_get, capsys, tmp_path):
+    """IPv4-mapped IPv6 addresses are allowed only when the mapped IPv4 is global."""
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=_addrinfo_for("::ffff:93.184.216.34"),
+    ):
+        cli.main(["--url", "http://example.com/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    assert "restricted/private" not in outerr.err
+    mock_get.assert_called_once()
 
 
 @patch("requests.Session.get")
@@ -70,7 +105,7 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     for url in urls:
         with patch(
             "html2md.cli.socket.getaddrinfo",
-            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))],
+            return_value=_addrinfo_for("93.184.216.34"),
         ):
             cli.main(["--url", url, "--outdir", str(outdir)])
         outerr = capsys.readouterr()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,6 +1,8 @@
 """Security-focused tests for CLI URL and output path handling."""
 
 from unittest.mock import MagicMock, patch
+import socket
+
 import pytest
 
 from html2md import cli
@@ -24,18 +26,23 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
 
 
 @pytest.mark.parametrize(
-    "url",
+    "url, resolved_ip",
     [
-        "http://127.0.0.1:8080/admin",
-        "http://localhost/secret",
-        "http://192.168.1.1/config",
-        "http://10.0.0.5/",
+        ("http://127.0.0.1:8080/admin", "127.0.0.1"),
+        ("http://localhost/secret", "127.0.0.1"),
+        ("http://192.168.1.1/config", "192.168.1.1"),
+        ("http://10.0.0.5/", "10.0.0.5"),
+        ("http://100.64.0.1/", "100.64.0.1"),
     ],
 )
 @patch("requests.Session.get")
-def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url):
-    """Ensure that local, private, and loopback IPs are blocked to prevent SSRF."""
-    cli.main(["--url", url, "--outdir", str(tmp_path)])
+def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, resolved_ip):
+    """Ensure that non-global IPs are blocked to prevent SSRF."""
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", (resolved_ip, 0))],
+    ):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
     outerr = capsys.readouterr()
     assert "Error: URL resolves to a restricted/private network address." in outerr.err
     mock_get.assert_not_called()
@@ -61,7 +68,11 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     ]
 
     for url in urls:
-        cli.main(["--url", url, "--outdir", str(outdir)])
+        with patch(
+            "html2md.cli.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))],
+        ):
+            cli.main(["--url", url, "--outdir", str(outdir)])
         outerr = capsys.readouterr()
         assert "Success!" in outerr.out
 


### PR DESCRIPTION
### Motivation

- Prevent SSRF by ensuring hostnames do not resolve to non-global addresses (including carrier-grade NAT like `100.64.0.0/10`) that were missed by the previous deny-list logic. 
- Support validation across all resolved addresses (IPv4/IPv6 and multiple A/AAAA records) instead of validating only a single IPv4 result. 
- Make security tests hermetic so they do not depend on the environment's DNS configuration.

### Description

- Replaced `socket.gethostbyname` with `socket.getaddrinfo` in `process_url` and collect all candidate IPs to validate. 
- Use `ipaddress.ip_address(...).is_global` to require globally routable addresses and reject any non-global/reserved/private/loopback/link-local/multicast addresses. 
- Updated `tests/test_cli_security.py` to mock `html2md.cli.socket.getaddrinfo`, add an explicit `100.64.0.1` test case, and mock DNS in the traversal-path test to avoid real network/DNS lookups.

### Testing

- Ran the full test suite with `python -m pytest -q` and the tests completed successfully. 
- Verified the modified security tests assert that non-global addresses are blocked and that traversal-like outputs remain contained in `--outdir`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4a1b0fb4832098f5006837b4a51f)