### PR TITLE
Bind URL fetches to vetted DNS answers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.8",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,7 @@ import os
 import sys
 import socket
 import ipaddress
+import idna
 from urllib.parse import urljoin, urlparse, unquote
 
 _RESTRICTED_ADDRESS_ERROR = "Error: URL resolves to a restricted/private network address."
@@ -33,7 +34,12 @@ def _is_allowed_public_ip(ip: str) -> bool:
 
 def _normalize_hostname_for_dns_pin(hostname: str) -> str:
     """Normalize hostnames to the IDNA form used by urllib3 before connecting."""
-    return str(hostname).rstrip('.').lower().encode('idna').decode('ascii').lower()
+    normalized = str(hostname).rstrip('.').lower()
+    try:
+        ipaddress.ip_address(normalized)
+    except ValueError:
+        return idna.encode(normalized, strict=True, std3_rules=True).decode('ascii')
+    return normalized
 
 
 def _resolve_vetted_addresses(hostname: str, port: int):
@@ -73,7 +79,8 @@ def _validate_url_target(target_url: str):
         port = parsed.port or (443 if parsed.scheme == 'https' else 80)
     except ValueError as exc:
         raise _UrlValidationError("Error: URL contains an invalid port.") from exc
-    return parsed, _resolve_vetted_addresses(hostname, port)
+    normalized_hostname = _normalize_hostname_for_dns_pin(hostname)
+    return parsed, _resolve_vetted_addresses(normalized_hostname, port)
 
 
 def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, timeout: int):

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -31,6 +31,11 @@ def _is_allowed_public_ip(ip: str) -> bool:
     )
 
 
+def _normalize_hostname_for_dns_pin(hostname: str) -> str:
+    """Normalize hostnames to the IDNA form used by urllib3 before connecting."""
+    return str(hostname).rstrip('.').lower().encode('idna').decode('ascii').lower()
+
+
 def _resolve_vetted_addresses(hostname: str, port: int):
     """Resolve all stream addresses for hostname and reject any non-public result."""
     addrinfos = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
@@ -74,7 +79,7 @@ def _validate_url_target(target_url: str):
 def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, timeout: int):
     """Fetch a URL while forcing socket resolution to reuse vetted DNS answers."""
     original_getaddrinfo = socket.getaddrinfo
-    hostname = parsed.hostname
+    hostname = _normalize_hostname_for_dns_pin(parsed.hostname)
     port = parsed.port or (443 if parsed.scheme == 'https' else 80)
 
     def pinned_getaddrinfo(host, request_port, family=0, type=0, proto=0, flags=0):
@@ -84,7 +89,7 @@ def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, tim
             request_port_matches = False
 
         if (
-            str(host).rstrip('.').lower() == hostname.rstrip('.').lower()
+            _normalize_hostname_for_dns_pin(host) == hostname
             and request_port_matches
         ):
             return [

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,7 +6,125 @@ import os
 import sys
 import socket
 import ipaddress
-from urllib.parse import urlparse, unquote
+from urllib.parse import urljoin, urlparse, unquote
+
+_RESTRICTED_ADDRESS_ERROR = "Error: URL resolves to a restricted/private network address."
+_RESOLUTION_ERROR = "Error: Could not resolve hostname to a valid IP."
+_MAX_REDIRECTS = 10
+
+
+class _UrlValidationError(ValueError):
+    """Raised when a user-supplied URL fails SSRF validation."""
+
+
+def _is_allowed_public_ip(ip: str) -> bool:
+    """Return whether an IP address is safe for user-requested outbound fetches."""
+    ip_obj = ipaddress.ip_address(ip)
+    return (
+        ip_obj.is_global
+        and not ip_obj.is_private
+        and not ip_obj.is_loopback
+        and not ip_obj.is_link_local
+        and not ip_obj.is_multicast
+        and not ip_obj.is_reserved
+        and not ip_obj.is_unspecified
+    )
+
+
+def _resolve_vetted_addresses(hostname: str, port: int):
+    """Resolve all stream addresses for hostname and reject any non-public result."""
+    addrinfos = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    if not addrinfos:
+        raise ValueError("No addresses found")
+
+    vetted = []
+    seen = set()
+    for family, socktype, proto, canonname, sockaddr in addrinfos:
+        ip = sockaddr[0]
+        if not _is_allowed_public_ip(ip):
+            raise ValueError("Restricted address")
+
+        key = (family, socktype, proto, canonname, sockaddr)
+        if key not in seen:
+            seen.add(key)
+            vetted.append((family, socktype, proto, canonname, sockaddr))
+
+    return vetted
+
+
+def _validate_url_target(target_url: str):
+    """Validate a URL and return parsed URL plus DNS answers pinned to public IPs."""
+    parsed = urlparse(target_url)
+    if parsed.scheme not in ('http', 'https'):
+        raise _UrlValidationError(
+            f"Error: Unsupported URL scheme '{parsed.scheme}'. Only http and https are allowed."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise _UrlValidationError("Error: URL must include a hostname.")
+
+    try:
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    except ValueError as exc:
+        raise _UrlValidationError("Error: URL contains an invalid port.") from exc
+    return parsed, _resolve_vetted_addresses(hostname, port)
+
+
+def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, timeout: int):
+    """Fetch a URL while forcing socket resolution to reuse vetted DNS answers."""
+    original_getaddrinfo = socket.getaddrinfo
+    hostname = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+
+    def pinned_getaddrinfo(host, request_port, family=0, type=0, proto=0, flags=0):
+        try:
+            request_port_matches = request_port is None or int(request_port) == port
+        except (TypeError, ValueError):
+            request_port_matches = False
+
+        if (
+            str(host).rstrip('.').lower() == hostname.rstrip('.').lower()
+            and request_port_matches
+        ):
+            return [
+                addrinfo for addrinfo in vetted_addrinfos
+                if (family in (0, addrinfo[0]) and type in (0, addrinfo[1]) and
+                    proto in (0, addrinfo[2]))
+            ]
+        return original_getaddrinfo(host, request_port, family, type, proto, flags)
+
+    socket.getaddrinfo = pinned_getaddrinfo
+    try:
+        return session.get(target_url, timeout=timeout, allow_redirects=False)
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
+
+def _safe_get(session, target_url: str, timeout: int = 30):
+    """Fetch a URL after validating and pinning each redirect hop's DNS answers."""
+    current_url = target_url
+    for _ in range(_MAX_REDIRECTS + 1):
+        try:
+            parsed, vetted_addrinfos = _validate_url_target(current_url)
+        except socket.gaierror as exc:
+            raise _UrlValidationError(_RESOLUTION_ERROR) from exc
+        except _UrlValidationError:
+            raise
+        except ValueError as exc:
+            raise _UrlValidationError(_RESTRICTED_ADDRESS_ERROR) from exc
+
+        response = _get_with_pinned_dns(session, current_url, parsed, vetted_addrinfos, timeout)
+        if getattr(response, 'is_redirect', False) is not True:
+            return response
+
+        location = response.headers.get('Location')
+        if not location:
+            return response
+        current_url = urljoin(current_url, location)
+
+    raise _UrlValidationError("Error: Too many redirects.")
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -68,24 +186,11 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return
 
-            hostname = parsed.hostname
-            if hostname:
-                try:
-                    ip = socket.gethostbyname(hostname)
-                    ip_obj = ipaddress.ip_address(ip)
-                    if (ip_obj.is_private or ip_obj.is_loopback or
-                        ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_reserved):
-                        print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
-                        return
-                except (socket.gaierror, ValueError):
-                    print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-                    return
-
             print(f"Processing URL: {target_url}")
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = _safe_get(session, target_url, timeout=30)
                 response.raise_for_status()
 
                 print("Converting to Markdown...")
@@ -120,6 +225,8 @@ def main(argv=None):
                 else:
                     print(md_content)
 
+            except _UrlValidationError as e:
+                print(str(e), file=sys.stderr)
             except requests.RequestException as e:
                 print(f"Network error: {e}", file=sys.stderr)
             except OSError as e:

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -4,12 +4,18 @@ from unittest.mock import patch, MagicMock
 import sys
 import io
 import os
+import socket
 import requests  # type: ignore[import-untyped]
 
 # Ensure src is in path before importing the local package.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 import html2md.cli  # pylint: disable=wrong-import-position  # type: ignore[import-untyped]
+
+
+def _public_addrinfo(ip="93.184.216.34", port=80):
+    """Build a deterministic public DNS response for CLI tests."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
 
 
 class TestCliError(unittest.TestCase):
@@ -34,10 +40,11 @@ class TestCliError(unittest.TestCase):
 
         with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
             with patch('sys.stderr', captured_stderr):
-                try:
-                    html2md.cli.main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                    try:
+                        html2md.cli.main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
         output = captured_stderr.getvalue()
         self.assertIn("Network error", output)
@@ -63,10 +70,11 @@ class TestCliError(unittest.TestCase):
 
         with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
             with patch('sys.stderr', captured_stderr):
-                try:
-                    html2md.cli.main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                    try:
+                        html2md.cli.main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
         output = captured_stderr.getvalue()
         # The code catches Exception and prints "Conversion failed: {e}"

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -2,8 +2,14 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import io
+import socket
 import requests  # type: ignore[import-untyped]
 from html2md.cli import main
+
+
+def _public_addrinfo(ip="93.184.216.34", port=80):
+    """Build a deterministic public DNS response for CLI tests."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -16,10 +22,11 @@ class TestCliExceptions(unittest.TestCase):
             with patch('requests.Session.get') as mock_get:
                 mock_get.side_effect = requests.RequestException("Network unreachable")
 
-                try:
-                    main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                    try:
+                        main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
                 output = captured_stderr.getvalue()
                 self.assertIn("Network error", output)
@@ -33,15 +40,17 @@ class TestCliExceptions(unittest.TestCase):
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
+                mock_resp.is_redirect = False
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
                         with patch('builtins.open', side_effect=OSError("Permission denied")):
-                            try:
-                                main(['--url', 'http://example.com', '--outdir', 'dummy'])
-                            except (SystemExit, RuntimeError, ValueError) as e:
-                                self.fail(f"main raised exception {e}")
+                            with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                                try:
+                                    main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                                except (SystemExit, RuntimeError, ValueError) as e:
+                                    self.fail(f"main raised exception {e}")
 
                             output = captured_stderr.getvalue()
                             self.assertIn("File error", output)
@@ -55,6 +64,7 @@ class TestCliExceptions(unittest.TestCase):
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
+                mock_resp.is_redirect = False
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
@@ -66,7 +76,8 @@ class TestCliExceptions(unittest.TestCase):
                                 return '/tmp/out'
 
                             with patch('os.path.realpath', side_effect=fake_realpath):
-                                main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
+                                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                                    main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -153,6 +153,46 @@ def test_process_url_pins_idna_normalized_hostname(mock_get, capsys, tmp_path):
 
 
 @patch("requests.Session.get")
+def test_process_url_resolves_idna2008_hostname_for_validation(mock_get, capsys, tmp_path):
+    """Validation resolves the same IDNA 2008 hostname urllib3 uses to connect."""
+    public_addrinfo = _addrinfo("93.184.216.34")
+    rebound_addrinfo = _addrinfo("127.0.0.1")
+    real_getaddrinfo = cli.socket.getaddrinfo
+    resolved_unicode_form = False
+
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):
+        nonlocal resolved_unicode_form
+        if host == "faß.de":
+            resolved_unicode_form = True
+            return [public_addrinfo]
+        if host == "xn--fa-hia.de":
+            return [rebound_addrinfo] if resolved_unicode_form else [public_addrinfo]
+        return real_getaddrinfo(host, port, *args, **kwargs)
+
+    def request_side_effect(url, timeout, allow_redirects):
+        assert url == "http://faß.de/"
+        assert timeout == 30
+        assert allow_redirects is False
+        # urllib3 uses IDNA 2008 for this hostname (xn--fa-hia.de), while the
+        # stdlib idna codec maps it to fass.de. The vetted IDNA 2008 answer
+        # must remain pinned for the actual connection hostname.
+        assert cli.socket.getaddrinfo("xn--fa-hia.de", 80) == [public_addrinfo]
+        response = MagicMock()
+        response.text = "<h1>safe</h1>"
+        response.is_redirect = False
+        response.raise_for_status.return_value = None
+        return response
+
+    mock_get.side_effect = request_side_effect
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=rebinding_getaddrinfo):
+        cli.main(["--url", "http://faß.de/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+
+
+@patch("requests.Session.get")
 def test_process_url_validates_redirect_targets(mock_get, capsys, tmp_path):
     """Redirect locations are revalidated before following them."""
     redirect_response = MagicMock()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -115,6 +115,44 @@ def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_pat
 
 
 @patch("requests.Session.get")
+def test_process_url_pins_idna_normalized_hostname(mock_get, capsys, tmp_path):
+    """DNS pinning matches the IDNA hostname urllib3 resolves for Unicode domains."""
+    public_addrinfo = _addrinfo("93.184.216.34")
+    rebound_addrinfo = _addrinfo("127.0.0.1")
+    real_getaddrinfo = cli.socket.getaddrinfo
+    lookup_count = 0
+
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):
+        nonlocal lookup_count
+        if host in {"éxample.com", "xn--xample-9ua.com"}:
+            lookup_count += 1
+            return [public_addrinfo] if lookup_count == 1 else [rebound_addrinfo]
+        return real_getaddrinfo(host, port, *args, **kwargs)
+
+    def request_side_effect(url, timeout, allow_redirects):
+        assert url == "http://éxample.com/"
+        assert timeout == 30
+        assert allow_redirects is False
+        # urllib3 resolves the IDNA/punycode form during connection setup. The
+        # pinned resolver must still return the public answer vetted for the
+        # original Unicode hostname, not a rebound private address.
+        assert cli.socket.getaddrinfo("xn--xample-9ua.com", 80) == [public_addrinfo]
+        response = MagicMock()
+        response.text = "<h1>safe</h1>"
+        response.is_redirect = False
+        response.raise_for_status.return_value = None
+        return response
+
+    mock_get.side_effect = request_side_effect
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=rebinding_getaddrinfo):
+        cli.main(["--url", "http://éxample.com/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+
+
+@patch("requests.Session.get")
 def test_process_url_validates_redirect_targets(mock_get, capsys, tmp_path):
     """Redirect locations are revalidated before following them."""
     redirect_response = MagicMock()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,9 +1,17 @@
 """Security-focused tests for CLI URL and output path handling."""
 
+import socket
 from unittest.mock import MagicMock, patch
 import pytest
 
 from html2md import cli
+
+
+def _addrinfo(ip, port=80, family=None):
+    """Build a getaddrinfo-style stream tuple for IPv4 or IPv6 tests."""
+    ip_family = family or (socket.AF_INET6 if ":" in ip else socket.AF_INET)
+    sockaddr = (ip, port, 0, 0) if ip_family == socket.AF_INET6 else (ip, port)
+    return (ip_family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
 
 
 @pytest.mark.parametrize(
@@ -24,21 +32,109 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
 
 
 @pytest.mark.parametrize(
-    "url",
+    "url, resolved_ip",
     [
-        "http://127.0.0.1:8080/admin",
-        "http://localhost/secret",
-        "http://192.168.1.1/config",
-        "http://10.0.0.5/",
+        ("http://127.0.0.1:8080/admin", "127.0.0.1"),
+        ("http://localhost/secret", "127.0.0.1"),
+        ("http://192.168.1.1/config", "192.168.1.1"),
+        ("http://10.0.0.5/", "10.0.0.5"),
+        ("http://[::1]/", "::1"),
+        ("http://100.64.0.1/", "100.64.0.1"),
+        ("http://0.0.0.0/", "0.0.0.0"),
     ],
 )
 @patch("requests.Session.get")
-def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url):
-    """Ensure that local, private, and loopback IPs are blocked to prevent SSRF."""
-    cli.main(["--url", url, "--outdir", str(tmp_path)])
+def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, resolved_ip):
+    """Ensure that non-global, private, and loopback IPs are blocked to prevent SSRF."""
+    with patch("html2md.cli.socket.getaddrinfo", return_value=[_addrinfo(resolved_ip)]):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
+
     outerr = capsys.readouterr()
     assert "Error: URL resolves to a restricted/private network address." in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_allows_public_ipv6(mock_get, capsys, tmp_path):
+    """Public IPv6 literal URLs remain fetchable after SSRF validation."""
+    response = MagicMock()
+    response.text = "<h1>IPv6</h1>"
+    response.is_redirect = False
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=[_addrinfo("2606:4700:4700::1111", port=443)],
+    ):
+        cli.main(["--url", "https://[2606:4700:4700::1111]/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    assert "restricted/private" not in outerr.err
+    mock_get.assert_called_once_with(
+        "https://[2606:4700:4700::1111]/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("requests.Session.get")
+def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_path):
+    """The request uses vetted addresses instead of re-resolving a rebound hostname."""
+    public_addrinfo = _addrinfo("93.184.216.34")
+    rebound_addrinfo = _addrinfo("127.0.0.1")
+    real_getaddrinfo = cli.socket.getaddrinfo
+    lookup_count = 0
+
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):
+        nonlocal lookup_count
+        if host == "rebind.example":
+            lookup_count += 1
+            return [public_addrinfo] if lookup_count == 1 else [rebound_addrinfo]
+        return real_getaddrinfo(host, port, *args, **kwargs)
+
+    def request_side_effect(url, timeout, allow_redirects):
+        assert url == "http://rebind.example/"
+        assert timeout == 30
+        assert allow_redirects is False
+        # If DNS pinning is not active here, the resolver would now return the
+        # private rebound address. The active request must still see the vetted IP.
+        assert cli.socket.getaddrinfo("rebind.example", 80) == [public_addrinfo]
+        response = MagicMock()
+        response.text = "<h1>safe</h1>"
+        response.is_redirect = False
+        response.raise_for_status.return_value = None
+        return response
+
+    mock_get.side_effect = request_side_effect
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=rebinding_getaddrinfo):
+        cli.main(["--url", "http://rebind.example/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+
+
+@patch("requests.Session.get")
+def test_process_url_validates_redirect_targets(mock_get, capsys, tmp_path):
+    """Redirect locations are revalidated before following them."""
+    redirect_response = MagicMock()
+    redirect_response.is_redirect = True
+    redirect_response.headers = {"Location": "http://127.0.0.1/admin"}
+    mock_get.return_value = redirect_response
+
+    def resolver(host, port, *args, **kwargs):
+        if host == "public.example":
+            return [_addrinfo("93.184.216.34", port=port)]
+        if host == "127.0.0.1":
+            return [_addrinfo("127.0.0.1", port=port)]
+        raise socket.gaierror(host)
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=resolver):
+        cli.main(["--url", "http://public.example/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: URL resolves to a restricted/private network address." in outerr.err
+    mock_get.assert_called_once_with("http://public.example/", timeout=30, allow_redirects=False)
 
 
 @patch("requests.Session.get")
@@ -52,6 +148,7 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
 
     response = MagicMock()
     response.text = "<h1>dummy</h1>"
+    response.is_redirect = False
     response.raise_for_status.return_value = None
     mock_get.return_value = response
 
@@ -60,10 +157,11 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         "http://example.com/foo/%2E%2E%2F%2E%2E%2Fsecret.txt",
     ]
 
-    for url in urls:
-        cli.main(["--url", url, "--outdir", str(outdir)])
-        outerr = capsys.readouterr()
-        assert "Success!" in outerr.out
+    with patch("html2md.cli.socket.getaddrinfo", return_value=[_addrinfo("93.184.216.34")]):
+        for url in urls:
+            cli.main(["--url", url, "--outdir", str(outdir)])
+            outerr = capsys.readouterr()
+            assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
     assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."


### PR DESCRIPTION
### Motivation
- Close a DNS rebinding/TOCTOU gap where the code validated one DNS answer but `requests` could later connect to a different (private) address. 
- Restore support for IPv6 and multi-record hostnames by validating all resolved addresses instead of a single IPv4 lookup. 
- Ensure redirect targets are revalidated before following them so a public URL cannot redirect to an internal address.

### Description
- Replace the IPv4-only `gethostbyname()` check with `socket.getaddrinfo()` and validate every returned IPv4/IPv6 stream address using a centralized `_is_allowed_public_ip` predicate that requires global/public addresses. 
- Add `_safe_get` and `_get_with_pinned_dns` helpers that disable automatic redirects and temporarily pin `socket.getaddrinfo` to vetted answers while performing `session.get`, so the connection uses only validated addresses. 
- Rework `process_url` to use the safe fetch path and raise a clear URL-validation error type for SSRF-related failures. 
- Update and extend tests to mock DNS resolution (`socket.getaddrinfo`) deterministically, add IPv6/public/CGNAT/unspecified/rebinding/redirect-target cases, and make existing error-path tests hermetic.

### Testing
- Ran unit tests with `python -m pytest -q` and the security-focused tests in `tests/test_cli_security.py`, which passed. 
- Verified the module compiles with `python -m py_compile src/html2md/cli.py` with no syntax errors. 
- All automated test runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4a0a2cac83208b49a1363b06525c)