### PR TITLE
Preserve healthcheck failures through tee

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -50,20 +50,23 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
+        shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
+        shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
+        shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs


### PR DESCRIPTION
### Motivation
- Prevent failures from `node scripts/healthcheck.mjs` and `node scripts/self-heal.mjs` being masked when their output is piped through `tee`, so the workflow's post-check gate (`steps.post.outcome`) accurately reflects script failures.

### Description
- Update `.github/workflows/self-heal.yml` to add `shell: bash` and use `set -euo pipefail` for the pre-repair, repair, and post-repair steps so errors propagate through `tee` instead of being swallowed.

### Testing
- Executed `git diff --check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49a7c4a88320a5df4e6bdeb133e4)