### PR TITLE
Fix self-heal pnpm setup ordering

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -25,16 +25,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Install deps (best-effort frozen)
         id: install_try_frozen


### PR DESCRIPTION
### Motivation
- Prevent the self-heal workflow from attempting to configure a `pnpm` cache before `pnpm` is installed (which can fail on fresh runners or when no `pnpm-lock.yaml` is present). 

### Description
- Move `pnpm/action-setup@v4` to run before `actions/setup-node@v4` and remove the `cache: 'pnpm'` option from `actions/setup-node` in `.github/workflows/self-heal.yml` so the workflow does not query/configure pnpm cache before pnpm is available. 

### Testing
- Ran `git diff --check` to validate the patch formatting and it succeeded. 
- Verified no remaining `cache: 'pnpm'` occurrences with `rg "cache: 'pnpm'|cache: \"pnpm\"" .github/workflows/self-heal.yml` and it returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48d8f274832098545e94fa084af4)