### PR TITLE
Pass PR number to Gemini action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -54,6 +54,7 @@ jobs:
             const sameRepo = pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("is_same_repo", String(sameRepo));
+            core.setOutput("pr_number", String(pr.number));
 
       - uses: actions/checkout@v6
         if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
@@ -69,6 +70,7 @@ jobs:
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           gemini_model: gemini-2.0-flash
+          github_pr_number: ${{ github.event.issue.number || steps.pr_head.outputs.pr_number }}
           prompt: |
             You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.
 


### PR DESCRIPTION
### Motivation
- Ensure the Gemini CLI action receives an explicit PR number when the workflow is started from PR conversation comments so the assistant has the correct pull request context.

### Description
- Add `pr_number` output from the `Resolve PR head SHA` step and pass it (with an `issue.number` fallback) into `google-github-actions/run-gemini-cli` via the `github_pr_number` input.

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'` and it succeeded.
- Ran `git diff --check` to validate the diff and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd481a80a48320a452308488ff8765)