### PR TITLE
Align healthcheck with repo CI: run pytest suite

### DIFF
--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,50 +1,48 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Healthcheck aligned with .github/workflows/ci.yml:
+   - install the Python package in editable mode
+   - install pytest
+   - run the same pytest suite used by CI
 */
-import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
 
-const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
-  try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
-};
+const pythonCandidates = [
+  process.env.PYTHON,
+  process.platform === "win32" ? "python" : "python3",
+  "python",
+].filter(Boolean);
 
-const tryRun = (name, cmd) => {
-  if (!cmd) return;
-  console.log(`\n==> ${name}`);
-  run(cmd);
-};
+const python = pythonCandidates.find((candidate, index, candidates) => {
+  if (candidates.indexOf(candidate) !== index) return false;
+  const result = spawnSync(candidate, ["--version"], { stdio: "pipe" });
+  return result.status === 0;
+});
 
-try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
-
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
-    }
-  }
-  process.exit(process.exitCode ?? 0);
-} catch (e) {
-  console.error(e);
+if (!python) {
+  console.error("[healthcheck] Could not find a usable Python interpreter.");
   process.exit(1);
 }
+
+const runCheck = (name, args) => {
+  console.log(`\n==> ${name}`);
+  try {
+    execFileSync(python, args, { stdio: "inherit" });
+  } catch {
+    process.exitCode = 1;
+  }
+};
+
+runCheck("Upgrade Python packaging tools", [
+  "-m",
+  "pip",
+  "install",
+  "--upgrade",
+  "pip",
+  "wheel",
+  "setuptools",
+]);
+runCheck("Install package", ["-m", "pip", "install", "-e", "."]);
+runCheck("Install pytest", ["-m", "pip", "install", "pytest"]);
+runCheck("Python test suite", ["-m", "pytest", "-q"]);
+
+process.exit(process.exitCode ?? 0);

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 /* Healthcheck aligned with .github/workflows/ci.yml:
+   - create an isolated Python virtual environment
    - install the Python package in editable mode
    - install pytest
    - run the same pytest suite used by CI
 */
 import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const MIN_PYTHON_VERSION = [3, 8];
 
 const pythonCandidates = [
   process.env.PYTHON,
@@ -12,37 +18,74 @@ const pythonCandidates = [
   "python",
 ].filter(Boolean);
 
+const isSupportedPython = (candidate) => {
+  const result = spawnSync(
+    candidate,
+    [
+      "-c",
+      `import sys; sys.exit(0 if sys.version_info >= ` +
+        `(${MIN_PYTHON_VERSION[0]}, ${MIN_PYTHON_VERSION[1]}) else 1)`,
+    ],
+    { stdio: "pipe" },
+  );
+  return result.status === 0;
+};
+
+const hasVenvModule = (candidate) => {
+  const result = spawnSync(candidate, ["-m", "venv", "--help"], { stdio: "pipe" });
+  return result.status === 0;
+};
+
 const python = pythonCandidates.find((candidate, index, candidates) => {
   if (candidates.indexOf(candidate) !== index) return false;
-  const result = spawnSync(candidate, ["--version"], { stdio: "pipe" });
-  return result.status === 0;
+  return isSupportedPython(candidate) && hasVenvModule(candidate);
 });
 
 if (!python) {
-  console.error("[healthcheck] Could not find a usable Python interpreter.");
+  console.error(
+    `[healthcheck] Could not find a Python ${MIN_PYTHON_VERSION.join(".")}+ interpreter with the venv module.`,
+  );
   process.exit(1);
 }
 
-const runCheck = (name, args) => {
+const venvDir = mkdtempSync(join(tmpdir(), "html2md-healthcheck-"));
+const venvPython = join(
+  venvDir,
+  process.platform === "win32" ? "Scripts/python.exe" : "bin/python",
+);
+
+const runCommand = (command, args) => {
+  execFileSync(command, args, { stdio: "inherit" });
+};
+
+const runCheck = (name, command, args) => {
   console.log(`\n==> ${name}`);
   try {
-    execFileSync(python, args, { stdio: "inherit" });
-  } catch {
+    runCommand(command, args);
+  } catch (error) {
+    const status =
+      typeof error.status === "number" ? ` (exit ${error.status})` : "";
+    console.error(`[healthcheck] ${name} failed${status}: ${error.message}`);
     process.exitCode = 1;
   }
 };
 
-runCheck("Upgrade Python packaging tools", [
-  "-m",
-  "pip",
-  "install",
-  "--upgrade",
-  "pip",
-  "wheel",
-  "setuptools",
-]);
-runCheck("Install package", ["-m", "pip", "install", "-e", "."]);
-runCheck("Install pytest", ["-m", "pip", "install", "pytest"]);
-runCheck("Python test suite", ["-m", "pytest", "-q"]);
+try {
+  runCheck("Create isolated Python virtual environment", python, ["-m", "venv", venvDir]);
+  runCheck("Upgrade Python packaging tools", venvPython, [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    "pip",
+    "wheel",
+    "setuptools",
+  ]);
+  runCheck("Install package", venvPython, ["-m", "pip", "install", "-e", "."]);
+  runCheck("Install pytest", venvPython, ["-m", "pip", "install", "pytest"]);
+  runCheck("Python test suite", venvPython, ["-m", "pytest", "-q"]);
+} finally {
+  rmSync(venvDir, { force: true, recursive: true });
+}
 
 process.exit(process.exitCode ?? 0);

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -35,10 +35,10 @@ const hasVenvModule = (candidate) => {
   const result = spawnSync(candidate, ["-m", "venv", "--help"], { stdio: "pipe" });
   return result.status === 0;
 };
-
 const python = pythonCandidates.find((candidate, index, candidates) => {
   if (candidates.indexOf(candidate) !== index) return false;
-  return isSupportedPython(candidate) && hasVenvModule(candidate);
+  const result = spawnSync(candidate, ["-c", "import sys; print(sys.version_info >= (3, 8))"], { stdio: "pipe" });
+  return result.status === 0 && result.stdout?.toString().trim() === "True";
 });
 
 if (!python) {


### PR DESCRIPTION
### Motivation

- The existing healthcheck ran pnpm/vitest checks that did not match this repository's CI, which runs `pytest`, so self-heal could claim success without validating the actual failing test suite. 
- Make the healthcheck reproduce the CI signal and continue through diagnostic steps while recording failures so all checks run and surface real issues.

### Description

- Replace the pnpm/vitest-oriented logic with Python-focused steps that upgrade packaging tools, install the package in editable mode, install `pytest`, and run the repository test suite via `python -m pytest -q` in `scripts/healthcheck.mjs`.
- Add Python interpreter discovery that respects a `PYTHON` override and falls back to `python3`/`python` as appropriate, and switch to `execFileSync` to invoke Python commands.
- Make each check non-fatal by setting `process.exitCode = 1` on failures so the script continues running all diagnostic steps and reports a summary exit code, and remove the workspace pnpm build/discovery logic that was not applicable to this repo.

### Testing

- Ran `node --check scripts/healthcheck.mjs` and it completed without syntax errors.
- Ran `git diff --check` to validate the working tree and it reported no whitespace/patch issues.
- Executed the healthcheck with `PYTHON=/root/.pyenv/versions/3.12.13/bin/python node scripts/healthcheck.mjs`, which ran the CI `pytest` suite and correctly revealed an existing failing test: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` (test failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48c850648320abf871b1df783576)