### PR TITLE
Keep Gemini Code Assist non-blocking

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -62,6 +62,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
+        continue-on-error: true
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Motivation
- Restore non-blocking behavior for the optional Gemini Code Assist job so transient Gemini quota/rate-limit or auth issues do not mark PR checks as failed.

### Description
- Add `continue-on-error: true` to the `Gemini Code Assist` step that uses `google-github-actions/run-gemini-cli@v0` in `.github/workflows/gemini-code-assist.yml`.

### Testing
- Ran `git diff --check` and parsed the workflow with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd483195b083209ee121c22d9f2fcd)