### PR TITLE
Pin Gemini CLI action to immutable SHA

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -62,7 +62,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
-        uses: google-github-actions/run-gemini-cli@v0
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Motivation
- Pin the `google-github-actions/run-gemini-cli` invocation to an immutable commit SHA instead of the floating `v0` tag to reduce supply-chain and reproducibility risk.

### Description
- Update `.github/workflows/gemini-code-assist.yml` to use `google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489` and retain an inline `# v0` note for traceability.

### Testing
- Ran `git diff --check` and parsed the workflow YAML with Python (`yaml.safe_load`) and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48271fa08320a9ed0f8c48f081e7)