### PR TITLE
Drop unused `pull-requests: write` permission from Jules review workflow

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   request-review:


### PR DESCRIPTION
### Motivation
- Narrow the `GITHUB_TOKEN` scope for the Jules review-request workflow by removing the unused `pull-requests: write` permission since the job only posts to the issues comments endpoint.

### Description
- Remove the `pull-requests: write` permission line from `.github/workflows/request-jules-review.yml` and keep `issues: write`, which is sufficient for posting the PR comment via `/repos/{owner}/{repo}/issues/{pr_number}/comments`.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and inspected the updated `request-jules-review.yml`; no automated test failures were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49e945b08320ba12817678d79b83)