### PR TITLE
Harden SSRF redirect validation

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,7 +6,123 @@ import os
 import sys
 import socket
 import ipaddress
-from urllib.parse import urlparse, unquote
+from urllib.parse import urlparse, unquote, urljoin
+
+MAX_REDIRECTS = 30
+RESTRICTED_NETWORK_ERROR = "Error: URL resolves to a restricted/private network address."
+REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+def _is_restricted_ip(ip: str) -> bool:
+    """Return whether an IP address is unsafe for user-requested fetches."""
+    ip_obj = ipaddress.ip_address(ip)
+    return (
+        not ip_obj.is_global
+        or ip_obj.is_private
+        or ip_obj.is_loopback
+        or ip_obj.is_link_local
+        or ip_obj.is_multicast
+        or ip_obj.is_reserved
+        or ip_obj.is_unspecified
+    )
+
+
+def _validate_fetch_url(target_url: str) -> None:
+    """Validate that a URL is safe to fetch over the network.
+
+    Raises:
+        ValueError: If the URL scheme or resolved addresses are unsafe.
+        socket.gaierror: If the hostname cannot be resolved.
+    """
+    parsed = urlparse(target_url)
+    if parsed.scheme not in ('http', 'https'):
+        raise ValueError(
+            f"Unsupported URL scheme '{parsed.scheme}'. Only http and https are allowed."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL is missing a hostname.")
+
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    resolved_addresses = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    if not resolved_addresses:
+        raise socket.gaierror("No addresses found")
+
+    checked_ips = set()
+    for result in resolved_addresses:
+        ip = result[4][0]
+        if ip in checked_ips:
+            continue
+        checked_ips.add(ip)
+        if _is_restricted_ip(ip):
+            raise PermissionError(RESTRICTED_NETWORK_ERROR)
+
+
+def _validated_create_connection(
+    address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None, socket_options=None
+):
+    """Create a socket using only freshly validated public address candidates."""
+    host, port = address
+    resolved_addresses = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    if not resolved_addresses:
+        raise socket.gaierror("No addresses found")
+
+    for result in resolved_addresses:
+        ip = result[4][0]
+        if _is_restricted_ip(ip):
+            raise PermissionError(RESTRICTED_NETWORK_ERROR)
+
+    err = None
+    for result in resolved_addresses:
+        family, socktype, proto, _canonname, sockaddr = result
+        sock = None
+        try:
+            sock = socket.socket(family, socktype, proto)
+            if socket_options:
+                for opt in socket_options:
+                    sock.setsockopt(*opt)
+            if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sockaddr)
+            return sock
+        except OSError as exc:
+            err = exc
+            if sock is not None:
+                sock.close()
+
+    if err is not None:
+        raise err
+    raise socket.gaierror("No addresses found")
+
+
+def _fetch_with_validated_redirects(
+    session, target_url: str, connection_module, timeout: int = 30
+):
+    """Fetch a URL, validating every redirect target before following it."""
+    current_url = target_url
+    for _ in range(MAX_REDIRECTS + 1):
+        _validate_fetch_url(current_url)
+        original_create_connection = connection_module.create_connection
+        connection_module.create_connection = _validated_create_connection
+        try:
+            response = session.get(current_url, timeout=timeout, allow_redirects=False)
+        finally:
+            connection_module.create_connection = original_create_connection
+
+        if response.status_code not in REDIRECT_STATUSES:
+            return response
+
+        location = response.headers.get('Location')
+        response.close()
+        if not location:
+            return response
+        current_url = urljoin(current_url, location)
+
+    raise RuntimeError("Too many redirects while fetching URL.")
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -33,6 +149,8 @@ def main(argv=None):
             print(f"Error: Missing dependency {e.name}."
                   "Please run: pip install requests markdownify", file=sys.stderr)
             return 1
+
+        import urllib3.util.connection as urllib3_connection  # type: ignore
 
         session = requests.Session()
         session.headers.update({
@@ -62,30 +180,25 @@ def main(argv=None):
             if '/?' in target_url:
                 target_url = target_url.replace('/?', '?')
 
-            parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
+            try:
+                _validate_fetch_url(target_url)
+            except PermissionError as e:
+                print(str(e), file=sys.stderr)
                 return
-
-            hostname = parsed.hostname
-            if hostname:
-                try:
-                    ip = socket.gethostbyname(hostname)
-                    ip_obj = ipaddress.ip_address(ip)
-                    if (ip_obj.is_private or ip_obj.is_loopback or
-                        ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_reserved):
-                        print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
-                        return
-                except (socket.gaierror, ValueError):
-                    print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-                    return
+            except ValueError as e:
+                print(f"Error: {e}", file=sys.stderr)
+                return
+            except socket.gaierror:
+                print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
+                return
 
             print(f"Processing URL: {target_url}")
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = _fetch_with_validated_redirects(
+                    session, target_url, urllib3_connection, timeout=30
+                )
                 response.raise_for_status()
 
                 print("Converting to Markdown...")
@@ -120,6 +233,12 @@ def main(argv=None):
                 else:
                     print(md_content)
 
+            except PermissionError as e:
+                print(str(e), file=sys.stderr)
+            except ValueError as e:
+                print(f"Error: {e}", file=sys.stderr)
+            except socket.gaierror:
+                print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
             except requests.RequestException as e:
                 print(f"Network error: {e}", file=sys.stderr)
             except OSError as e:

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -27,6 +27,11 @@ def _is_restricted_ip(ip: str) -> bool:
     )
 
 
+def _has_unsafe_url_characters(target_url: str) -> bool:
+    """Return whether a URL contains characters that parsers disagree on."""
+    return any(char == '\\' or ord(char) < 32 or ord(char) == 127 for char in target_url)
+
+
 def _validate_fetch_url(target_url: str) -> None:
     """Validate that a URL is safe to fetch over the network.
 
@@ -35,6 +40,9 @@ def _validate_fetch_url(target_url: str) -> None:
         PermissionError: If any resolved address is restricted/private.
         socket.gaierror: If the hostname cannot be resolved.
     """
+    if _has_unsafe_url_characters(target_url):
+        raise ValueError("URL contains unsafe characters.")
+
     parsed = urlparse(target_url)
     if parsed.scheme not in ('http', 'https'):
         raise ValueError(

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -32,6 +32,7 @@ def _validate_fetch_url(target_url: str) -> None:
 
     Raises:
         ValueError: If the URL scheme or resolved addresses are unsafe.
+        PermissionError: If any resolved address is restricted/private.
         socket.gaierror: If the hostname cannot be resolved.
     """
     parsed = urlparse(target_url)
@@ -102,6 +103,9 @@ def _fetch_with_validated_redirects(
     session, target_url: str, connection_module, timeout: int = 30
 ):
     """Fetch a URL, validating every redirect target before following it."""
+    # Environment proxies resolve the target outside our validated DNS path,
+    # so force these guarded fetches to connect directly.
+    session.trust_env = False
     current_url = target_url
     for _ in range(MAX_REDIRECTS + 1):
         _validate_fetch_url(current_url)
@@ -116,9 +120,9 @@ def _fetch_with_validated_redirects(
             return response
 
         location = response.headers.get('Location')
-        response.close()
         if not location:
             return response
+        response.close()
         current_url = urljoin(current_url, location)
 
     raise RuntimeError("Too many redirects while fetching URL.")

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -99,6 +99,13 @@ def _validated_create_connection(
     raise socket.gaierror("No addresses found")
 
 
+def _get_connection_patch_target(connection_module):
+    """Return the object whose create_connection urllib3 calls for new sockets."""
+    if hasattr(connection_module, 'create_connection'):
+        return connection_module
+    return connection_module.connection
+
+
 def _fetch_with_validated_redirects(
     session, target_url: str, connection_module, timeout: int = 30
 ):
@@ -109,12 +116,13 @@ def _fetch_with_validated_redirects(
     current_url = target_url
     for _ in range(MAX_REDIRECTS + 1):
         _validate_fetch_url(current_url)
-        original_create_connection = connection_module.create_connection
-        connection_module.create_connection = _validated_create_connection
+        patch_target = _get_connection_patch_target(connection_module)
+        original_create_connection = patch_target.create_connection
+        patch_target.create_connection = _validated_create_connection
         try:
             response = session.get(current_url, timeout=timeout, allow_redirects=False)
         finally:
-            connection_module.create_connection = original_create_connection
+            patch_target.create_connection = original_create_connection
 
         if response.status_code not in REDIRECT_STATUSES:
             return response
@@ -154,7 +162,7 @@ def main(argv=None):
                   "Please run: pip install requests markdownify", file=sys.stderr)
             return 1
 
-        import urllib3.util.connection as urllib3_connection  # type: ignore
+        import urllib3.connection as urllib3_connection  # type: ignore
 
         session = requests.Session()
         session.headers.update({

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -1,15 +1,29 @@
 """Tests for html2md CLI error-handling paths."""
-import unittest
-from unittest.mock import patch, MagicMock
-import sys
 import io
 import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
 import requests  # type: ignore[import-untyped]
 
 # Ensure src is in path before importing the local package.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 import html2md.cli  # pylint: disable=wrong-import-position  # type: ignore[import-untyped]
+
+
+def public_addrinfo():
+    """Build a deterministic public getaddrinfo response for tests."""
+    return [
+        (
+            html2md.cli.socket.AF_INET,
+            html2md.cli.socket.SOCK_STREAM,
+            6,
+            '',
+            ('93.184.216.34', 80),
+        )
+    ]
 
 
 class TestCliError(unittest.TestCase):
@@ -33,11 +47,12 @@ class TestCliError(unittest.TestCase):
         captured_stderr = io.StringIO()
 
         with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
-            with patch('sys.stderr', captured_stderr):
-                try:
-                    html2md.cli.main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+            with patch('html2md.cli.socket.getaddrinfo', return_value=public_addrinfo()):
+                with patch('sys.stderr', captured_stderr):
+                    try:
+                        html2md.cli.main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
         output = captured_stderr.getvalue()
         self.assertIn("Network error", output)
@@ -62,16 +77,18 @@ class TestCliError(unittest.TestCase):
         captured_stderr = io.StringIO()
 
         with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
-            with patch('sys.stderr', captured_stderr):
-                try:
-                    html2md.cli.main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+            with patch('html2md.cli.socket.getaddrinfo', return_value=public_addrinfo()):
+                with patch('sys.stderr', captured_stderr):
+                    try:
+                        html2md.cli.main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
         output = captured_stderr.getvalue()
         # The code catches Exception and prints "Conversion failed: {e}"
         self.assertIn("Conversion failed", output)
         self.assertIn("Parse error", output)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -1,9 +1,17 @@
 """Tests for html2md CLI exception-handling paths."""
-import unittest
-from unittest.mock import patch, MagicMock
 import io
+import unittest
+from unittest.mock import MagicMock, patch
+
 import requests  # type: ignore[import-untyped]
+
+from html2md import cli
 from html2md.cli import main
+
+
+def public_addrinfo():
+    """Build a deterministic public getaddrinfo response for tests."""
+    return [(cli.socket.AF_INET, cli.socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))]
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -13,61 +21,64 @@ class TestCliExceptions(unittest.TestCase):
         """Test that network errors are caught and printed."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
-                mock_get.side_effect = requests.RequestException("Network unreachable")
+            with patch('html2md.cli.socket.getaddrinfo', return_value=public_addrinfo()):
+                with patch('requests.Session.get') as mock_get:
+                    mock_get.side_effect = requests.RequestException("Network unreachable")
 
-                try:
-                    main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                    try:
+                        main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
-                output = captured_stderr.getvalue()
-                self.assertIn("Network error", output)
-                self.assertIn("Network unreachable", output)
+                    output = captured_stderr.getvalue()
+                    self.assertIn("Network error", output)
+                    self.assertIn("Network unreachable", output)
 
     def test_file_error(self):
         """Test that file I/O errors are caught and printed."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+            with patch('html2md.cli.socket.getaddrinfo', return_value=public_addrinfo()):
+                with patch('requests.Session.get') as mock_get:
+                    mock_resp = MagicMock()
+                    mock_resp.text = "<h1>Hello</h1>"
+                    mock_resp.status_code = 200
+                    mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
-                    with patch('os.makedirs'), patch('os.path.exists', return_value=False):
-                        with patch('builtins.open', side_effect=OSError("Permission denied")):
-                            try:
-                                main(['--url', 'http://example.com', '--outdir', 'dummy'])
-                            except (SystemExit, RuntimeError, ValueError) as e:
-                                self.fail(f"main raised exception {e}")
+                    with patch('markdownify.markdownify', return_value="# Hello"):
+                        with patch('os.makedirs'), patch('os.path.exists', return_value=False):
+                            with patch('builtins.open', side_effect=OSError("Permission denied")):
+                                try:
+                                    main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                                except (SystemExit, RuntimeError, ValueError) as e:
+                                    self.fail(f"main raised exception {e}")
 
-                            output = captured_stderr.getvalue()
-                            self.assertIn("File error", output)
-                            self.assertIn("Permission denied", output)
+                                output = captured_stderr.getvalue()
+                                self.assertIn("File error", output)
+                                self.assertIn("Permission denied", output)
 
     def test_outdir_containment_uses_path_aware_check(self):
         """Test that output containment check rejects prefix-matching escapes."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.text = "<h1>Hello</h1>"
-                mock_resp.status_code = 200
-                mock_get.return_value = mock_resp
+            with patch('html2md.cli.socket.getaddrinfo', return_value=public_addrinfo()):
+                with patch('requests.Session.get') as mock_get:
+                    mock_resp = MagicMock()
+                    mock_resp.text = "<h1>Hello</h1>"
+                    mock_resp.status_code = 200
+                    mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
-                    with patch('os.path.exists', return_value=True):
-                        with patch('html2md.cli.open', create=True) as mock_open:
-                            def fake_realpath(path):
-                                if str(path).endswith('.md'):
-                                    return '/tmp/outside/a.md'
-                                return '/tmp/out'
+                    with patch('markdownify.markdownify', return_value="# Hello"):
+                        with patch('os.path.exists', return_value=True):
+                            with patch('html2md.cli.open', create=True) as mock_open:
+                                def fake_realpath(path):
+                                    if str(path).endswith('.md'):
+                                        return '/tmp/outside/a.md'
+                                    return '/tmp/out'
 
-                            with patch('os.path.realpath', side_effect=fake_realpath):
-                                main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
+                                with patch('os.path.realpath', side_effect=fake_realpath):
+                                    main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
 
-                            output = captured_stderr.getvalue()
-                            self.assertIn("Output path escapes output directory", output)
-                            mock_open.assert_not_called()
+                                output = captured_stderr.getvalue()
+                                self.assertIn("Output path escapes output directory", output)
+                                mock_open.assert_not_called()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,6 +1,9 @@
 """Security-focused tests for CLI URL and output path handling."""
 
+import sys
+import types
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 from html2md import cli
@@ -93,6 +96,44 @@ def test_process_url_blocks_redirect_to_private_address(mock_get, capsys, tmp_pa
     mock_get.assert_called_once_with(
         "http://public.example/start", timeout=30, allow_redirects=False
     )
+
+
+def test_process_url_uses_requests_connection_module_for_rebinding_guard(capsys):
+    """The CLI patches the create_connection symbol requests/urllib3 calls."""
+    fake_requests = types.ModuleType("requests")
+    fake_requests.RequestException = RuntimeError
+    fake_requests.Session = MagicMock(return_value=MagicMock())
+    fake_markdownify = types.ModuleType("markdownify")
+    fake_markdownify.markdownify = MagicMock(return_value="guarded")
+    fake_urllib3 = types.ModuleType("urllib3")
+    fake_connection = types.ModuleType("urllib3.connection")
+    fake_connection.create_connection = MagicMock()
+    fake_urllib3.connection = fake_connection
+
+    response = MagicMock()
+    response.text = "<h1>guarded</h1>"
+    response.raise_for_status.return_value = None
+    captured = {}
+
+    def fake_fetch(session, target_url, connection_module, timeout=30):
+        captured["connection_module"] = connection_module
+        return response
+
+    modules = {
+        "requests": fake_requests,
+        "markdownify": fake_markdownify,
+        "urllib3": fake_urllib3,
+        "urllib3.connection": fake_connection,
+    }
+    with patch.dict(sys.modules, modules):
+        with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo("93.184.216.34")):
+            with patch("html2md.cli._fetch_with_validated_redirects", side_effect=fake_fetch):
+                cli.main(["--url", "http://public.example/start"])
+
+    outerr = capsys.readouterr()
+    assert "guarded" in outerr.out
+    assert outerr.err == ""
+    assert captured["connection_module"] is fake_connection
 
 
 def test_validated_fetch_disables_environment_proxy_settings():

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -98,6 +98,45 @@ def test_process_url_blocks_redirect_to_private_address(mock_get, capsys, tmp_pa
     )
 
 
+@patch("requests.Session.get")
+def test_process_url_blocks_redirect_with_backslash_authority_confusion(
+    mock_get, capsys, tmp_path
+):
+    """Redirect locations with backslashes are rejected before refetching."""
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {"Location": "http://127.0.0.1\\@public.example/"}
+    mock_get.return_value = redirect_response
+
+    with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo("93.184.216.34")):
+        cli.main(["--url", "http://public.example/start", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: URL contains unsafe characters." in outerr.err
+    mock_get.assert_called_once_with(
+        "http://public.example/start", timeout=30, allow_redirects=False
+    )
+    redirect_response.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "target_url",
+    [
+        "http://public.example\\@127.0.0.1/",
+        "http://public.example/has\\backslash",
+        "http://public.example/has\ttab",
+        "http://public.example/has\x7fdelete",
+    ],
+)
+def test_validate_fetch_url_rejects_parser_ambiguous_characters(target_url):
+    """Unsafe raw URL characters are rejected before DNS resolution."""
+    with patch("html2md.cli.socket.getaddrinfo") as mock_getaddrinfo:
+        with pytest.raises(ValueError, match="URL contains unsafe characters"):
+            cli._validate_fetch_url(target_url)
+
+    mock_getaddrinfo.assert_not_called()
+
+
 def test_process_url_uses_requests_connection_module_for_rebinding_guard(capsys):
     """The CLI patches the create_connection symbol requests/urllib3 calls."""
     fake_requests = types.ModuleType("requests")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -95,6 +95,45 @@ def test_process_url_blocks_redirect_to_private_address(mock_get, capsys, tmp_pa
     )
 
 
+def test_validated_fetch_disables_environment_proxy_settings():
+    """Validated fetches must not use HTTP_PROXY/HTTPS_PROXY from the environment."""
+    session = MagicMock()
+    session.trust_env = True
+    response = MagicMock()
+    response.status_code = 200
+    session.get.return_value = response
+    connection_module = MagicMock()
+
+    with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo("93.184.216.34")):
+        result = cli._fetch_with_validated_redirects(
+            session, "http://public.example/start", connection_module
+        )
+
+    assert result is response
+    assert session.trust_env is False
+    session.get.assert_called_once_with(
+        "http://public.example/start", timeout=30, allow_redirects=False
+    )
+
+
+def test_validated_fetch_returns_open_redirect_response_without_location():
+    """Redirect responses without Location are returned open for caller handling."""
+    session = MagicMock()
+    response = MagicMock()
+    response.status_code = 302
+    response.headers = {}
+    session.get.return_value = response
+    connection_module = MagicMock()
+
+    with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo("93.184.216.34")):
+        result = cli._fetch_with_validated_redirects(
+            session, "http://public.example/start", connection_module
+        )
+
+    assert result is response
+    response.close.assert_not_called()
+
+
 def test_validated_create_connection_rejects_mixed_private_candidates():
     """The connection resolver refuses hostnames with any restricted candidate."""
     mixed_addresses = addrinfo("93.184.216.34") + addrinfo("127.0.0.1")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -6,6 +6,13 @@ import pytest
 from html2md import cli
 
 
+def addrinfo(ip, port=80):
+    """Build a socket.getaddrinfo-style result for tests."""
+    family = cli.socket.AF_INET6 if ":" in ip else cli.socket.AF_INET
+    sockaddr = (ip, port, 0, 0) if family == cli.socket.AF_INET6 else (ip, port)
+    return [(family, cli.socket.SOCK_STREAM, 6, "", sockaddr)]
+
+
 @pytest.mark.parametrize(
     "url, scheme",
     [
@@ -24,21 +31,79 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
 
 
 @pytest.mark.parametrize(
-    "url",
+    "url, resolved_ip",
     [
-        "http://127.0.0.1:8080/admin",
-        "http://localhost/secret",
-        "http://192.168.1.1/config",
-        "http://10.0.0.5/",
+        ("http://127.0.0.1:8080/admin", "127.0.0.1"),
+        ("http://localhost/secret", "127.0.0.1"),
+        ("http://192.168.1.1/config", "192.168.1.1"),
+        ("http://10.0.0.5/", "10.0.0.5"),
+        ("http://100.64.0.1/", "100.64.0.1"),
     ],
 )
 @patch("requests.Session.get")
-def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url):
-    """Ensure that local, private, and loopback IPs are blocked to prevent SSRF."""
-    cli.main(["--url", url, "--outdir", str(tmp_path)])
+def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, resolved_ip):
+    """Ensure that non-global IPs are blocked to prevent SSRF."""
+    with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo(resolved_ip)):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
     outerr = capsys.readouterr()
     assert "Error: URL resolves to a restricted/private network address." in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_allows_public_ipv6(mock_get, capsys, tmp_path):
+    """Public IPv6 targets remain supported by the SSRF guard."""
+    response = MagicMock()
+    response.status_code = 200
+    response.text = "<h1>ipv6</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo("2606:4700:4700::1111")):
+        cli.main(["--url", "https://[2606:4700:4700::1111]/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    assert outerr.err == ""
+    mock_get.assert_called_once_with(
+        "https://[2606:4700:4700::1111]/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("requests.Session.get")
+def test_process_url_blocks_redirect_to_private_address(mock_get, capsys, tmp_path):
+    """Redirect targets are validated before the CLI follows them."""
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {"Location": "http://127.0.0.1:8080/admin"}
+    mock_get.return_value = redirect_response
+
+    def resolve_by_host(hostname, port, *args, **kwargs):
+        if hostname == "public.example":
+            return addrinfo("93.184.216.34", port)
+        if hostname == "127.0.0.1":
+            return addrinfo("127.0.0.1", port)
+        raise AssertionError(f"Unexpected hostname: {hostname}")
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=resolve_by_host):
+        cli.main(["--url", "http://public.example/start", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: URL resolves to a restricted/private network address." in outerr.err
+    mock_get.assert_called_once_with(
+        "http://public.example/start", timeout=30, allow_redirects=False
+    )
+
+
+def test_validated_create_connection_rejects_mixed_private_candidates():
+    """The connection resolver refuses hostnames with any restricted candidate."""
+    mixed_addresses = addrinfo("93.184.216.34") + addrinfo("127.0.0.1")
+    with patch("html2md.cli.socket.getaddrinfo", return_value=mixed_addresses):
+        with patch("html2md.cli.socket.socket") as mock_socket:
+            with pytest.raises(PermissionError):
+                cli._validated_create_connection(("mixed.example", 80))
+
+    mock_socket.assert_not_called()
 
 
 @patch("requests.Session.get")
@@ -61,7 +126,8 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     ]
 
     for url in urls:
-        cli.main(["--url", url, "--outdir", str(outdir)])
+        with patch("html2md.cli.socket.getaddrinfo", return_value=addrinfo("93.184.216.34")):
+            cli.main(["--url", url, "--outdir", str(outdir)])
         outerr = capsys.readouterr()
         assert "Success!" in outerr.out
 


### PR DESCRIPTION
### Motivation
- Prevent SSRF bypasses via redirects and DNS rebinding by validating every connection target before connecting. 
- Support IPv6 and multi-record hostnames rather than relying on a single IPv4-only lookup.
- Make unit tests hermetic by mocking DNS resolution so CI/dev environments don't perform real lookups.

### Description
- Add IP classification helpers and validation using `socket.getaddrinfo` and `ipaddress` in `_validate_fetch_url` and `_is_restricted_ip` to reject non-global/private/unspecified addresses. (`src/html2md/cli.py`)
- Replace single `session.get` call with `_fetch_with_validated_redirects` that disables automatic redirects, revalidates each `Location`, and follows redirects only after validating the next target; this uses a temporary hook into `urllib3.util.connection.create_connection` via `_validated_create_connection` to ensure the actual socket connects only to vetted addresses. (`src/html2md/cli.py`)
- Update `process_url` to use the new validation/fetch functions and to surface the same human-friendly error message for restricted targets. (`src/html2md/cli.py`)
- Update and expand tests to mock `socket.getaddrinfo` deterministically, restore IPv6 support, and add cases for redirect-to-private, shared non-global address (100.64.0.0/10), mixed candidate lists, and public IPv6 acceptance; also update existing exception/error tests to mock DNS so they remain hermetic. (`tests/test_cli_security.py`, `tests/test_cli_error.py`, `tests/test_cli_exceptions.py`)

### Testing
- Ran the full test suite with `PYENV_VERSION=3.12.13 pytest -q` and all tests passed. 
- Ran targeted test runs (`pytest tests/test_cli_error.py tests/test_cli_exceptions.py tests/test_cli_security.py`) under the same environment and they passed. 
- Performed automated checks (`git diff --check` equivalent) with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49fe21b883208203ce857e39c9fe)