### PR TITLE
Propagate self-heal tee pipeline failures

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -50,15 +50,21 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: |
+          set -o pipefail
+          node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()


### PR DESCRIPTION
### Motivation
- Ensure failures from the Node healthcheck/self-heal scripts are not masked by `tee` so the workflow steps and the PR creation gate reflect real exit codes.

### Description
- Add `set -o pipefail` to the workflow `run` blocks that pipe `node scripts/healthcheck.mjs` and `node scripts/self-heal.mjs` into `tee` for the pre-repair, repair, and post-repair steps.

### Testing
- Confirmed the modified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'` and ran `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48d64d1083208f7570a7257a1981)