### PR TITLE
Fix GUI single-URL PowerShell command parsing

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -347,10 +347,17 @@ $ConvertBtn.Add_Click({
         }
     }
 
+    function ConvertTo-PowerShellSingleQuotedLiteral {
+        param([string]$Value)
+
+        return "'" + ($Value -replace "'", "''") + "'"
+    }
+
     # Use a robust way to launch the process:
     # 1. Revert to ProcessStartInfo for precise control over the command line.
     # 2. Use powershell.exe to keep the window open with -NoExit.
-    # 3. Use -File for batch mode and -Command with proper quoting for single URL mode.
+    # 3. Use -File for batch mode and for temporary single-URL launch scripts so URLs
+    #    are passed as data instead of being re-parsed by powershell.exe -Command.
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = "powershell.exe"
     $psi.WorkingDirectory = $scriptDir
@@ -363,7 +370,7 @@ $ConvertBtn.Add_Click({
         $urlList | Set-Content -Path $tempFile
 
         # Sanitize for -File arguments by using double quotes to handle spaces
-        # Windows command line splitting treates " as the primary quote character.
+        # Windows command-line splitting treats " as the primary quote character.
         $safeCommandPath = "`"$PSCommandPath`""
         $safeTempFile = "`"$tempFile`""
         $safeOutDir = "`"$outdir`""
@@ -377,24 +384,25 @@ $ConvertBtn.Add_Click({
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
-        # If Whole Page is unchecked, we add the flag to ignore headers/footers
-        $optArg = if (-not $WholePageChk.IsChecked) { " --main-content" } else { "" }
-
-        # Sanitize inputs for PowerShell -Command interpolation.
-        # We use double quotes around arguments and escape internal double quotes, dollar signs,
-        # and backticks with the PowerShell escape character (backtick) to prevent subexpression execution.
-        $safeUrl = $url -replace '["$`]', '`$0'
-        $safeOutDir = $outdir -replace '["$`]', '`$0'
-        $safeVenvExe = $venvExe -replace '["$`]', '`$0'
-        $safePyScript = $pyScript -replace '["$`]', '`$0'
+        $singleUrlScript = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), ".ps1")
+        $urlLiteral = ConvertTo-PowerShellSingleQuotedLiteral $url
+        $outDirLiteral = ConvertTo-PowerShellSingleQuotedLiteral $outdir
+        $optArgs = @()
+        if (-not $WholePageChk.IsChecked) { $optArgs += "--main-content" }
 
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -Command `"& `"$safeVenvExe`" --url `"$safeUrl`" --outdir `"$safeOutDir`" --all-formats$optArg`""
+            $exeLiteral = ConvertTo-PowerShellSingleQuotedLiteral $venvExe
+            $launchLines = @(
+                "& $exeLiteral --url $urlLiteral --outdir $outDirLiteral --all-formats"
+            )
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -Command `"& $pyCmd `"$safePyScript`" --url `"$safeUrl`" --outdir `"$safeOutDir`" --all-formats$optArg`""
+            $pyScriptLiteral = ConvertTo-PowerShellSingleQuotedLiteral $pyScript
+            $launchLines = @(
+                "& $pyCmd $pyScriptLiteral --url $urlLiteral --outdir $outDirLiteral --all-formats"
+            )
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."
@@ -404,6 +412,13 @@ $ConvertBtn.Add_Click({
             $ProgressBar.IsIndeterminate = $false
             return
         }
+
+        if ($optArgs.Count -gt 0) {
+            $launchLines[0] += " " + ($optArgs -join " ")
+        }
+        $launchLines | Set-Content -LiteralPath $singleUrlScript -Encoding UTF8
+        $safeSingleUrlScript = "`"$singleUrlScript`""
+        $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File $safeSingleUrlScript"
     }
     
     $LogBox.AppendText("Executing process...`r`n")

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -412,7 +412,7 @@ $ConvertBtn.Add_Click({
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
-        $singleUrlScript = Join-Path $env:TEMP ("html2md-" + [System.Guid]::NewGuid().ToString() + ".ps1")
+        $singleUrlScript = Join-Path ([System.IO.Path]::GetTempPath()) ("html2md-" + [System.Guid]::NewGuid().ToString() + ".ps1")
         $urlLiteral = ConvertTo-PowerShellSingleQuotedLiteral $url
         $outDirLiteral = ConvertTo-PowerShellSingleQuotedLiteral $outdir
         $optArgs = @()
@@ -445,7 +445,7 @@ $ConvertBtn.Add_Click({
             $launchLines[0] += " " + ($optArgs -join " ")
         }
         # Self-delete at end of wrapper so the temp script is cleaned up after the tool runs
-        $launchLines += "Remove-Item -LiteralPath `$MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyContinue"
+        $launchLines += "try { Remove-Item -LiteralPath `$MyInvocation.MyCommand.Path -Force -ErrorAction Stop } catch { Write-Warning `"Could not delete temporary script: `$_`" }"
         $launchLines | Set-Content -LiteralPath $singleUrlScript -Encoding UTF8
         $safeSingleUrlScript = "`"$singleUrlScript`""
         $psi.Arguments = "-NoExit -NoProfile -ExecutionPolicy Bypass -File $safeSingleUrlScript"


### PR DESCRIPTION
### Motivation
- Passing validated single URLs and outdir text into a `powershell.exe -Command` string allowed PowerShell to re-parse metacharacters (e.g., `&`, `;`, `$()`) and could strip nested quotes at the native command-line layer, breaking paths and creating a command-injection risk.
- The single-URL launch path needed to preserve URL/path text exactly as data so PowerShell would not evaluate or split it before the tool received the arguments.
- Also tidy up a nearby comment typo about Windows command-line quoting to avoid confusion during maintenance.

### Description
- Added `ConvertTo-PowerShellSingleQuotedLiteral` to build safe single-quoted PowerShell literals that preserve arbitrary text including single quotes. (file: `gui-url-convert.ps1`)
- Reworked the single-URL GUI launch to write a temporary `.ps1` wrapper containing single-quoted literals and to invoke it with `powershell.exe -File`, so URLs/outdirs are passed as data instead of embedded in a `-Command` string that would be reparsed. (file: `gui-url-convert.ps1`)
- Left batch-mode relaunch logic using `-File` intact and fixed a typo in the comment about Windows command-line splitting. (file: `gui-url-convert.ps1`)

### Testing
- Ran `PYENV_VERSION=3.11.15 PYTHONPATH=src python -m pytest tests/test_log_export.py tests/test_csv_security.py`, and all tests passed (`10 passed`).
- Ran repository checks including `git diff --check` and a grep to confirm no remaining single-URL `-Command` construction, and those checks succeeded.
- Note: PowerShell is not available in the Linux test container, so live PowerShell runtime execution of the new launcher was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00068379c88320a65231815d787fd4)