### PR TITLE
Wire Gemini /review comments to PR review tooling

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -26,7 +26,7 @@ jobs:
          contains(github.event.comment.body, '@gemini-code-assist')))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GEMINI_CLI_TRUST_WORKSPACE: true
+      GEMINI_CLI_TRUST_WORKSPACE: "true"
     steps:
       - name: Resolve PR head SHA
         id: pr_head
@@ -54,31 +54,96 @@ jobs:
             const sameRepo = pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("is_same_repo", String(sameRepo));
+            core.setOutput("pr_number", String(pr.number));
 
       - uses: actions/checkout@v6
         if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
+
+      - name: Build Gemini prompt
+        id: gemini_prompt
+        if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login || github.actor }}
+          COMMENT_URL: ${{ github.event.comment.html_url || github.server_url }}
+          PR_NUMBER: ${{ steps.pr_head.outputs.pr_number || github.event.pull_request.number || github.event.issue.number || '' }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [[ "$COMMENT_BODY" == *"/review"* ]]; then
+            echo "prompt=/pr-code-review" >> "$GITHUB_OUTPUT"
+          else
+            delimiter="gemini_prompt_$(uuidgen)"
+            pr_context="manual workflow_dispatch"
+            if [[ -n "$PR_NUMBER" ]]; then
+              pr_context="#${PR_NUMBER}"
+            fi
+            {
+              echo "prompt<<${delimiter}"
+              cat <<PROMPT
+          You are Gemini Code Assist running in a GitHub Actions workflow for ${REPOSITORY}.
+
+          Event: ${EVENT_NAME}
+          Pull request: ${pr_context}
+          Comment author: ${COMMENT_AUTHOR}
+          Comment URL: ${COMMENT_URL}
+
+          Respond to the pull request by carrying out the request in the triggering comment.
+          Use the GitHub CLI or GitHub API when you need pull request details, diffs, or to post feedback.
+
+          Triggering comment:
+          ${COMMENT_BODY:-Manual workflow_dispatch run: review the checked-out repository and summarize any actionable findings.}
+          PROMPT
+              echo "${delimiter}"
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ steps.pr_head.outputs.pr_number || github.event.pull_request.number || github.event.issue.number || '' }}
+          ADDITIONAL_CONTEXT: ${{ github.event.comment.body || 'Manual workflow_dispatch run.' }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
-          gemini_model: gemini-2.0-flash
-          prompt: |
-            You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.
-
-            Event: ${{ github.event_name }}
-            Pull request: #${{ github.event.pull_request.number || github.event.issue.number || 'manual workflow_dispatch' }}
-            Comment author: ${{ github.event.comment.user.login || github.actor }}
-            Comment URL: ${{ github.event.comment.html_url || github.server_url }}
-
-            Respond to the pull request by carrying out the request in the triggering comment.
-            Use the GitHub CLI or GitHub API when you need pull request details, diffs, or to post feedback.
-
-            Triggering comment:
-            ${{ github.event.comment.body || 'Manual workflow_dispatch run: review the checked-out repository and summarize any actionable findings.' }}
+          github_pr_number: ${{ steps.pr_head.outputs.pr_number || github.event.pull_request.number || github.event.issue.number || '' }}
+          settings: |
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": []
+              }
+            }
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: ${{ steps.gemini_prompt.outputs.prompt }}


### PR DESCRIPTION
### Motivation
- Ensure maintainer comment triggers like `/review` are actually passed as a PR-review command to the Gemini code-review extension so invoked runs perform and publish review feedback. 
- Provide concrete PR context (PR number and head SHA) to the Gemini action for `issue_comment` and `pull_request_review_comment` events so issue-comment triggers work correctly. 
- Give the Gemini runner authenticated GitHub access and the appropriate MCP/tools configuration so it can read PR details and submit review comments.

### Description
- Emit the resolved `pr_number` from the `Resolve PR head SHA` step and continue to explicitly check out the PR head SHA for non-dispatch events. 
- Add a `Build Gemini prompt` step that maps trusted maintainer comments containing `/review` to the code-review extension command (`/pr-code-review`) and otherwise builds a contextual prompt containing the triggering comment and PR context. 
- Invoke `google-github-actions/run-gemini-cli` with `github_pr_number`, an authenticated GitHub token (`GITHUB_TOKEN`/`GH_TOKEN`), configured `settings` for the GitHub MCP server, and the `code-review` extension so Gemini can read PR diffs and post review feedback, and forward the generated `prompt` to the action. 
- Quote `GEMINI_CLI_TRUST_WORKSPACE` to ensure the env value is passed unambiguously.

### Testing
- Ran `git diff --check` to validate whitespace and patch hygiene, which completed successfully. 
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml')"` which reported OK. 
- Performed local validation of the updated workflow file structure (YAML parsing and diffs) and observed no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4864e2248320985e57eb2860d97e)