### PR TITLE
Use Gemini CLI default model

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -68,7 +68,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
-          gemini_model: gemini-2.0-flash
           prompt: |
             You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.
 


### PR DESCRIPTION
### Motivation
- Avoid pinning the workflow to a specific Gemini model that may be deprecated or shut down and let the CLI action pick a supported default.

### Description
- Removed the explicit `gemini_model: gemini-2.0-flash` line from `.github/workflows/gemini-code-assist.yml` so `google-github-actions/run-gemini-cli` will use its default model.

### Testing
- Ran `git diff --check`, `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'`, and a grep check for `gemini_model|gemini_api_key|run-gemini-cli`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd484642288320aa840fcff140e45d)