### PR TITLE
Add manual `workflow_dispatch` inputs and forward prompt/PR context to Gemini CLI

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -106,4 +106,4 @@ jobs:
             Request precedence: triggering comment body, then workflow_dispatch prompt, then automatic PR review.
 
             Request:
-            ${{ github.event.comment.body || (github.event.inputs && github.event.inputs.prompt) || 'Automatically review the checked-out pull request and post actionable feedback on the PR.' }}
+            ${{ github.event.comment.body || github.event.inputs.prompt || 'Automatically review the checked-out pull request and post actionable feedback on the PR.' }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -106,4 +106,4 @@ jobs:
             Request precedence: triggering comment body, then workflow_dispatch prompt, then automatic PR review.
 
             Request:
-            ${{ github.event.comment.body || github.event.inputs.prompt || 'Automatically review the checked-out pull request and post actionable feedback on the PR.' }}
+            ${{ github.event.comment.body || (github.event.inputs && github.event.inputs.prompt) || 'Automatically review the checked-out pull request and post actionable feedback on the PR.' }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,15 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+    inputs:
+      prompt:
+        description: "Task or review instructions for Gemini Code Assist."
+        required: true
+        type: string
+      pr_number:
+        description: "Optional same-repository pull request number to check out and review."
+        required: false
+        type: number
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -26,16 +35,22 @@ jobs:
          contains(github.event.comment.body, '@gemini-code-assist')))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GEMINI_CLI_TRUST_WORKSPACE: true
+      GEMINI_CLI_TRUST_WORKSPACE: "true"
     steps:
       - name: Resolve PR head SHA
         id: pr_head
-        if: github.event_name != 'workflow_dispatch'
         uses: actions/github-script@v7
         with:
           script: |
             let pr;
-            if (context.eventName === "pull_request_review_comment") {
+            if (context.eventName === "workflow_dispatch" && context.payload.inputs?.pr_number) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(context.payload.inputs.pr_number),
+              });
+              pr = response.data;
+            } else if (context.eventName === "pull_request_review_comment") {
               pr = context.payload.pull_request;
             } else if (context.eventName === "issue_comment" && context.payload.issue?.pull_request) {
               const response = await github.rest.pulls.get({
@@ -47,21 +62,24 @@ jobs:
             }
 
             if (!pr) {
-              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request_review_comment or issue_comment on a pull request.");
+              core.setOutput("head_sha", context.sha);
+              core.setOutput("is_same_repo", "true");
+              core.setOutput("pr_number", "");
               return;
             }
 
             const sameRepo = pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("is_same_repo", String(sameRepo));
+            core.setOutput("pr_number", String(pr.number));
 
       - uses: actions/checkout@v6
-        if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
+        if: steps.pr_head.outputs.is_same_repo == 'true'
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
+          ref: ${{ steps.pr_head.outputs.head_sha }}
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
+        if: env.GEMINI_API_KEY != '' && steps.pr_head.outputs.is_same_repo == 'true'
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -73,12 +91,12 @@ jobs:
             You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.
 
             Event: ${{ github.event_name }}
-            Pull request: #${{ github.event.pull_request.number || github.event.issue.number || 'manual workflow_dispatch' }}
+            Pull request: #${{ steps.pr_head.outputs.pr_number || 'not specified' }}
             Comment author: ${{ github.event.comment.user.login || github.actor }}
             Comment URL: ${{ github.event.comment.html_url || github.server_url }}
 
-            Respond to the pull request by carrying out the request in the triggering comment.
+            Carry out the request from the workflow input or triggering comment. If a pull request number is provided, respond on that pull request.
             Use the GitHub CLI or GitHub API when you need pull request details, diffs, or to post feedback.
 
-            Triggering comment:
-            ${{ github.event.comment.body || 'Manual workflow_dispatch run: review the checked-out repository and summarize any actionable findings.' }}
+            Request:
+            ${{ github.event.comment.body || github.event.inputs.prompt }}

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -103,6 +103,7 @@ jobs:
 
             Carry out the request from the workflow input or triggering comment. If a pull request number is provided, respond on that pull request.
             Use the GitHub CLI or GitHub API when you need pull request details, diffs, or to post feedback.
+            Request precedence: triggering comment body, then workflow_dispatch prompt, then automatic PR review.
 
             Request:
             ${{ github.event.comment.body || github.event.inputs.prompt || 'Automatically review the checked-out pull request and post actionable feedback on the PR.' }}


### PR DESCRIPTION
### Motivation
- The manual Actions-tab dispatch had no inputs so runs consumed Gemini requests with a generic default prompt and no PR context, producing unhelpful reviews. 
- Manual dispatch and comment-triggered runs need a way to supply an explicit task `prompt` and optional same-repo `pr_number` so Gemini can act on the maintainer request and check out the correct code. 

### Description
- Add `workflow_dispatch` inputs: a required `prompt` (string) and an optional `pr_number` (number) to the Gemini Code Assist workflow. 
- Update the `Resolve PR head SHA` step to resolve an optional `pr_number` from `workflow_dispatch`, keep existing comment-based resolution, and output `head_sha`, `is_same_repo`, and `pr_number`. 
- Change `actions/checkout` to use the resolved `head_sha` only when `is_same_repo` is `true`, and tighten the Gemini step `if:` so it only runs when `GEMINI_API_KEY` is set and the target is same-repo. 
- Forward the manual `prompt` (or the triggering comment body) into `google-github-actions/run-gemini-cli` so manual runs no longer fall back to the action default prompt, and coerce `GEMINI_CLI_TRUST_WORKSPACE` to a quoted string for YAML clarity. 

### Testing
- Ran `git diff --check` which reported no issues. 
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd483bd37083208e9bf1a6e817bd70)