### PR TITLE
Propagate post-healthcheck failures through tee

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()


### PR DESCRIPTION
### Motivation
- Ensure the post-repair healthcheck step fails the job when `node scripts/healthcheck.mjs` exits non-zero, because piping into `tee` previously masked the exit status.

### Description
- Add `set -o pipefail` to the `Run healthcheck (post-repair)` step so the pipeline returns a non-zero exit code when `node scripts/healthcheck.mjs` fails (`run: |\n  set -o pipefail\n  node scripts/healthcheck.mjs | tee selfheal-post.txt`).

### Testing
- Ran `git diff --check` which completed successfully with no whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48ffa0348320871f6b475fe13f76)