### PR TITLE
[AI-Assisted] Use portable Python for Claude hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python3 .claude/hooks/protect-sensitive-files.py; elif command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python .claude/hooks/protect-sensitive-files.py; else echo 'No usable Python >= 3.8 found for protect-sensitive-files.py' >&2; exit 1; fi"
+            "command": "if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python3 .claude/hooks/protect-sensitive-files.py; elif command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python .claude/hooks/protect-sensitive-files.py; else echo 'No usable Python >= 3.8 found for protect-sensitive-files.py' >&2; exit 2; fi"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python3 .claude/hooks/protect-sensitive-files.py; elif command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python .claude/hooks/protect-sensitive-files.py; else echo 'No usable Python >= 3.8 found for protect-sensitive-files.py' >&2; exit 2; fi"
+            "command": "if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then\n  exec python3 .claude/hooks/protect-sensitive-files.py\nelif command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then\n  exec python .claude/hooks/protect-sensitive-files.py\nelse\n  echo 'No usable Python >= 3.8 found for protect-sensitive-files.py' >&2\n  exit 2\nfi"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/protect-sensitive-files.py"
+            "command": "if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python3 .claude/hooks/protect-sensitive-files.py; elif command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then exec python .claude/hooks/protect-sensitive-files.py; else echo 'No usable Python >= 3.8 found for protect-sensitive-files.py' >&2; exit 1; fi"
           }
         ]
       }

--- a/scripts/test_baseline_hook.sh
+++ b/scripts/test_baseline_hook.sh
@@ -90,6 +90,28 @@ EOF
 fi
 pass "settings hook command uses working python3 when python is unavailable"
 
+NO_PYTHON_DIR="$TMP_DIR/no-usable-python"
+mkdir "$NO_PYTHON_DIR" || fail "could not create no-usable-python directory"
+cat >"$NO_PYTHON_DIR/python" <<'SH'
+#!/bin/sh
+echo "simulated missing python" >&2
+exit 127
+SH
+cat >"$NO_PYTHON_DIR/python3" <<'SH'
+#!/bin/sh
+echo "simulated missing python3" >&2
+exit 127
+SH
+chmod +x "$NO_PYTHON_DIR/python" "$NO_PYTHON_DIR/python3"
+PATH="$NO_PYTHON_DIR" /bin/sh -c "$SETTINGS_HOOK_COMMAND" <<'EOF' >/dev/null 2>&1
+{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"src/html2md/cli.py"}}
+EOF
+NO_PYTHON_STATUS=$?
+if [ "$NO_PYTHON_STATUS" -ne 2 ]; then
+  fail "settings hook command should exit 2 when no usable Python is available, got $NO_PYTHON_STATUS"
+fi
+pass "settings hook command exits 2 when no usable Python is available"
+
 # --- BLOCK cases (expect non-zero exit) ---
 for path in ".env" ".env.local" ".env.production" "config/.env" \
             ".envrc" ".envrc.local" "config/.envrc" \

--- a/scripts/test_baseline_hook.sh
+++ b/scripts/test_baseline_hook.sh
@@ -36,6 +36,20 @@ fi
 import sys
 sys.exit(0 if sys.version_info >= (3, 8) else 1)
 PY
+PYTHON_BIN_PATH="$($PYTHON_BIN - <<'PY'
+import sys
+print(sys.executable)
+PY
+)" || fail "could not resolve python interpreter: $PYTHON_BIN"
+
+SETTINGS_HOOK_COMMAND="$($PYTHON_BIN - <<'PY'
+import json
+from pathlib import Path
+
+settings = json.loads(Path(".claude/settings.json").read_text(encoding="utf-8"))
+print(settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"])
+PY
+)" || fail "could not read hook command from .claude/settings.json"
 
 # Helper: run the hook with a given tool_name and file_path; return its exit code.
 run_hook() {
@@ -53,6 +67,28 @@ run_hook_payload() {
   local payload="$1"
   printf "%s\n" "$payload" | "$PYTHON_BIN" "$HOOK"
 }
+
+# Ensure the configured Claude hook command skips an unusable `python` shim
+# (for example, pyenv with a missing .python-version) when `python3` works.
+TMP_DIR="$(mktemp -d)" || fail "could not create temporary directory"
+cleanup_tmp_dir() { rm -rf "$TMP_DIR"; }
+trap cleanup_tmp_dir EXIT
+cat >"$TMP_DIR/python" <<'SH'
+#!/usr/bin/env sh
+echo "simulated broken python" >&2
+exit 127
+SH
+cat >"$TMP_DIR/python3" <<SH
+#!/usr/bin/env sh
+exec "$PYTHON_BIN_PATH" "\$@"
+SH
+chmod +x "$TMP_DIR/python" "$TMP_DIR/python3"
+if ! PATH="$TMP_DIR:$PATH" sh -c "$SETTINGS_HOOK_COMMAND" <<'EOF' >/dev/null 2>&1; then
+{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"src/html2md/cli.py"}}
+EOF
+  fail "settings hook command should use working python3 when python is unavailable"
+fi
+pass "settings hook command uses working python3 when python is unavailable"
 
 # --- BLOCK cases (expect non-zero exit) ---
 for path in ".env" ".env.local" ".env.production" "config/.env" \

--- a/scripts/test_baseline_hook.sh
+++ b/scripts/test_baseline_hook.sh
@@ -41,6 +41,14 @@ import sys
 print(sys.executable)
 PY
 )" || fail "could not resolve python interpreter: $PYTHON_BIN"
+PYTHON3_BIN_PATH=""
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON3_BIN_PATH="$(python3 - <<'PY'
+import sys
+print(sys.executable)
+PY
+)" || fail "could not resolve python3 interpreter"
+fi
 
 SETTINGS_HOOK_COMMAND="$($PYTHON_BIN - <<'PY'
 import json
@@ -70,25 +78,33 @@ run_hook_payload() {
 
 # Ensure the configured Claude hook command skips an unusable `python` shim
 # (for example, pyenv with a missing .python-version) when `python3` works.
-TMP_DIR="$(mktemp -d)" || fail "could not create temporary directory"
+make_tmp_dir() {
+  mktemp -d 2>/dev/null || mktemp -d -t html2md-hook-test
+}
+
+TMP_DIR="$(make_tmp_dir)" || fail "could not create temporary directory"
 cleanup_tmp_dir() { rm -rf "$TMP_DIR"; }
 trap cleanup_tmp_dir EXIT
-cat >"$TMP_DIR/python" <<'SH'
-#!/usr/bin/env sh
+if [ -n "$PYTHON3_BIN_PATH" ]; then
+  cat >"$TMP_DIR/python" <<'SH'
+#!/bin/sh
 echo "simulated broken python" >&2
 exit 127
 SH
-cat >"$TMP_DIR/python3" <<SH
-#!/usr/bin/env sh
-exec "$PYTHON_BIN_PATH" "\$@"
+  cat >"$TMP_DIR/python3" <<SH
+#!/bin/sh
+exec "$PYTHON3_BIN_PATH" "\$@"
 SH
-chmod +x "$TMP_DIR/python" "$TMP_DIR/python3"
-if ! PATH="$TMP_DIR:$PATH" sh -c "$SETTINGS_HOOK_COMMAND" <<'EOF' >/dev/null 2>&1; then
+  chmod +x "$TMP_DIR/python" "$TMP_DIR/python3"
+  if ! PATH="$TMP_DIR:$PATH" /bin/sh -c "$SETTINGS_HOOK_COMMAND" <<'EOF' >/dev/null 2>&1; then
 {"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"src/html2md/cli.py"}}
 EOF
-  fail "settings hook command should use working python3 when python is unavailable"
+    fail "settings hook command should use working python3 when python is unavailable"
+  fi
+  pass "settings hook command uses working python3 when python is unavailable"
+else
+  pass "skipped python3 preference check because python3 is not available"
 fi
-pass "settings hook command uses working python3 when python is unavailable"
 
 NO_PYTHON_DIR="$TMP_DIR/no-usable-python"
 mkdir "$NO_PYTHON_DIR" || fail "could not create no-usable-python directory"


### PR DESCRIPTION
### Motivation
- The Claude PreToolUse hook was invoked via a hard-coded `python` command which can fail in checkouts where `python` is a broken pyenv shim while `python3` is available, causing the sensitive-file guard to not run.
- The test harness should verify the configured hook command itself uses a usable Python interpreter so an environment with a missing `.python-version` does not silently bypass protections.

### Description
- Change the hook launcher in `.claude/settings.json` to probe for a usable Python >= 3.8 and prefer `python3`, falling back to `python`, and fail if none are suitable (the hook `command` string now validates interpreter availability before `exec`).
- Enhance `scripts/test_baseline_hook.sh` to resolve the selected interpreter path from the settings, simulate a broken `python` shim, and assert the configured settings command still runs using the working `python3` binary; the script also continues to exercise the existing block/allow cases for sensitive paths.

### Testing
- Ran `scripts/test_baseline_hook.sh`, which succeeded (smoke tests passed and the new simulated-broken-`python` check passed).
- Ran `scripts/check_agents_consistency.sh` and `scripts/lint_ai_pr_guard_workflow.sh`, both of which reported OK.
- Ran `git diff --check`, which reported no whitespace/format issues.
- `pytest -q` / `python3 -m pytest -q` were not run successfully in this environment due to local `pyenv` configuration and `pytest` not being installed for the active interpreter (blocked by missing configured Python / missing `pytest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd495a757883208354427f8b6e12ff)