### PR TITLE
Disable pnpm cache without lockfile

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
### Motivation
- `actions/setup-node`'s pnpm caching requires a `pnpm-lock.yaml`, and enabling `cache: 'pnpm'` in a repo without a lockfile can fail before installs run.

### Description
- Remove the `cache: 'pnpm'` setting from the `actions/setup-node@v4` step in `.github/workflows/self-heal.yml` so the self-heal workflow does not attempt pnpm caching when no lockfile is present.

### Testing
- Ran `git diff --check` to validate the change and found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd495698e88320ad8a8673243d6fec)