### PR TITLE
Fix GUI single URL PowerShell launch quoting

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -6,7 +6,47 @@ WPF GUI for html2md
 - Safe for double-click or PowerShell execution
 #>
 
-param([string]$BatchFile, [string]$BatchOutDir, [switch]$BatchWholePage)
+param(
+    [string]$BatchFile,
+    [string]$BatchOutDir,
+    [switch]$BatchWholePage,
+    [string]$SingleUrl,
+    [string]$SingleOutDir,
+    [switch]$SingleWholePage
+)
+
+if ($SingleUrl) {
+    $scriptDir = Split-Path -Parent $PSCommandPath
+    if (-not $scriptDir) { $scriptDir = (Get-Location).Path }
+
+    $venvExe = Join-Path $scriptDir ".venv\Scripts\html2md.exe"
+    $pyScript = Join-Path $scriptDir "html2md.py"
+    $outDir = if (-not [string]::IsNullOrWhiteSpace($SingleOutDir)) { $SingleOutDir } else { "$env:USERPROFILE\Downloads" }
+
+    $uriOut = $null
+    if ([System.Uri]::TryCreate($SingleUrl, [System.UriKind]::Absolute, [ref]$uriOut) -and $uriOut.Scheme -match '^https?$') {
+        $SingleUrl = $uriOut.AbsoluteUri
+    } else {
+        Write-Error "Invalid URL: $SingleUrl"
+        exit 1
+    }
+
+    Write-Host "Processing: $SingleUrl"
+    $argsList = @("--url", "$SingleUrl", "--outdir", "$outDir", "--all-formats")
+    if (-not $SingleWholePage) { $argsList += "--main-content" }
+
+    if (Test-Path -LiteralPath $venvExe) {
+        & $venvExe @argsList
+    } elseif (Test-Path -LiteralPath $pyScript) {
+        $pyCmd = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "python3" }
+        $argsList = @("$pyScript") + $argsList
+        & $pyCmd @argsList
+    } else {
+        Write-Error "Could not find html2md executable or script."
+        exit 1
+    }
+    exit
+}
 
 if ($BatchFile) {
     if (-not (Test-Path -LiteralPath $BatchFile)) {
@@ -224,6 +264,38 @@ function Get-ClipboardTextSta {
     return $state
 }
 
+
+function ConvertTo-NativeCommandLineArgument {
+    param([AllowEmptyString()][string]$Argument)
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append('"')
+    $backslashCount = 0
+
+    foreach ($char in $Argument.ToCharArray()) {
+        if ($char -eq '\') {
+            $backslashCount++
+        } elseif ($char -eq '"') {
+            [void]$builder.Append('\' * ($backslashCount * 2 + 1))
+            [void]$builder.Append('"')
+            $backslashCount = 0
+        } else {
+            if ($backslashCount -gt 0) {
+                [void]$builder.Append('\' * $backslashCount)
+                $backslashCount = 0
+            }
+            [void]$builder.Append($char)
+        }
+    }
+
+    if ($backslashCount -gt 0) {
+        [void]$builder.Append('\' * ($backslashCount * 2))
+    }
+
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
 # --- Paste button logic ---
 $PasteBtn.Add_Click({
     try {
@@ -350,7 +422,7 @@ $ConvertBtn.Add_Click({
     # Use a robust way to launch the process:
     # 1. Revert to ProcessStartInfo for precise control over the command line.
     # 2. Use powershell.exe to keep the window open with -NoExit.
-    # 3. Use -File for batch mode and -Command with proper quoting for single URL mode.
+    # 3. Use -File for both batch and single URL modes so arguments remain data.
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = "powershell.exe"
     $psi.WorkingDirectory = $scriptDir
@@ -362,14 +434,11 @@ $ConvertBtn.Add_Click({
         $tempFile = [System.IO.Path]::GetTempFileName()
         $urlList | Set-Content -Path $tempFile
 
-        # Sanitize for -File arguments by using double quotes to handle spaces
-        # Windows command line splitting treates " as the primary quote character.
-        $safeCommandPath = "`"$PSCommandPath`""
-        $safeTempFile = "`"$tempFile`""
-        $safeOutDir = "`"$outdir`""
+        # Relaunch this script in batch mode with -File so URL data is passed as data, not PowerShell code.
+        $safeCommandPath = ConvertTo-NativeCommandLineArgument $PSCommandPath
+        $safeTempFile = ConvertTo-NativeCommandLineArgument $tempFile
+        $safeOutDir = ConvertTo-NativeCommandLineArgument $outdir
 
-        # Relaunch this script in batch mode
-        # Use -File with double-quoted paths for robust Windows command-line handling
         $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File $safeCommandPath -BatchFile $safeTempFile -BatchOutDir $safeOutDir"
         if ($WholePageChk.IsChecked) {
             $psi.Arguments += " -BatchWholePage"
@@ -377,24 +446,25 @@ $ConvertBtn.Add_Click({
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
-        # If Whole Page is unchecked, we add the flag to ignore headers/footers
-        $optArg = if (-not $WholePageChk.IsChecked) { " --main-content" } else { "" }
-
-        # Sanitize inputs for PowerShell -Command interpolation.
-        # We use double quotes around arguments and escape internal double quotes, dollar signs,
-        # and backticks with the PowerShell escape character (backtick) to prevent subexpression execution.
-        $safeUrl = $url -replace '["$`]', '`$0'
-        $safeOutDir = $outdir -replace '["$`]', '`$0'
-        $safeVenvExe = $venvExe -replace '["$`]', '`$0'
-        $safePyScript = $pyScript -replace '["$`]', '`$0'
+        # Relaunch this script in single-URL mode with -File. Avoid -Command so URL
+        # characters such as ; and & are passed as argument text rather than executable syntax.
+        $safeCommandPath = ConvertTo-NativeCommandLineArgument $PSCommandPath
+        $safeUrl = ConvertTo-NativeCommandLineArgument $url
+        $safeOutDir = ConvertTo-NativeCommandLineArgument $outdir
 
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -Command `"& `"$safeVenvExe`" --url `"$safeUrl`" --outdir `"$safeOutDir`" --all-formats$optArg`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File $safeCommandPath -SingleUrl $safeUrl -SingleOutDir $safeOutDir"
+            if ($WholePageChk.IsChecked) {
+                $psi.Arguments += " -SingleWholePage"
+            }
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -Command `"& $pyCmd `"$safePyScript`" --url `"$safeUrl`" --outdir `"$safeOutDir`" --all-formats$optArg`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File $safeCommandPath -SingleUrl $safeUrl -SingleOutDir $safeOutDir"
+            if ($WholePageChk.IsChecked) {
+                $psi.Arguments += " -SingleWholePage"
+            }
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."

--- a/tests/test_gui_launcher_security.py
+++ b/tests/test_gui_launcher_security.py
@@ -10,3 +10,19 @@ def test_gui_launcher_uses_file_mode_for_paths() -> None:
     assert "-Command" not in launcher
     assert '-File "%SCRIPT_DIR%gui-url-convert.ps1"' in launcher
     assert "Set-Location -LiteralPath '%SCRIPT_DIR%'" not in launcher
+
+
+def test_gui_single_url_launch_avoids_command_mode() -> None:
+    launcher = (ROOT / "gui-url-convert.ps1").read_text(encoding="utf-8")
+
+    assert "-NoExit -Command" not in launcher
+    assert "-SingleUrl $safeUrl -SingleOutDir $safeOutDir" in launcher
+    assert "ConvertTo-NativeCommandLineArgument $url" in launcher
+
+
+def test_gui_single_url_handler_invokes_backend_with_argument_array() -> None:
+    launcher = (ROOT / "gui-url-convert.ps1").read_text(encoding="utf-8")
+
+    assert "[string]$SingleUrl" in launcher
+    assert "& $venvExe @argsList" in launcher
+    assert "& $pyCmd @argsList" in launcher


### PR DESCRIPTION
### Motivation

- Prevent command-injection and argument-stripping when relaunching the GUI for single-URL conversions by avoiding `-Command` and ensuring metacharacters like `;` and `&` are treated as data rather than executable syntax. 
- Make relaunch argument quoting robust against Windows native command-line parsing and preserve nested quotes/backslashes when passing data into `powershell.exe`.

### Description

- Added dedicated single-URL relaunch parameters (`[string]$SingleUrl`, `[string]$SingleOutDir`, `[switch]$SingleWholePage`) and a single-URL handler that validates the URL using `[System.Uri]::TryCreate` and uses `AbsoluteUri` before invocation. 
- Implemented `ConvertTo-NativeCommandLineArgument` to produce safely quoted native command-line arguments that preserve embedded quotes and backslashes. 
- Switched both batch and single-URL relaunched invocations to use `powershell.exe -File` with safely quoted arguments (passing `-SingleUrl` / `-SingleOutDir`) instead of constructing an inline `-Command` string. 
- Ensured backend invocation in relaunch handlers uses argument arrays (e.g. `& $venvExe @argsList` and `& $pyCmd @argsList`) and added regression tests to assert the new behavior in `tests/test_gui_launcher_security.py`.

### Testing

- Ran `PYENV_VERSION=3.12.13 PYTHONPATH=src python -m pytest -q tests/test_gui_launcher_security.py tests/test_csv_security.py tests/test_log_export.py` and the test suite completed successfully (all relevant tests passed). 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_gui_launcher_security.py` and it passed. 
- Verified `git diff --check` produced no whitespace or merge errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0006f59cd48320a459aa788b2be3f9)