### PR TITLE
Skip workspace builds when no build script exists

### DIFF
--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -4,8 +4,7 @@
    - workspaces: smoke build where available
 */
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const run = (cmd) => execSync(cmd, { stdio: "inherit" });

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -4,7 +4,7 @@
    - workspaces: smoke build where available
 */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -22,6 +22,14 @@ const tryRun = (name, cmd) => {
   run(cmd);
 };
 
+const hasBuildScript = (dir) => {
+  const packageJson = join(dir, "package.json");
+  if (!existsSync(packageJson)) return false;
+
+  const pkg = JSON.parse(readFileSync(packageJson, "utf8"));
+  return !!pkg.scripts?.build;
+};
+
 try {
   // Root-level checks (best-effort if scripts exist)
   tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
@@ -36,6 +44,7 @@ try {
       const dir = join(base, name);
       if (!statSync(dir).isDirectory()) continue;
       try {
+        if (!hasBuildScript(dir)) continue;
         execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
       } catch (e) {
         console.error(`[healthcheck] build failed in ${dir}`);


### PR DESCRIPTION
### Motivation
- The workspace smoke-build loop ran `pnpm run -s build` for every directory under `apps/` and `packages/`, causing the healthcheck to fail for packages that have no `build` script.
- Make the smoke-builds truly best-effort by skipping directories that do not define a `build` script in their `package.json`.

### Description
- Import `readFileSync` from `node:fs` and add a `hasBuildScript(dir)` helper that reads `package.json` and returns whether `scripts.build` exists.
- Update the `apps/*` and `packages/*` loop in `scripts/healthcheck.mjs` to skip directories where `hasBuildScript(dir)` is false before invoking `pnpm run -s build`.
- Commit message: "Skip workspace builds without build scripts".

### Testing
- Ran `node --check scripts/healthcheck.mjs` to validate syntax and it succeeded.
- Created temporary fixtures (`apps/no-build`, `apps/with-build`, `packages/no-package`) and a fake `pnpm` wrapper, then ran `node scripts/healthcheck.mjs` and verified only `apps/with-build` invoked `pnpm run -s build`.
- Confirmed the local change with `git status --short` and `git diff` and committed the patch successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4968b56483209662d6485d281ad5)