### PR TITLE
Disable pnpm setup-node cache without lockfile

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
### Motivation
- `actions/setup-node` was configured with `cache: 'pnpm'` but the repository does not include a `pnpm-lock.yaml`, which can cause the `Use Node.js` step to fail before pnpm is installed.

### Description
- Removed the `cache: 'pnpm'` line from the `actions/setup-node@v4` step in `.github/workflows/self-heal.yml` so the workflow no longer depends on a committed pnpm lockfile before pnpm is set up.

### Testing
- Ran `git diff --check` to validate the change and it completed without reporting whitespace or formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48bdc29483209717aa7e73c87a05)