### PR TITLE
Fix self-heal to work for this non-workspace repo and harden workflow

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -8,12 +8,11 @@ on:
       - completed
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   actions: read
 
 jobs:
-  self-heal:
+  repair:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure' &&
@@ -22,12 +21,34 @@ jobs:
        !startsWith(github.event.workflow_run.head_branch, 'self-heal-fixes-'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      has_changes: ${{ steps.diff.outputs.has_changes }}
+      target_sha: ${{ steps.target.outputs.sha }}
     steps:
+      - name: Resolve target revision
+        id: target
+        run: |
+          set -euo pipefail
+          echo "sha=${{ github.event.workflow_run.head_sha || github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted
+          persist-credentials: false
+
       - name: Checkout failed revision
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ steps.target.outputs.sha }}
+          path: target
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -45,6 +66,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python deps
+        working-directory: target
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip wheel setuptools
@@ -53,34 +75,39 @@ jobs:
 
       - name: Install Node deps (best-effort frozen)
         id: install_try_frozen
+        working-directory: target
         run: |
           set -euxo pipefail
-          pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
+          pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> "$GITHUB_OUTPUT"
 
       - name: Install Node deps (fallback non-frozen)
         if: steps.install_try_frozen.outputs.FROZEN_FAILED == '1'
+        working-directory: target
         run: |
           set -euxo pipefail
           pnpm install
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
+        working-directory: target
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          node ../trusted/scripts/healthcheck.mjs | tee ../selfheal-pre.txt
 
       - name: Attempt self-heal repairs
         continue-on-error: true
+        working-directory: target
         run: |
           set -o pipefail
-          node scripts/self-heal.mjs | tee selfheal-repair.txt
+          node ../trusted/scripts/self-heal.mjs | tee ../selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
+        working-directory: target
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node ../trusted/scripts/healthcheck.mjs | tee ../selfheal-post.txt
 
       - name: Collect logs
         if: always()
@@ -92,18 +119,66 @@ jobs:
             selfheal-repair.txt
             selfheal-post.txt
 
-      - name: Create PR with fixes
+      - name: Build sanitized patch
+        id: diff
         if: steps.post.outcome == 'success'
+        run: |
+          set -euo pipefail
+          git -C target diff --binary -- \
+            . \
+            ':(exclude)node_modules' \
+            ':(exclude)selfheal-*.txt' \
+            ':(exclude).github/workflows/**' \
+            > selfheal.patch
+          if [ -s selfheal.patch ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload sanitized patch
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfheal-patch
+          path: selfheal.patch
+
+  create-pr:
+    needs: repair
+    if: needs.repair.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout failed revision without credentials
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.repair.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Download sanitized patch
+        uses: actions/download-artifact@v4
+        with:
+          name: selfheal-patch
+
+      - name: Create PR with fixes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          rm -rf node_modules selfheal-*.txt
+          set -euo pipefail
+          git apply --check selfheal.patch
+          git apply selfheal.patch
+          rm selfheal.patch
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b self-heal-fixes-${{ github.run_id }}
-            git add . ':!node_modules' ':!selfheal-*.txt'
+            branch="self-heal-fixes-${{ github.run_id }}"
+            git checkout -b "$branch"
+            git add .
             git commit -m "chore: self-heal auto-fixes"
-            git push origin self-heal-fixes-${{ github.run_id }}
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$branch"
             gh pr create --title "Self-heal auto-fixes" --body "Auto-generated PR from self-healing workflow. See job logs for details." --label "self-heal"
           fi

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,33 +16,48 @@ jobs:
   self-heal:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       !startsWith(github.event.workflow_run.head_branch, 'self-heal-fixes-'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout
+      - name: Checkout failed revision
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
-      - name: Install deps (best-effort frozen)
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python deps
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          pip install pytest
+
+      - name: Install Node deps (best-effort frozen)
         id: install_try_frozen
         run: |
           set -euxo pipefail
           pnpm install --frozen-lockfile || echo "FROZEN_FAILED=1" >> $GITHUB_OUTPUT
 
-      - name: Install deps (fallback non-frozen)
+      - name: Install Node deps (fallback non-frozen)
         if: steps.install_try_frozen.outputs.FROZEN_FAILED == '1'
         run: |
           set -euxo pipefail
@@ -50,15 +65,22 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()
@@ -75,11 +97,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          rm -rf node_modules selfheal-*.txt
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git checkout -b self-heal-fixes-${{ github.run_id }}
-            git add .
+            git add . ':!node_modules' ':!selfheal-*.txt'
             git commit -m "chore: self-heal auto-fixes"
             git push origin self-heal-fixes-${{ github.run_id }}
             gh pr create --title "Self-heal auto-fixes" --body "Auto-generated PR from self-healing workflow. See job logs for details." --label "self-heal"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "healthcheck": "node scripts/healthcheck.mjs",
-    "self:heal": "node scripts/self-heal.mjs",
-    "lint": "eslint .",
-    "format": "prettier -w .",
-    "typecheck": "tsc -b",
-    "test": "vitest run"
+    "self:heal": "node scripts/self-heal.mjs"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -1,50 +1,67 @@
 #!/usr/bin/env node
-/* Minimal, opinionated healthcheck for a pnpm monorepo:
-   - root: typecheck? test? lint? build?
-   - workspaces: smoke build where available
+/* Repository healthcheck for self-heal automation.
+   Mirrors the existing CI signal first (Python pytest), then runs any
+   explicitly configured root/package Node checks without assuming a pnpm
+   workspace or using workspace-only pnpm flags.
 */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-const run = (cmd) => execSync(cmd, { stdio: "inherit" });
-const hasScript = (name) => {
+const run = (cmd, opts = {}) => execSync(cmd, { stdio: "inherit", ...opts });
+
+const readPackage = (pkgPath) => {
   try {
-    const out = execSync("pnpm run -r", { stdio: "pipe" }).toString();
-    return out.includes(name);
-  } catch { return false; }
+    return JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    return null;
+  }
 };
 
-const tryRun = (name, cmd) => {
+const rootPackage = readPackage("package.json") ?? {};
+const hasRootScript = (name) => !!rootPackage.scripts?.[name];
+const hasPackageScript = (dir, name) => {
+  const pkg = readPackage(join(dir, "package.json"));
+  return !!pkg?.scripts?.[name];
+};
+const python = process.env.PYTHON ?? (process.platform === "win32" ? "python" : "python3");
+const pythonEnv = {
+  ...process.env,
+  LANG: "C",
+  LANGUAGE: "C",
+  LC_ALL: "C",
+  LC_MESSAGES: "C",
+};
+
+const tryRun = (name, cmd, opts = {}) => {
   if (!cmd) return;
   console.log(`\n==> ${name}`);
-  run(cmd);
+  try {
+    run(cmd, opts);
+  } catch {
+    process.exitCode = 1;
+  }
 };
 
-try {
-  // Root-level checks (best-effort if scripts exist)
-  tryRun("Typecheck", hasScript("typecheck") ? "pnpm -w run typecheck" : null);
-  tryRun("Lint", hasScript("lint") ? "pnpm -w run lint" : null);
-  tryRun("Unit tests", hasScript("test") ? "pnpm -w run test -- --run" : null);
+// Match the repository's existing CI workflow.
+tryRun("Python tests", existsSync("tests") ? `${python} -m pytest -q` : null, { env: pythonEnv });
 
-  // Workspace smoke builds (apps/* and packages/* if build exists)
-  const roots = ["apps", "packages"];
-  for (const base of roots) {
+// Root-level JavaScript checks, if this repository later opts into them.
+tryRun("Typecheck", hasRootScript("typecheck") ? "pnpm run typecheck" : null);
+tryRun("Lint", hasRootScript("lint") ? "pnpm run lint" : null);
+tryRun("Unit tests", hasRootScript("test") ? "pnpm run test" : null);
+tryRun("Build", hasRootScript("build") ? "pnpm run build" : null);
+
+// Workspace smoke builds are only meaningful in an actual pnpm workspace.
+if (existsSync("pnpm-workspace.yaml")) {
+  for (const base of ["apps", "packages"]) {
     if (!existsSync(base)) continue;
     for (const name of readdirSync(base)) {
       const dir = join(base, name);
-      if (!statSync(dir).isDirectory()) continue;
-      try {
-        execSync("pnpm run -s build", { cwd: dir, stdio: "inherit" });
-      } catch (e) {
-        console.error(`[healthcheck] build failed in ${dir}`);
-        process.exitCode = 1;
-      }
+      if (!statSync(dir).isDirectory() || !hasPackageScript(dir, "build")) continue;
+      tryRun(`Build ${dir}`, "pnpm run -s build", { cwd: dir });
     }
   }
-  process.exit(process.exitCode ?? 0);
-} catch (e) {
-  console.error(e);
-  process.exit(1);
 }
+
+process.exit(process.exitCode ?? 0);

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -3,7 +3,7 @@
    Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
 */
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const sh = (cmd, opts={}) => {
   console.log(`\n$ ${cmd}`);
@@ -12,9 +12,16 @@ const sh = (cmd, opts={}) => {
 const trySh = (cmd, opts={}) => {
   try { sh(cmd, opts); return true; } catch { return false; }
 };
-const changed = () => {
-  const out = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
-  return (out.stdout || "").trim().length > 0;
+const getStatus = () => spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" }).stdout || "";
+const initialStatus = getStatus();
+const changed = () => getStatus() !== initialStatus;
+const hasRootScript = (name) => {
+  try {
+    const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+    return !!pkg.scripts?.[name];
+  } catch {
+    return false;
+  }
 };
 const passHealth = () => {
   try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
@@ -23,13 +30,13 @@ const passHealth = () => {
 let fixed = false;
 
 // 1) Lint/format
-trySh("pnpm -w run lint --fix");
-trySh("pnpm -w run format");
+if (hasRootScript("lint")) trySh("pnpm run lint -- --fix");
+if (hasRootScript("format")) trySh("pnpm run format");
 if (passHealth()) fixed = fixed || changed();
 
 // 2) Snapshot updates (only if tests fail with snapshots)
 if (!passHealth()) {
-  trySh("pnpm -w exec vitest -u");
+  trySh("pnpm exec vitest -u");
   if (passHealth()) fixed = fixed || changed();
 }
 
@@ -37,7 +44,7 @@ if (!passHealth()) {
 if (!passHealth()) {
   trySh("pnpm dlx typesync --save-dev");
   // In case typesync suggests @types/node et al.
-  trySh("pnpm -w install");
+  trySh("pnpm install");
   if (passHealth()) fixed = fixed || changed();
 }
 
@@ -47,7 +54,7 @@ if (!passHealth()) {
   trySh("pnpm install");
   if (!passHealth()) {
     // Last resort: refresh lockfile (scoped)
-    trySh("pnpm -w up --latest --interactive=false");
+    trySh("pnpm install --lockfile-only");
   }
   if (passHealth()) fixed = fixed || changed();
 }

--- a/scripts/self-heal.mjs
+++ b/scripts/self-heal.mjs
@@ -4,6 +4,10 @@
 */
 import { execSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const shellQuote = (value) => `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+const healthcheckScript = fileURLToPath(new URL("./healthcheck.mjs", import.meta.url));
 
 const sh = (cmd, opts={}) => {
   console.log(`\n$ ${cmd}`);
@@ -24,7 +28,12 @@ const hasRootScript = (name) => {
   }
 };
 const passHealth = () => {
-  try { sh("node scripts/healthcheck.mjs"); return true; } catch { return false; }
+  try {
+    sh(`${shellQuote(process.execPath)} ${shellQuote(healthcheckScript)}`);
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 let fixed = false;


### PR DESCRIPTION
### Motivation
- The new healthcheck assumed a pnpm workspace and ran `pnpm -w` which fails in this repository and blocks self-heal from validating fixes.  
- The repo's CI signal is Python `pytest`, so the healthcheck must mirror that rather than always running Node workspace checks.  
- The self-heal workflow needed hardening to avoid running untrusted fork code, leaking artifacts into PRs, and masking failures when piping to `tee`.

### Description
- Updated `scripts/healthcheck.mjs` to run the repo's Python test suite first (`pytest`), parse the root `package.json` directly to discover optional root scripts, avoid `pnpm -w`/workspace-only flags, and only attempt workspace builds when `pnpm-workspace.yaml` is present.  
- Revised `scripts/self-heal.mjs` to remove unused imports, capture an initial `git status` baseline and detect real diffs, avoid workspace-only `pnpm` flags, only run lint/format when root scripts exist, and replace aggressive `pnpm -w up --latest` with a safer lockfile-only regeneration fallback.  
- Hardened `.github/workflows/self-heal.yml` to check out the failed revision (`workflow_run.head_sha` or `github.sha`), restrict `workflow_run` healing to same-repo `push` runs and skip self-heal branches, remove pnpm caching without a lockfile, install Python deps to reproduce CI, enable `set -o pipefail` for steps that pipe to `tee`, and exclude generated artifacts/node_modules from auto-fix commits.  
- Simplified `package.json` scripts to only expose `healthcheck`/`self:heal` in this Python repo and added a minimal `pnpm-lock.yaml` so frozen installs behave deterministically in the workflow.

### Testing
- Ran `pnpm install --frozen-lockfile` on the workspace and it completed successfully. (Succeeded)  
- Executed the healthcheck via `PYTHON="PYENV_VERSION=3.11.15 python" pnpm run healthcheck` which ran the python test step and returned the expected results. (Succeeded)  
- Ran the upstream test suite with `LC_ALL=C PYENV_VERSION=3.11.15 python -m pytest -q` and all tests passed. (Succeeded)  
- Performed static checks with `node --check scripts/healthcheck.mjs` and `node --check scripts/self-heal.mjs` to validate script syntax. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48b215788320a02ee20b43a8b163)