### PR TITLE
Remove TypeScript healthcheck gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "self:heal": "node scripts/self-heal.mjs",
     "lint": "eslint .",
     "format": "prettier -w .",
-    "typecheck": "tsc -b",
     "test": "vitest run"
   }
 }

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: test? lint? build?
+   - root: lint? test?
    - workspaces: smoke build where available
 */
 import { execSync } from "node:child_process";

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
+   - root: test? lint? build?
    - workspaces: smoke build where available
 */
 import { execSync } from "node:child_process";
@@ -24,7 +24,6 @@ const tryRun = (name, cmd) => {
 
 try {
   // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
   tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
   tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
 


### PR DESCRIPTION
### Motivation
- The repository is a Python project without TypeScript project files, so the root `typecheck` script (which ran `tsc -b`) and its healthcheck gate caused spurious failures.

### Description
- Remove the `typecheck` script from `package.json` and remove the corresponding TypeScript check from `scripts/healthcheck.mjs`, and update the healthcheck comment to reference only `test`, `lint`, and `build` checks.

### Testing
- Ran `git diff --check`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49b06d4c8320b6f56e5de15debb1)