### PR TITLE
Use CI-capable token for self-heal PR creation

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -73,14 +74,21 @@ jobs:
       - name: Create PR with fixes
         if: steps.post.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SELF_HEAL_TOKEN }}
+          SELF_HEAL_TOKEN: ${{ secrets.SELF_HEAL_TOKEN }}
         run: |
+          set -euo pipefail
+          if [ -z "${SELF_HEAL_TOKEN}" ]; then
+            echo "SELF_HEAL_TOKEN must be an app token or PAT so generated PRs trigger CI." >&2
+            exit 1
+          fi
+
           if [ -n "$(git status --porcelain)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git config user.name "self-heal[bot]"
+            git config user.email "self-heal[bot]@users.noreply.github.com"
             git checkout -b self-heal-fixes-${{ github.run_id }}
             git add .
             git commit -m "chore: self-heal auto-fixes"
-            git push origin self-heal-fixes-${{ github.run_id }}
+            git push "https://x-access-token:${SELF_HEAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" self-heal-fixes-${{ github.run_id }}
             gh pr create --title "Self-heal auto-fixes" --body "Auto-generated PR from self-healing workflow. See job logs for details." --label "self-heal"
           fi


### PR DESCRIPTION
### Motivation
- Ensure auto-generated self-heal PRs can trigger repository CI by avoiding the limitations of the repository `GITHUB_TOKEN` and using an app/PAT instead. 
- Prevent accidental reuse of the default Actions token when pushing repair branches to reduce security surface and avoid silently failing to trigger workflows.

### Description
- Disable persisted checkout credentials by setting `persist-credentials: false` on the `actions/checkout` step to avoid reusing the default `GITHUB_TOKEN` for later pushes. 
- Switch the PR creation step to use `secrets.SELF_HEAL_TOKEN` (exposed as `SELF_HEAL_TOKEN`) instead of `secrets.GITHUB_TOKEN`. 
- Add an explicit runtime check that `SELF_HEAL_TOKEN` is set and fail early with a clear error if missing, and enable `set -euo pipefail` for the PR creation step. 
- Use an authenticated push URL (`https://x-access-token:${SELF_HEAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`) and set the commit author to `self-heal[bot]` before creating the PR so the push/pr are performed with the CI-capable token.

### Testing
- Ran `git diff --check` to validate formatting and whitespace (passed). 
- Parsed the modified workflow with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'` to ensure valid YAML (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4912db38832099bcabd3b5a42c06)