### PR TITLE
Provide GitHub auth to Gemini CLI

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -26,7 +26,7 @@ jobs:
          contains(github.event.comment.body, '@gemini-code-assist')))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GEMINI_CLI_TRUST_WORKSPACE: true
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: Resolve PR head SHA
         id: pr_head
@@ -64,10 +64,35 @@ jobs:
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         uses: google-github-actions/run-gemini-cli@v0
         env:
+          # Expose the workflow token to Gemini CLI and any GitHub tooling it invokes.
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          settings: |
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              }
+            }
           gemini_model: gemini-2.0-flash
           prompt: |
             You are Gemini Code Assist running in a GitHub Actions workflow for ${{ github.repository }}.


### PR DESCRIPTION
### Motivation
- The Gemini action needs an authenticated GitHub token and explicit MCP settings so it can read PRs and post review feedback when invoked from workflow comment or dispatch events. 
- Avoid YAML type coercion for `GEMINI_CLI_TRUST_WORKSPACE` by ensuring it is passed as a string.

### Description
- Updated `.github/workflows/gemini-code-assist.yml` to quote `GEMINI_CLI_TRUST_WORKSPACE` so the env value is the intended string (`'true'`).
- Exported the workflow token into the Gemini step as `GITHUB_TOKEN` and `GH_TOKEN` so the CLI and any GitHub tooling it runs can authenticate. 
- Added a `settings` input to the `google-github-actions/run-gemini-cli` invocation that configures the GitHub MCP server (via the `ghcr.io/github/github-mcp-server` docker image) and enables the PR review tools `add_comment_to_pending_review`, `pull_request_read`, and `pull_request_review_write`, passing the workflow token into the MCP server env.

### Testing
- Ran `git diff --check` to validate no whitespace or diff issues and it passed. 
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'YAML OK'"` which succeeded. 
- Verified the local file diff shows the intended changes to `/.github/workflows/gemini-code-assist.yml` with no remaining parse errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4810d6488320912a2ea5397c087c)