### PR TITLE
Support IPv6 hostname resolution in SSRF guard

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -8,6 +8,29 @@ import socket
 import ipaddress
 from urllib.parse import urlparse, unquote
 
+
+def _hostname_resolves_to_global_addresses(hostname: str) -> bool:
+    """Return True only when all IPv4/IPv6 answers for hostname are global."""
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return False
+
+    if not addrinfo:
+        return False
+
+    for result in addrinfo:
+        try:
+            ip_obj = ipaddress.ip_address(result[4][0])
+        except (IndexError, ValueError):
+            return False
+
+        if not ip_obj.is_global:
+            return False
+
+    return True
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -69,17 +92,12 @@ def main(argv=None):
                 return
 
             hostname = parsed.hostname
-            if hostname:
-                try:
-                    ip = socket.gethostbyname(hostname)
-                    ip_obj = ipaddress.ip_address(ip)
-                    if (ip_obj.is_private or ip_obj.is_loopback or
-                        ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_reserved):
-                        print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
-                        return
-                except (socket.gaierror, ValueError):
-                    print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-                    return
+            if hostname and not _hostname_resolves_to_global_addresses(hostname):
+                print(
+                    "Error: URL resolves to a restricted/private network address.",
+                    file=sys.stderr,
+                )
+                return
 
             print(f"Processing URL: {target_url}")
 

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -25,10 +25,22 @@ def _hostname_resolves_to_global_addresses(hostname: str) -> bool:
         except (IndexError, ValueError):
             return False
 
-        if not ip_obj.is_global:
+        if _is_restricted_ip_address(ip_obj):
             return False
 
     return True
+
+
+def _is_restricted_ip_address(
+    ip_obj: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """Return True when an IP address is unsafe for URL fetching."""
+    return (
+        not ip_obj.is_global
+        or ip_obj.is_reserved
+        or ip_obj.is_multicast
+        or getattr(ip_obj, "is_site_local", False)
+    )
 
 
 def main(argv=None):

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -99,6 +99,34 @@ def test_process_url_blocks_any_non_global_address(mock_get, capsys, tmp_path):
     mock_get.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "url, resolved_ip",
+    [
+        ("http://[64:ff9b::8.8.8.8]/", "64:ff9b::8.8.8.8"),
+        ("http://224.0.0.1/", "224.0.0.1"),
+        ("http://[ff02::1]/", "ff02::1"),
+        ("http://[fec0::1]/", "fec0::1"),
+    ],
+)
+@patch("requests.Session.get")
+def test_process_url_blocks_global_restricted_addresses(
+    mock_get, capsys, tmp_path, url, resolved_ip,
+):
+    """Restricted IP predicates are enforced even when is_global is True."""
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=addrinfo(resolved_ip),
+    ):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert (
+        "Error: URL resolves to a restricted/private network address."
+        in outerr.err
+    )
+    mock_get.assert_not_called()
+
+
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -6,6 +6,14 @@ import pytest
 from html2md import cli
 
 
+def addrinfo(*ip_addresses):
+    """Build deterministic getaddrinfo-style results for tests."""
+    return [
+        (None, None, None, None, (ip_address, 0))
+        for ip_address in ip_addresses
+    ]
+
+
 @pytest.mark.parametrize(
     "url, scheme",
     [
@@ -24,20 +32,70 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
 
 
 @pytest.mark.parametrize(
-    "url",
+    "url, resolved_ip",
     [
-        "http://127.0.0.1:8080/admin",
-        "http://localhost/secret",
-        "http://192.168.1.1/config",
-        "http://10.0.0.5/",
+        ("http://127.0.0.1:8080/admin", "127.0.0.1"),
+        ("http://localhost/secret", "::1"),
+        ("http://192.168.1.1/config", "192.168.1.1"),
+        ("http://10.0.0.5/", "10.0.0.5"),
+        ("http://100.64.0.1/", "100.64.0.1"),
     ],
 )
 @patch("requests.Session.get")
-def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url):
-    """Ensure that local, private, and loopback IPs are blocked to prevent SSRF."""
-    cli.main(["--url", url, "--outdir", str(tmp_path)])
+def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, resolved_ip):
+    """Ensure that non-global addresses are blocked to prevent SSRF."""
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=addrinfo(resolved_ip),
+    ):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
     outerr = capsys.readouterr()
-    assert "Error: URL resolves to a restricted/private network address." in outerr.err
+    assert (
+        "Error: URL resolves to a restricted/private network address."
+        in outerr.err
+    )
+    mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_allows_global_ipv6_address(mock_get, capsys, tmp_path):
+    """Public IPv6 addresses are valid URL targets."""
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=addrinfo("2606:4700:4700::1111"),
+    ):
+        cli.main([
+            "--url",
+            "https://[2606:4700:4700::1111]/",
+            "--outdir",
+            str(tmp_path),
+        ])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    assert "restricted/private" not in outerr.err
+    mock_get.assert_called_once()
+
+
+@patch("requests.Session.get")
+def test_process_url_blocks_any_non_global_address(mock_get, capsys, tmp_path):
+    """Every address from getaddrinfo must be globally reachable."""
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=addrinfo("93.184.216.34", "fd00::1"),
+    ):
+        cli.main(["--url", "https://example.com", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert (
+        "Error: URL resolves to a restricted/private network address."
+        in outerr.err
+    )
     mock_get.assert_not_called()
 
 
@@ -60,12 +118,18 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         "http://example.com/foo/%2E%2E%2F%2E%2E%2Fsecret.txt",
     ]
 
-    for url in urls:
-        cli.main(["--url", url, "--outdir", str(outdir)])
-        outerr = capsys.readouterr()
-        assert "Success!" in outerr.out
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=addrinfo("93.184.216.34"),
+    ):
+        for url in urls:
+            cli.main(["--url", url, "--outdir", str(outdir)])
+            outerr = capsys.readouterr()
+            assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
-    assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
+    assert list(outdir.rglob("*.md")), (
+        "No markdown files were created in the output directory."
+    )
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()


### PR DESCRIPTION
### Motivation
- The prior SSRF check used `socket.gethostbyname`, which is IPv4-only and only returns a single address, causing IPv6 targets to be rejected and missing additional A/AAAA answers. 
- The guard must validate all resolved addresses and treat non-global ranges (including CGNAT and other non-global addresses) as blocked, and tests must remain hermetic by mocking DNS.

### Description
- Added `_hostname_resolves_to_global_addresses(hostname: str)` which calls `socket.getaddrinfo` and validates every returned IPv4/IPv6 address with `ipaddress.ip_address(...).is_global` before allowing a fetch. 
- Replaced the old `gethostbyname`-based check with a call to the new helper inside `process_url` so IPv6 literals and AAAA-only hosts are supported. 
- Updated `tests/test_cli_security.py` to provide a deterministic `addrinfo(...)` helper and to patch `socket.getaddrinfo` in tests so they are hermetic, added tests for allowed public IPv6, CGNAT/non-global addresses, and mixed public/private DNS answers. 
- Kept network calls mocked via `@patch("requests.Session.get")` in tests to ensure no real network I/O during conversion-path tests.

### Testing
- Installed the package in editable mode with `python -m pip install -e .` and ran the full test suite with `PYENV_VERSION=3.12.13 pytest -q`. 
- All tests passed (`pytest` completed with no failures) including the expanded `tests/test_cli_security.py` coverage for IPv6 and mixed DNS answers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4a10ee5083208b1575ed7f30d0e2)