### PR TITLE
Align self-heal with Python repo: remove Node-only checks, run pytest, and harden workflow

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,49 +16,52 @@ jobs:
   self-heal:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       !startsWith(github.event.workflow_run.head_branch, 'self-heal-fixes-'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout
+      - name: Checkout failed revision
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          version: 9
+          python-version: '3.x'
 
-      - name: Install deps (best-effort frozen)
-        id: install_try_frozen
+      - name: Install Python deps
         run: |
           set -euxo pipefail
-          pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
-
-      - name: Install deps (fallback non-frozen)
-        if: steps.install_try_frozen.outputs.FROZEN_FAILED == '1'
-        run: |
-          set -euxo pipefail
-          pnpm install
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          pip install pytest
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: |
+          set -o pipefail
+          node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()
@@ -75,11 +78,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
+          rm -f selfheal-pre.txt selfheal-repair.txt selfheal-post.txt
+          if [ -n "$(git status --porcelain -- . ':!node_modules')" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git checkout -b self-heal-fixes-${{ github.run_id }}
-            git add .
+            git add -- . ':!node_modules' ':!selfheal-*.txt'
             git commit -m "chore: self-heal auto-fixes"
             git push origin self-heal-fixes-${{ github.run_id }}
             gh pr create --title "Self-heal auto-fixes" --body "Auto-generated PR from self-healing workflow. See job logs for details." --label "self-heal"

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -8,12 +8,11 @@ on:
       - completed
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   actions: read
 
 jobs:
-  self-heal:
+  repair:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure' &&
@@ -21,12 +20,26 @@ jobs:
        !startsWith(github.event.workflow_run.head_branch, 'self-heal-fixes-'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      has_fixes: ${{ steps.patch.outputs.has_fixes }}
     steps:
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted
+          fetch-depth: 1
+
       - name: Checkout failed revision
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          path: work
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -39,6 +52,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python deps
+        working-directory: work
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip wheel setuptools
@@ -47,21 +61,38 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
+        working-directory: work
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          node ../trusted/scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
+        working-directory: work
         run: |
           set -o pipefail
-          node scripts/self-heal.mjs | tee selfheal-repair.txt
+          node ../trusted/scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
+        working-directory: work
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node ../trusted/scripts/healthcheck.mjs | tee selfheal-post.txt
+
+      - name: Build repair patch
+        id: patch
+        if: steps.post.outcome == 'success'
+        working-directory: work
+        run: |
+          set -euo pipefail
+          rm -f selfheal-pre.txt selfheal-repair.txt selfheal-post.txt
+          if git diff --quiet -- . ':!node_modules' ':!selfheal-*.txt'; then
+            echo "has_fixes=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff --binary -- . ':!node_modules' ':!selfheal-*.txt' > ../selfheal.patch
+            echo "has_fixes=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Collect logs
         if: always()
@@ -69,22 +100,55 @@ jobs:
         with:
           name: selfheal-logs
           path: |
-            selfheal-pre.txt
-            selfheal-repair.txt
-            selfheal-post.txt
+            work/selfheal-pre.txt
+            work/selfheal-repair.txt
+            work/selfheal-post.txt
+
+      - name: Upload repair patch
+        if: steps.patch.outputs.has_fixes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfheal-patch
+          path: selfheal.patch
+          if-no-files-found: error
+
+  create-pr:
+    needs: repair
+    if: needs.repair.outputs.has_fixes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Checkout failed revision for patch application
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Download repair patch
+        uses: actions/download-artifact@v4
+        with:
+          name: selfheal-patch
 
       - name: Create PR with fixes
-        if: steps.post.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          FIX_BRANCH: self-heal-fixes-${{ github.run_id }}
         run: |
-          rm -f selfheal-pre.txt selfheal-repair.txt selfheal-post.txt
-          if [ -n "$(git status --porcelain -- . ':!node_modules')" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b self-heal-fixes-${{ github.run_id }}
-            git add -- . ':!node_modules' ':!selfheal-*.txt'
-            git commit -m "chore: self-heal auto-fixes"
-            git push origin self-heal-fixes-${{ github.run_id }}
-            gh pr create --title "Self-heal auto-fixes" --body "Auto-generated PR from self-healing workflow. See job logs for details." --label "self-heal"
+          set -euo pipefail
+          git apply --index selfheal.patch
+          rm -f selfheal.patch
+          if git diff --cached --quiet; then
+            echo "Repair patch produced no staged changes; skipping PR creation."
+            exit 0
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$FIX_BRANCH"
+          git commit -m "chore: self-heal auto-fixes"
+          git push origin "$FIX_BRANCH"
+          gh pr create --base "$BASE_BRANCH" --head "$FIX_BRANCH" --title "Self-heal auto-fixes" --body "Auto-generated PR from self-healing workflow. See job logs for details." --label "self-heal"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
-    "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
-    "format": "prettier -w .",
-    "typecheck": "tsc -b",
-    "test": "vitest run"
+    "self:heal": "node scripts/self-heal.mjs"
   }
 }

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,50 +1,20 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
-*/
+/* Repository healthcheck aligned with the existing Python CI workflow. */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
 
-const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
-};
+const checks = [
+  ["Python tests", "python -m pytest -q"],
+];
 
-const tryRun = (name, cmd) => {
-  if (!cmd) return;
+let failed = false;
+
+for (const [name, cmd] of checks) {
   console.log(`\n==> ${name}`);
-  run(cmd);
-};
-
-try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
-
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
-    }
+  try {
+    execSync(cmd, { stdio: "inherit" });
+  } catch {
+    failed = true;
   }
-  process.exit(process.exitCode ?? 0);
-} catch (e) {
-  console.error(e);
-  process.exit(1);
 }
+
+process.exit(failed ? 1 : 0);

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -5,6 +5,12 @@
  */
 import { execSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const healthcheckPath = join(scriptDir, "healthcheck.mjs");
+const shellQuote = (value) => `'${value.replaceAll("'", "'\\''")}'`;
 
 const sh = (cmd, opts = {}) => {
   console.log(`\n$ ${cmd}`);
@@ -26,7 +32,7 @@ const changed = () => getStatus() !== initialStatus;
 
 const passHealth = () => {
   try {
-    sh("node scripts/healthcheck.mjs");
+    sh(`node ${shellQuote(healthcheckPath)}`);
     return true;
   } catch {
     return false;

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -1,72 +1,58 @@
 #!/usr/bin/env node
-/* Targeted, ordered repairs. Each step is idempotent and re-runs healthcheck.
-   Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
-*/
+/*
+ * Targeted, ordered repairs for this Python repository.
+ * Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
+ */
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 
-const sh = (cmd, opts={}) => {
+const sh = (cmd, opts = {}) => {
   console.log(`\n$ ${cmd}`);
   return execSync(cmd, { stdio: "inherit", ...opts });
 };
-const trySh = (cmd, opts={}) => {
-  try { sh(cmd, opts); return true; } catch { return false; }
+
+const trySh = (cmd, opts = {}) => {
+  try {
+    sh(cmd, opts);
+    return true;
+  } catch {
+    return false;
+  }
 };
-const changed = () => {
-  const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
-  return (out.stdout || "").trim().length > 0;
-};
+
+const getStatus = () => spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" }).stdout || "";
+const initialStatus = getStatus();
+const changed = () => getStatus() !== initialStatus;
+
 const passHealth = () => {
-  try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
+  try {
+    sh("node scripts/healthcheck.mjs");
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 let fixed = false;
 
-// 1) Lint/format
-trySh("pnpm -w run lint --fix");
-trySh("pnpm -w run format");
-if (passHealth()) fixed = fixed || changed();
-
-// 2) Snapshot updates (only if tests fail with snapshots)
-if (!passHealth()) {
-  trySh("pnpm -w exec vitest -u");
+// 1) If optional Python formatters are available, let them normalize the tree.
+for (const cmd of ["python -m ruff check --fix .", "python -m ruff format .", "python -m black ."]) {
+  trySh(cmd);
   if (passHealth()) fixed = fixed || changed();
 }
 
-// 3) Type acquisition
-if (!passHealth()) {
-  trySh("pnpm dlx typesync --save-dev");
-  // In case typesync suggests @types/node et al.
-  trySh("pnpm -w install");
-  if (passHealth()) fixed = fixed || changed();
-}
-
-// 4) Lockfile repair (only if integrity complaints)
-if (!passHealth()) {
-  // Try a clean install + re-resolve
-  trySh("pnpm install");
-  if (!passHealth()) {
-    // Last resort: refresh lockfile (scoped)
-    trySh("pnpm -w up --latest --interactive=false");
+// 2) Known generators, if present.
+for (const script of ["scripts/update-icon-docs.mjs", "scripts/verify-static.mjs"]) {
+  if (!passHealth() && existsSync(script)) {
+    trySh(`node ${script}`);
+    if (passHealth()) fixed = fixed || changed();
   }
-  if (passHealth()) fixed = fixed || changed();
-}
-
-// 5) Known generators (icons/docs), if present
-if (!passHealth()) {
-  if (existsSync("scripts/update-icon-docs.mjs")) {
-    trySh("node scripts/update-icon-docs.mjs");
-  }
-  if (existsSync("scripts/verify-static.mjs")) {
-    trySh("node scripts/verify-static.mjs");
-  }
-  if (passHealth()) fixed = fixed || changed();
 }
 
 if (fixed) {
   console.log("Self-heal successful and produced a diff.");
   process.exit(0);
-} else {
-  console.log("Self-heal failed or no changes were needed.");
-  process.exit(1);
 }
+
+console.log("Self-heal failed or no changes were needed.");
+process.exit(1);


### PR DESCRIPTION
### Motivation
- The repository is Python-first but the added self-heal/tooling assumed a pnpm/TypeScript workspace and advertised Node checks that don't apply here, causing healthchecks to fail on CI.
- The self-heal workflow needed hardening to avoid checking out the wrong SHA, leaking generated artifacts into commits, and masking failures when piping logs through `tee`.

### Description
- Removed root `lint`, `format`, `typecheck`, and `test` scripts from `package.json` so the repo no longer advertises TypeScript/Vitest/ESLint/Prettier checks without configuration. (`package.json`).
- Replaced the pnpm/monorepo `scripts/healthcheck.mjs` with a lightweight healthcheck that runs the repo's Python test command (`python -m pytest -q`). (`scripts/healthcheck.mjs`).
- Rewrote `scripts/self-heal.mjs` to perform Python-oriented repairs only, capture initial git status and compare after fixes, and avoid pnpm/type acquisition/lockfile logic. (`scripts/self-heal.mjs`).
- Updated `.github/workflows/self-heal.yml` to check out the failing revision (`github.event.workflow_run.head_sha`), install Python dependencies instead of pnpm, enable `pipefail` for steps that pipe into `tee`, skip committing `node_modules` and `selfheal-*.txt`, and avoid running on self-heal-generated branches. (`.github/workflows/self-heal.yml`).

### Testing
- Ran `git diff --check` to validate whitespace/formatting (passed).
- Parsed `package.json` and `.github/workflows/self-heal.yml` with Python (`json.loads` / `yaml.safe_load`) to ensure syntactic validity (passed).
- Executed the new healthcheck via `node scripts/healthcheck.mjs` which invokes `python -m pytest -q`; an initial run failed due to local `pyenv` selecting an unavailable Python version (diagnostic). After setting `PYENV_VERSION=3.12.13` the environment installed package dependencies and ran the test suite, which exercised pytest but reported one failing test: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` (failing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48e87e1883209c9b85656dde221d)