### PR TITLE
Remove unsupported ESLint healthcheck gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
     "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
     "format": "prettier -w .",
     "typecheck": "tsc -b",
     "test": "vitest run"


### PR DESCRIPTION
### Motivation
- The repo had a root `lint` script which the new healthcheck would run even though there is no ESLint configuration, causing self-heal runs to fail on config discovery rather than real project issues.

### Description
- Remove the root `"lint": "eslint ."` script from `package.json` so the healthcheck will not invoke ESLint at the workspace root.

### Testing
- Ran `git diff --check` which passed.
- Verified `package.json` parses with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49922c8883208b7ab7a59ca3fa65)