### PR TITLE
Run pytest in self-heal healthcheck

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -25,6 +25,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python test deps
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          pip install pytest
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "lint": "eslint .",
     "format": "prettier -w .",
     "typecheck": "tsc -b",
-    "test": "vitest run"
+    "test": "pytest -q"
   }
 }

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,49 +1,21 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Minimal healthcheck for this Python repository:
+   - mirrors CI by running the pytest suite
 */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
 
-const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
-};
-
-const tryRun = (name, cmd) => {
-  if (!cmd) return;
-  console.log(`\n==> ${name}`);
-  run(cmd);
-};
+const run = (cmd) => execSync(cmd, {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    LC_ALL: "C",
+    PYTHONCOERCECLOCALE: process.env.PYTHONCOERCECLOCALE || "0",
+  },
+});
 
 try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
-
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
-    }
-  }
-  process.exit(process.exitCode ?? 0);
+  console.log("\n==> Unit tests");
+  run("pytest -q");
 } catch (e) {
   console.error(e);
   process.exit(1);


### PR DESCRIPTION
### Motivation
- The self-heal healthcheck previously invoked pnpm/Vitest paths that do not exercise this repository’s Python test suite, so the post-repair gate could miss real pytest failures. 
- The workflow also lacked steps to prepare the Python test environment, preventing the healthcheck from running here. 

### Description
- Replace `scripts/healthcheck.mjs` with a Python-focused healthcheck that runs `pytest -q` and forces a stable `LC_ALL`/`PYTHONCOERCECLOCALE` environment for subprocesses. 
- Update `package.json` `test` script to `pytest -q` so the root `test` task mirrors repository CI. 
- Update `.github/workflows/self-heal.yml` to set up Python and install test dependencies (`pip install -e .` and `pip install pytest`) before running the healthcheck steps. 

### Testing
- Ran `PYENV_VERSION=3.12.13 node scripts/healthcheck.mjs` and the script invoked `pytest` and completed (healthcheck exercised the test suite). 
- Ran `PYENV_VERSION=3.12.13 LC_ALL=C PYTHONCOERCECLOCALE=0 pytest -q` and the test suite passed. 
- Ran `git diff --check` and no whitespace or patch issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd497d17a48320b99815303160625a)