### PR TITLE
Fix batch output directory Windows quoting

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -8,6 +8,18 @@ WPF GUI for html2md
 
 param([string]$BatchFile, [string]$BatchOutDir, [switch]$BatchWholePage)
 
+
+function ConvertTo-WindowsCommandLineArgument {
+    param([string]$Argument)
+
+    if ($null -eq $Argument) { return '""' }
+
+    # Windows native command-line parsing treats backslashes before quotes specially.
+    # Escape embedded quotes and double terminal backslashes so they cannot escape
+    # the closing quote (for example, C:\ remains a single quoted argument).
+    return '"' + ($Argument -replace '(\\*)"', '$1$1\"' -replace '(\\+)$', '$1$1') + '"'
+}
+
 if ($BatchFile) {
     if (-not (Test-Path -LiteralPath $BatchFile)) {
         Write-Error "Batch file not found: $BatchFile"
@@ -362,11 +374,11 @@ $ConvertBtn.Add_Click({
         $tempFile = [System.IO.Path]::GetTempFileName()
         $urlList | Set-Content -Path $tempFile
 
-        # Sanitize for -File arguments by using double quotes to handle spaces
-        # Windows command line splitting treates " as the primary quote character.
-        $safeCommandPath = "`"$PSCommandPath`""
-        $safeTempFile = "`"$tempFile`""
-        $safeOutDir = "`"$outdir`""
+        # Quote -File arguments for Windows native command-line parsing. This preserves
+        # spaces and trailing backslashes (for example, C:\) as literal argument text.
+        $safeCommandPath = ConvertTo-WindowsCommandLineArgument $PSCommandPath
+        $safeTempFile = ConvertTo-WindowsCommandLineArgument $tempFile
+        $safeOutDir = ConvertTo-WindowsCommandLineArgument $outdir
 
         # Relaunch this script in batch mode
         # Use -File with double-quoted paths for robust Windows command-line handling


### PR DESCRIPTION
### Motivation
- Batch-mode relaunch was vulnerable to Windows native command-line parsing where a trailing backslash (e.g. `C:\`) could escape a closing quote and corrupt the `-BatchOutDir` argument, breaking multi-URL conversions.

### Description
- Added a helper function `ConvertTo-WindowsCommandLineArgument` in `gui-url-convert.ps1` that wraps an argument in double quotes and escapes embedded quotes and terminal backslashes for Windows native command-line parsing.
- Updated the batch relaunch logic to use `ConvertTo-WindowsCommandLineArgument` for `-File`, `-BatchFile`, and `-BatchOutDir` so paths with spaces and trailing backslashes are preserved when re-invoking `powershell.exe`.

### Testing
- Ran `git diff --check` to ensure no whitespace/syntax diffs were introduced and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0006992f5083209bbad67ad38732ee)