### PR TITLE
Ignore self-heal log files in repair detection

### DIFF
--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -12,9 +12,19 @@ const sh = (cmd, opts={}) => {
 const trySh = (cmd, opts={}) => {
   try { sh(cmd, opts); return true; } catch { return false; }
 };
+const selfHealLogFiles = new Set([
+  "selfheal-pre.txt",
+  "selfheal-repair.txt",
+  "selfheal-post.txt",
+]);
 const changed = () => {
   const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
-  return (out.stdout || "").trim().length > 0;
+  return (out.stdout || "")
+    .split("\n")
+    .some((line) => {
+      const path = line.slice(3).trim();
+      return path && !selfHealLogFiles.has(path);
+    });
 };
 const passHealth = () => {
   try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }


### PR DESCRIPTION
### Motivation
- Prevent self-heal from treating its own `selfheal-*.txt` log artifacts as repository repairs so the workflow doesn't open PRs containing only log files.

### Description
- Add a `selfHealLogFiles` set and update `changed()` in `scripts/self-heal.mjs` to ignore `selfheal-pre.txt`, `selfheal-repair.txt`, and `selfheal-post.txt` when scanning `git status --porcelain` for changes.

### Testing
- Ran `git diff --check` and `node --check scripts/self-heal.mjs` with no errors, and validated behavior by creating temporary `selfheal-*.txt` files and confirming the change detector ignores log-only status while still detecting actual source changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd499cb0808320a65dd59ab15ab09e)