### PR TITLE
Fix pnpm setup order in self-heal workflow

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -25,16 +25,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install deps (best-effort frozen)
         id: install_try_frozen


### PR DESCRIPTION
### Motivation
- Ensure `pnpm` is available on `PATH` before enabling `cache: 'pnpm'` so the self-heal job does not fail with `Unable to locate executable file: pnpm`.

### Description
- Reordered the steps in `.github/workflows/self-heal.yml` to run `pnpm/action-setup@v4` before `actions/setup-node@v4` (so `pnpm` is installed prior to enabling the pnpm cache).

### Testing
- Ran `git diff --check` which passed and committed the change to update the workflow file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4970ded48320a2cdbc235b11424c)