### PR TITLE
Fix self-heal healthcheck for non-workspace Python repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
-    "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
-    "format": "prettier -w .",
-    "typecheck": "tsc -b",
-    "test": "vitest run"
+    "self:heal": "node scripts/self-heal.mjs"
   }
 }

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,20 +1,19 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Minimal, opinionated healthcheck for this Python project:
+   - run the same pytest suite as CI when tests are present
+   - optionally run root package scripts, without pnpm workspace flags
+   - in real pnpm workspaces only, smoke build packages that declare build
 */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
-};
+const run = (cmd, opts = {}) => execSync(cmd, { stdio: "inherit", ...opts });
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+const rootPkgPath = join(process.cwd(), "package.json");
+const rootPkg = existsSync(rootPkgPath) ? readJson(rootPkgPath) : {};
+const hasScript = (name) => !!rootPkg.scripts?.[name];
+const hasPnpmWorkspace = existsSync("pnpm-workspace.yaml");
 
 const tryRun = (name, cmd) => {
   if (!cmd) return;
@@ -23,26 +22,37 @@ const tryRun = (name, cmd) => {
 };
 
 try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+  // Match the repository's Python CI gate first; this repo is not a pnpm workspace.
+  tryRun("Python tests", existsSync("tests") ? "python -m pytest -q" : null);
 
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
+  // Optional root-level package checks. Use plain pnpm commands, never `pnpm -w`,
+  // because this repository has no pnpm-workspace.yaml.
+  tryRun("Typecheck", hasScript("typecheck") ? "pnpm run typecheck" : null);
+  tryRun("Lint", hasScript("lint") ? "pnpm run lint" : null);
+  tryRun("Unit tests", hasScript("test") ? "pnpm run test" : null);
+  tryRun("Build", hasScript("build") ? "pnpm run build" : null);
+
+  // Workspace smoke builds only apply to actual pnpm workspaces.
+  if (hasPnpmWorkspace) {
+    const roots = ["apps", "packages"];
+    for (const base of roots) {
+      if (!existsSync(base)) continue;
+      for (const name of readdirSync(base)) {
+        const dir = join(base, name);
+        const pkgPath = join(dir, "package.json");
+        if (!statSync(dir).isDirectory() || !existsSync(pkgPath)) continue;
+        const pkg = readJson(pkgPath);
+        if (!pkg.scripts?.build) continue;
+        try {
+          execSync("pnpm run --if-present build", { cwd: dir, stdio: "inherit" });
+        } catch (e) {
+          console.error(`[healthcheck] build failed in ${dir}`);
+          process.exitCode = 1;
+        }
       }
     }
   }
+
   process.exit(process.exitCode ?? 0);
 } catch (e) {
   console.error(e);

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* Minimal, opinionated healthcheck for this Python project:
-   - run the same pytest suite as CI when tests are present
+   - install Python test dependencies before running the same pytest suite as CI
    - optionally run root package scripts, without pnpm workspace flags
    - in real pnpm workspaces only, smoke build packages that declare build
 */
@@ -21,9 +21,18 @@ const tryRun = (name, cmd) => {
   run(cmd);
 };
 
+const runPythonTests = () => {
+  if (!existsSync("tests")) return;
+
+  // Match CI's Python setup before invoking pytest so clean self-heal runners
+  // have pytest and the src-layout package installed.
+  tryRun("Python test dependencies", "python -m pip install -e . pytest");
+  tryRun("Python tests", "python -m pytest -q");
+};
+
 try {
-  // Match the repository's Python CI gate first; this repo is not a pnpm workspace.
-  tryRun("Python tests", existsSync("tests") ? "python -m pytest -q" : null);
+  // Run the repository's Python CI gate first; this repo is not a pnpm workspace.
+  runPythonTests();
 
   // Optional root-level package checks. Use plain pnpm commands, never `pnpm -w`,
   // because this repository has no pnpm-workspace.yaml.

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -4,16 +4,24 @@
    - optionally run root package scripts, without pnpm workspace flags
    - in real pnpm workspaces only, smoke build packages that declare build
 */
-import { execSync } from "node:child_process";
+import { execFileSync, execSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const run = (cmd, opts = {}) => execSync(cmd, { stdio: "inherit", ...opts });
+const runFile = (file, args, opts = {}) =>
+  execFileSync(file, args, { stdio: "inherit", ...opts });
 const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
 const rootPkgPath = join(process.cwd(), "package.json");
 const rootPkg = existsSync(rootPkgPath) ? readJson(rootPkgPath) : {};
 const hasScript = (name) => !!rootPkg.scripts?.[name];
 const hasPnpmWorkspace = existsSync("pnpm-workspace.yaml");
+const requestedPython = existsSync(".python-version")
+  ? readFileSync(".python-version", "utf8").trim()
+  : null;
+const minPython = [3, 8];
+const versionProbe =
+  "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')";
 
 const tryRun = (name, cmd) => {
   if (!cmd) return;
@@ -21,13 +29,113 @@ const tryRun = (name, cmd) => {
   run(cmd);
 };
 
+const parseVersion = (version) => version.trim().split(".").map(Number);
+const compareVersions = (left, right) => {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  for (let i = 0; i < Math.max(leftParts.length, rightParts.length); i += 1) {
+    const diff = (leftParts[i] ?? 0) - (rightParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+};
+const sameMajorMinor = (left, right) => {
+  if (!left || !right) return false;
+  const [leftMajor, leftMinor] = parseVersion(left);
+  const [rightMajor, rightMinor] = parseVersion(right);
+  return leftMajor === rightMajor && leftMinor === rightMinor;
+};
+const isSupportedPython = (version) => {
+  const [major = 0, minor = 0] = parseVersion(version);
+  return major > minPython[0] || (major === minPython[0] && minor >= minPython[1]);
+};
+
+const probePython = ({ file, args = [], env = process.env, label = file }) => {
+  const result = spawnSync(file, [...args, "-c", versionProbe], {
+    encoding: "utf8",
+    env,
+  });
+  if (result.status !== 0) return null;
+
+  const version = result.stdout.trim();
+  if (!isSupportedPython(version)) return null;
+
+  const pip = spawnSync(file, [...args, "-m", "pip", "--version"], {
+    encoding: "utf8",
+    env,
+  });
+  if (pip.status !== 0) return null;
+
+  return { file, args, env, label, version };
+};
+
+const pyenvPythonCandidates = () => {
+  const result = spawnSync("pyenv", ["versions", "--bare", "--skip-aliases"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return [];
+
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort((left, right) => {
+      const leftMatches = sameMajorMinor(left, requestedPython);
+      const rightMatches = sameMajorMinor(right, requestedPython);
+      if (leftMatches !== rightMatches) return leftMatches ? -1 : 1;
+      return compareVersions(right, left);
+    })
+    .map((version) => ({
+      file: "python",
+      env: { ...process.env, PYENV_VERSION: version },
+      label: `pyenv ${version}`,
+    }));
+};
+
+const findPython = () => {
+  const candidates = [
+    ...(process.env.PYTHON ? [{ file: process.env.PYTHON, label: "$PYTHON" }] : []),
+    { file: "python" },
+    { file: "python3" },
+    ...pyenvPythonCandidates(),
+  ];
+
+  if (process.platform === "win32") {
+    candidates.push({ file: "py", args: ["-3"] });
+  }
+
+  for (const candidate of candidates) {
+    const python = probePython(candidate);
+    if (python) return python;
+  }
+
+  throw new Error(
+    `Unable to find a working Python >=${minPython.join(".")} interpreter. ` +
+      "Install Python or set PYTHON to an interpreter path before running healthcheck.",
+  );
+};
+
+const runPython = (name, python, args) => {
+  console.log(`\n==> ${name} (${python.label}, Python ${python.version})`);
+  runFile(python.file, [...python.args, ...args], { env: python.env });
+};
+
 const runPythonTests = () => {
   if (!existsSync("tests")) return;
 
+  const python = findPython();
+
   // Match CI's Python setup before invoking pytest so clean self-heal runners
   // have pytest and the src-layout package installed.
-  tryRun("Python test dependencies", "python -m pip install -e . pytest");
-  tryRun("Python tests", "python -m pytest -q");
+  runPython("Python test dependencies", python, [
+    "-m",
+    "pip",
+    "install",
+    "-e",
+    ".",
+    "pytest",
+  ]);
+  runPython("Python tests", python, ["-m", "pytest", "-q"]);
 };
 
 try {
@@ -50,10 +158,10 @@ try {
         const dir = join(base, name);
         const pkgPath = join(dir, "package.json");
         if (!statSync(dir).isDirectory() || !existsSync(pkgPath)) continue;
-        const pkg = readJson(pkgPath);
-        if (!pkg.scripts?.build) continue;
         try {
-          execSync("pnpm run --if-present build", { cwd: dir, stdio: "inherit" });
+          const pkg = readJson(pkgPath);
+          if (!pkg.scripts?.build) continue;
+          run("pnpm run build", { cwd: dir });
         } catch (e) {
           console.error(`[healthcheck] build failed in ${dir}`);
           process.exitCode = 1;


### PR DESCRIPTION
### Motivation
- The healthcheck unconditionally invoked pnpm workspace commands (e.g. `pnpm -w` / `pnpm run -r`) in a repository that is a Python project without a `pnpm-workspace.yaml`, causing the self-heal workflow to fail before running the Python CI gate.

### Description
- Updated `scripts/healthcheck.mjs` to run the repository's Python test gate (`pytest`) first instead of relying on workspace pnpm commands. 
- Replaced the workspace-wide script detection with a direct root `package.json` script check and switched root invocations to plain `pnpm run` (never `pnpm -w`).
- Restricted workspace smoke builds to repositories that actually contain `pnpm-workspace.yaml` and only run package `build` scripts when they are declared, using `pnpm run --if-present` for best-effort behavior.
- Simplified `package.json` to remove Node tooling scripts (ESLint/Prettier/TypeScript/Vitest) that do not exist in this Python repo so the healthcheck does not attempt to run unavailable tooling.

### Testing
- Ran `node --check scripts/healthcheck.mjs` and it passed syntax checks. 
- Ran `node --check scripts/self-heal.mjs` and it passed syntax checks. 
- Executed the updated healthcheck (`node scripts/healthcheck.mjs`) in the repository environment which invoked the Python test suite after installing dependencies (`python -m pip install -e . pytest`); the pytest run exercised the tests but revealed a failing test: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd493f18508320acf853cee62d1dc3)