### PR TITLE
Harden SSRF validation across redirects

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -161,6 +161,10 @@ def main(argv=None):
             return 1
 
         session = requests.Session()
+        # Do not trust HTTP_PROXY/HTTPS_PROXY/ALL_PROXY from the environment for
+        # security-sensitive URL fetches; targets must resolve through the
+        # validated and pinned DNS path in this process.
+        session.trust_env = False
         session.headers.update({
             'User-Agent': (
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,7 +6,78 @@ import os
 import sys
 import socket
 import ipaddress
-from urllib.parse import urlparse, unquote
+from urllib.parse import urljoin, urlparse, unquote
+
+REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+MAX_REDIRECTS = 10
+
+
+def _validate_url_target(target_url: str) -> bool:
+    """Return True when a URL has an allowed scheme and resolves globally."""
+    parsed = urlparse(target_url)
+    if parsed.scheme not in ('http', 'https'):
+        print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
+              "Only http and https are allowed.", file=sys.stderr)
+        return False
+
+    hostname = parsed.hostname
+    if not hostname:
+        print("Error: URL must include a hostname.", file=sys.stderr)
+        return False
+
+    try:
+        addrinfo = socket.getaddrinfo(hostname, parsed.port, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
+        return False
+
+    if not addrinfo:
+        print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
+        return False
+
+    for result in addrinfo:
+        ip = result[4][0]
+        if '%' in ip:
+            ip = ip.split('%', 1)[0]
+        try:
+            ip_obj = ipaddress.ip_address(ip)
+        except ValueError:
+            print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
+            return False
+        if not ip_obj.is_global:
+            print(
+                "Error: URL resolves to a restricted/private network address.",
+                file=sys.stderr,
+            )
+            return False
+
+    return True
+
+
+def _get_with_validated_redirects(
+    session, target_url: str, timeout: int, first_url_validated=False
+):
+    """Fetch a URL while validating every redirect target before following it."""
+    current_url = target_url
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        if not (first_url_validated and redirect_count == 0):
+            if not _validate_url_target(current_url):
+                return None
+
+        response = session.get(current_url, timeout=timeout, allow_redirects=False)
+        status_code = getattr(response, 'status_code', None)
+        if status_code not in REDIRECT_STATUSES:
+            return response
+
+        location = response.headers.get('Location')
+        if not location:
+            return response
+
+        current_url = urljoin(current_url, location)
+
+    print("Error: Too many redirects.", file=sys.stderr)
+    return None
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -62,30 +133,18 @@ def main(argv=None):
             if '/?' in target_url:
                 target_url = target_url.replace('/?', '?')
 
-            parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
+            if not _validate_url_target(target_url):
                 return
-
-            hostname = parsed.hostname
-            if hostname:
-                try:
-                    ip = socket.gethostbyname(hostname)
-                    ip_obj = ipaddress.ip_address(ip)
-                    if (ip_obj.is_private or ip_obj.is_loopback or
-                        ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_reserved):
-                        print("Error: URL resolves to a restricted/private network address.", file=sys.stderr)
-                        return
-                except (socket.gaierror, ValueError):
-                    print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-                    return
 
             print(f"Processing URL: {target_url}")
 
             try:
                 print("Fetching content...")
-                response = session.get(target_url, timeout=30)
+                response = _get_with_validated_redirects(
+                    session, target_url, timeout=30, first_url_validated=True
+                )
+                if response is None:
+                    return
                 response.raise_for_status()
 
                 print("Converting to Markdown...")

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,34 +6,44 @@ import os
 import sys
 import socket
 import ipaddress
+from contextlib import contextmanager
 from urllib.parse import urljoin, urlparse, unquote
 
 REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 MAX_REDIRECTS = 10
 
 
-def _validate_url_target(target_url: str) -> bool:
-    """Return True when a URL has an allowed scheme and resolves globally."""
+def _port_for_url(parsed) -> int:
+    """Return the explicit or scheme-default port for a parsed URL."""
+    if parsed.port is not None:
+        return parsed.port
+    return 443 if parsed.scheme == 'https' else 80
+
+
+def _validated_addrinfo_for_url(target_url: str):
+    """Return validated address info for an allowed URL, or None if blocked."""
     parsed = urlparse(target_url)
     if parsed.scheme not in ('http', 'https'):
         print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
               "Only http and https are allowed.", file=sys.stderr)
-        return False
+        return None
 
     hostname = parsed.hostname
     if not hostname:
         print("Error: URL must include a hostname.", file=sys.stderr)
-        return False
+        return None
 
     try:
-        addrinfo = socket.getaddrinfo(hostname, parsed.port, type=socket.SOCK_STREAM)
+        addrinfo = socket.getaddrinfo(
+            hostname, _port_for_url(parsed), type=socket.SOCK_STREAM
+        )
     except socket.gaierror:
         print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-        return False
+        return None
 
     if not addrinfo:
         print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-        return False
+        return None
 
     for result in addrinfo:
         ip = result[4][0]
@@ -43,28 +53,72 @@ def _validate_url_target(target_url: str) -> bool:
             ip_obj = ipaddress.ip_address(ip)
         except ValueError:
             print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
-            return False
+            return None
         if not ip_obj.is_global:
             print(
                 "Error: URL resolves to a restricted/private network address.",
                 file=sys.stderr,
             )
-            return False
+            return None
 
-    return True
+    return addrinfo
+
+
+def _validate_url_target(target_url: str) -> bool:
+    """Return True when a URL has an allowed scheme and resolves globally."""
+    return _validated_addrinfo_for_url(target_url) is not None
+
+
+def _addrinfo_with_port(addrinfo, port):
+    """Return address info with socket addresses adjusted to the requested port."""
+    pinned_addrinfo = []
+    for family, socktype, proto, canonname, sockaddr in addrinfo:
+        if len(sockaddr) == 2:
+            host, _ = sockaddr
+            sockaddr = (host, port)
+        elif len(sockaddr) == 4:
+            host, _, flowinfo, scopeid = sockaddr
+            sockaddr = (host, port, flowinfo, scopeid)
+        pinned_addrinfo.append((family, socktype, proto, canonname, sockaddr))
+    return pinned_addrinfo
+
+
+@contextmanager
+def _pin_dns_resolution(hostname: str, port: int, addrinfo):
+    """Force socket lookups for hostname:port to reuse prevalidated addresses."""
+    original_getaddrinfo = socket.getaddrinfo
+
+    def pinned_getaddrinfo(host, service, *args, **kwargs):
+        if host == hostname and service in (port, str(port)):
+            return _addrinfo_with_port(addrinfo, port)
+        return original_getaddrinfo(host, service, *args, **kwargs)
+
+    socket.getaddrinfo = pinned_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
 
 
 def _get_with_validated_redirects(
-    session, target_url: str, timeout: int, first_url_validated=False
+    session, target_url: str, timeout: int, first_validated_addrinfo=None
 ):
-    """Fetch a URL while validating every redirect target before following it."""
+    """Fetch a URL while validating and pinning every redirect target."""
     current_url = target_url
-    for redirect_count in range(MAX_REDIRECTS + 1):
-        if not (first_url_validated and redirect_count == 0):
-            if not _validate_url_target(current_url):
+    validated_addrinfo = first_validated_addrinfo
+    for _ in range(MAX_REDIRECTS + 1):
+        if validated_addrinfo is None:
+            validated_addrinfo = _validated_addrinfo_for_url(current_url)
+            if validated_addrinfo is None:
                 return None
 
-        response = session.get(current_url, timeout=timeout, allow_redirects=False)
+        parsed = urlparse(current_url)
+        with _pin_dns_resolution(
+            parsed.hostname, _port_for_url(parsed), validated_addrinfo
+        ):
+            response = session.get(
+                current_url, timeout=timeout, allow_redirects=False
+            )
         status_code = getattr(response, 'status_code', None)
         if status_code not in REDIRECT_STATUSES:
             return response
@@ -74,6 +128,7 @@ def _get_with_validated_redirects(
             return response
 
         current_url = urljoin(current_url, location)
+        validated_addrinfo = None
 
     print("Error: Too many redirects.", file=sys.stderr)
     return None
@@ -133,7 +188,8 @@ def main(argv=None):
             if '/?' in target_url:
                 target_url = target_url.replace('/?', '?')
 
-            if not _validate_url_target(target_url):
+            validated_addrinfo = _validated_addrinfo_for_url(target_url)
+            if validated_addrinfo is None:
                 return
 
             print(f"Processing URL: {target_url}")
@@ -141,7 +197,10 @@ def main(argv=None):
             try:
                 print("Fetching content...")
                 response = _get_with_validated_redirects(
-                    session, target_url, timeout=30, first_url_validated=True
+                    session,
+                    target_url,
+                    timeout=30,
+                    first_validated_addrinfo=validated_addrinfo,
                 )
                 if response is None:
                     return

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -4,12 +4,18 @@ from unittest.mock import patch, MagicMock
 import sys
 import io
 import os
+import socket
 import requests  # type: ignore[import-untyped]
 
 # Ensure src is in path before importing the local package.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 import html2md.cli  # pylint: disable=wrong-import-position  # type: ignore[import-untyped]
+
+
+def _public_addrinfo():
+    """Return deterministic public DNS results for request-mocked tests."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 80))]
 
 
 class TestCliError(unittest.TestCase):
@@ -34,10 +40,11 @@ class TestCliError(unittest.TestCase):
 
         with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
             with patch('sys.stderr', captured_stderr):
-                try:
-                    html2md.cli.main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                    try:
+                        html2md.cli.main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
         output = captured_stderr.getvalue()
         self.assertIn("Network error", output)
@@ -63,10 +70,11 @@ class TestCliError(unittest.TestCase):
 
         with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
             with patch('sys.stderr', captured_stderr):
-                try:
-                    html2md.cli.main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                    try:
+                        html2md.cli.main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
         output = captured_stderr.getvalue()
         # The code catches Exception and prints "Conversion failed: {e}"

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -2,8 +2,14 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import io
+import socket
 import requests  # type: ignore[import-untyped]
 from html2md.cli import main
+
+
+def _public_addrinfo():
+    """Return deterministic public DNS results for request-mocked tests."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 80))]
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -16,10 +22,11 @@ class TestCliExceptions(unittest.TestCase):
             with patch('requests.Session.get') as mock_get:
                 mock_get.side_effect = requests.RequestException("Network unreachable")
 
-                try:
-                    main(['--url', 'http://example.com'])
-                except (SystemExit, RuntimeError, ValueError) as e:
-                    self.fail(f"main raised exception {e}")
+                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                    try:
+                        main(['--url', 'http://example.com'])
+                    except (SystemExit, RuntimeError, ValueError) as e:
+                        self.fail(f"main raised exception {e}")
 
                 output = captured_stderr.getvalue()
                 self.assertIn("Network error", output)
@@ -38,10 +45,11 @@ class TestCliExceptions(unittest.TestCase):
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.makedirs'), patch('os.path.exists', return_value=False):
                         with patch('builtins.open', side_effect=OSError("Permission denied")):
-                            try:
-                                main(['--url', 'http://example.com', '--outdir', 'dummy'])
-                            except (SystemExit, RuntimeError, ValueError) as e:
-                                self.fail(f"main raised exception {e}")
+                            with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                                try:
+                                    main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                                except (SystemExit, RuntimeError, ValueError) as e:
+                                    self.fail(f"main raised exception {e}")
 
                             output = captured_stderr.getvalue()
                             self.assertIn("File error", output)
@@ -66,7 +74,8 @@ class TestCliExceptions(unittest.TestCase):
                                 return '/tmp/out'
 
                             with patch('os.path.realpath', side_effect=fake_realpath):
-                                main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
+                                with patch('html2md.cli.socket.getaddrinfo', return_value=_public_addrinfo()):
+                                    main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -103,6 +103,53 @@ def test_process_url_blocks_redirect_to_private_address(mock_get, capsys, tmp_pa
     )
 
 
+def test_redirect_fetch_pins_validated_dns_result(capsys, tmp_path):
+    """Redirect fetches reuse the IP that passed validation, blocking rebinding."""
+    fetched_ips = []
+    resolve_counts = {}
+
+    def resolve(hostname, port, type):  # pylint: disable=redefined-builtin
+        resolve_counts[hostname] = resolve_counts.get(hostname, 0) + 1
+        if hostname == "example.com":
+            return _addrinfo_for("93.184.216.34")
+        if hostname == "redirect.example":
+            if resolve_counts[hostname] == 1:
+                return _addrinfo_for("93.184.216.35")
+            return _addrinfo_for("127.0.0.1")
+        raise AssertionError(f"Unexpected hostname: {hostname}")
+
+    class RebindingSession:
+        headers = {}
+
+        def get(self, url, timeout, allow_redirects):
+            parsed = cli.urlparse(url)
+            port = 443 if parsed.scheme == "https" else 80
+            addrinfo = cli.socket.getaddrinfo(
+                parsed.hostname, port, type=socket.SOCK_STREAM
+            )
+            fetched_ips.append(addrinfo[0][4][0])
+
+            response = MagicMock()
+            response.status_code = 200
+            response.headers = {}
+            response.text = "<h1>ok</h1>"
+            response.raise_for_status.return_value = None
+            if parsed.hostname == "example.com":
+                response.status_code = 302
+                response.headers = {"Location": "https://redirect.example/final"}
+            return response
+
+    with patch("requests.Session", return_value=RebindingSession()), patch(
+        "html2md.cli.socket.getaddrinfo", side_effect=resolve
+    ):
+        cli.main(["--url", "https://example.com/start", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    assert fetched_ips == ["93.184.216.34", "93.184.216.35"]
+    assert resolve_counts == {"example.com": 1, "redirect.example": 1}
+
+
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -150,6 +150,32 @@ def test_redirect_fetch_pins_validated_dns_result(capsys, tmp_path):
     assert resolve_counts == {"example.com": 1, "redirect.example": 1}
 
 
+def test_url_fetch_session_disables_environment_proxies(capsys, tmp_path):
+    """URL fetching must ignore ambient proxy settings to keep DNS pinned."""
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>proxied</h1>"
+    response.raise_for_status.return_value = None
+
+    session = MagicMock()
+    session.headers = {}
+    session.get.return_value = response
+
+    with patch("requests.Session", return_value=session), patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=_addrinfo_for("93.184.216.34"),
+    ):
+        cli.main(["--url", "https://example.com/proxy", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    assert session.trust_env is False
+    session.get.assert_called_once_with(
+        "https://example.com/proxy", timeout=30, allow_redirects=False
+    )
+
+
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,9 +1,16 @@
 """Security-focused tests for CLI URL and output path handling."""
 
+import socket
 from unittest.mock import MagicMock, patch
 import pytest
 
 from html2md import cli
+
+
+def _addrinfo_for(ip):
+    """Build a getaddrinfo-style result for a deterministic IP address."""
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return [(family, socket.SOCK_STREAM, 0, "", (ip, 443))]
 
 
 @pytest.mark.parametrize(
@@ -24,21 +31,76 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
 
 
 @pytest.mark.parametrize(
-    "url",
+    "url, ip",
     [
-        "http://127.0.0.1:8080/admin",
-        "http://localhost/secret",
-        "http://192.168.1.1/config",
-        "http://10.0.0.5/",
+        ("http://127.0.0.1:8080/admin", "127.0.0.1"),
+        ("http://localhost/secret", "127.0.0.1"),
+        ("http://192.168.1.1/config", "192.168.1.1"),
+        ("http://10.0.0.5/", "10.0.0.5"),
+        ("http://[::1]/", "::1"),
+        ("http://100.64.0.1/", "100.64.0.1"),
     ],
 )
 @patch("requests.Session.get")
-def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url):
-    """Ensure that local, private, and loopback IPs are blocked to prevent SSRF."""
-    cli.main(["--url", url, "--outdir", str(tmp_path)])
+def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, ip):
+    """Ensure that non-global IPs are blocked to prevent SSRF."""
+    with patch("html2md.cli.socket.getaddrinfo", return_value=_addrinfo_for(ip)):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
     outerr = capsys.readouterr()
     assert "Error: URL resolves to a restricted/private network address." in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_allows_public_ipv6(mock_get, capsys, tmp_path):
+    """Public IPv6 targets should remain valid after SSRF validation."""
+    response = MagicMock()
+    response.status_code = 200
+    response.text = "<h1>ipv6</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=_addrinfo_for("2606:4700:4700::1111"),
+    ):
+        cli.main([
+            "--url",
+            "https://[2606:4700:4700::1111]/",
+            "--outdir",
+            str(tmp_path),
+        ])
+
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+    mock_get.assert_called_once_with(
+        "https://[2606:4700:4700::1111]/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("requests.Session.get")
+def test_process_url_blocks_redirect_to_private_address(mock_get, capsys, tmp_path):
+    """Redirect targets are validated before the redirected request is fetched."""
+    redirect = MagicMock()
+    redirect.status_code = 302
+    redirect.headers = {"Location": "http://127.0.0.1:8080/admin"}
+    mock_get.return_value = redirect
+
+    def resolve(hostname, port, type):  # pylint: disable=redefined-builtin
+        if hostname == "example.com":
+            return _addrinfo_for("93.184.216.34")
+        if hostname == "127.0.0.1":
+            return _addrinfo_for("127.0.0.1")
+        raise AssertionError(f"Unexpected hostname: {hostname}")
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=resolve):
+        cli.main(["--url", "https://example.com/start", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: URL resolves to a restricted/private network address." in outerr.err
+    mock_get.assert_called_once_with(
+        "https://example.com/start", timeout=30, allow_redirects=False
+    )
 
 
 @patch("requests.Session.get")
@@ -60,12 +122,18 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         "http://example.com/foo/%2E%2E%2F%2E%2E%2Fsecret.txt",
     ]
 
-    for url in urls:
-        cli.main(["--url", url, "--outdir", str(outdir)])
-        outerr = capsys.readouterr()
-        assert "Success!" in outerr.out
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=_addrinfo_for("93.184.216.34"),
+    ):
+        for url in urls:
+            cli.main(["--url", url, "--outdir", str(outdir)])
+            outerr = capsys.readouterr()
+            assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
-    assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
+    assert list(outdir.rglob("*.md")), (
+        "No markdown files were created in the output directory."
+    )
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()


### PR DESCRIPTION
### Motivation
- Prevent SSRF bypasses where a public hostname resolves to a safe IP at check time but redirects or alternate records lead to private/loopback/CGN addresses at fetch time.
- Restore IPv6 support and avoid IPv4-only resolution regressions introduced by using `socket.gethostbyname`.
- Make security tests hermetic so they do not rely on real DNS during unit test runs.

### Description
- Replaced single-address IPv4 lookup with `_validate_url_target(target_url)` that uses `socket.getaddrinfo` and `ipaddress.ip_address(...).is_global` to validate all resolved IPv4/IPv6 answers for a URL.
- Added `_get_with_validated_redirects(session, target_url, ...)` which disables `requests` automatic redirects (`allow_redirects=False`), validates each redirect `Location` (resolved via `urljoin`) before following it, and enforces a `MAX_REDIRECTS` limit.
- Updated URL processing to call `_validate_url_target` for the initial URL and to fetch via `_get_with_validated_redirects`, returning early on validation failures.
- Updated tests in `tests/test_cli_security.py` to mock `socket.getaddrinfo` (via `patch`) for deterministic DNS behavior and added cases for IPv6, CGN (`100.64.0.0/10`), and a redirect-to-loopback regression check.

### Testing
- Ran unit tests with `PYENV_VERSION=3.11.15 pytest -q` and the test suite passed (all tests succeeded).
- Verified no whitespace/diff issues with `git diff --check` (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49f044108320b3b6873eebb54311)