### PR TITLE
ci: block PR-local Gemini command overrides

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -58,15 +58,15 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Remove PR-local Gemini command overrides
-        # Project-local .gemini/commands/*.toml can shadow extension commands
-        # in Gemini CLI's loader, so a PR could plant a pr-code-review.toml
-        # that hijacks /pr-code-review. Remove checkout-provided commands
-        # before installing the pinned code-review extension.
+      - name: Remove PR-local Gemini configuration
+        # Gemini CLI loads project-local configuration and .env files from the
+        # checked-out .gemini tree. A PR could use those files to override CLI
+        # behavior or telemetry settings before the pinned review extension runs,
+        # so remove the entire checkout-provided tree before invoking Gemini.
         run: |
-          rm -rf .gemini/commands
-          if find .gemini -path '*/commands/pr-code-review.toml' -print -quit 2>/dev/null | grep -q .; then
-            echo "::error::PR-local Gemini pr-code-review command override is still present."
+          rm -rf .gemini
+          if [ -e .gemini ]; then
+            echo "::error::PR-local Gemini configuration is still present."
             exit 1
           fi
       - name: Gemini Code Assist

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -60,13 +60,14 @@ jobs:
           persist-credentials: false
       - name: Remove PR-local Gemini configuration
         # Gemini CLI loads project-local configuration and .env files from the
-        # checked-out .gemini tree. A PR could use those files to override CLI
-        # behavior or telemetry settings before the pinned review extension runs,
-        # so remove the entire checkout-provided tree before invoking Gemini.
+        # checked-out .gemini tree. A PR could use those files, including
+        # symlinked settings.json targets, to override CLI behavior or corrupt
+        # files before the pinned review extension runs, so remove the entire
+        # checkout-provided tree before invoking Gemini.
         run: |
-          rm -rf .gemini
-          if [ -e .gemini ]; then
-            echo "::error::PR-local Gemini configuration is still present."
+          rm -rf -- .gemini
+          if [ -e .gemini ] || [ -L .gemini ]; then
+            echo "::error::PR-local Gemini configuration or symlink is still present."
             exit 1
           fi
       - name: Gemini Code Assist

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -58,12 +58,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Strip PR-supplied Gemini config
-        # Project-local .gemini/commands/*.toml shadow extension commands
+      - name: Remove PR-local Gemini command overrides
+        # Project-local .gemini/commands/*.toml can shadow extension commands
         # in Gemini CLI's loader, so a PR could plant a pr-code-review.toml
-        # that hijacks /pr-code-review. We don't ship .gemini/ in the repo,
-        # so wiping it is safe and removes the attack surface.
-        run: rm -rf .gemini
+        # that hijacks /pr-code-review. Remove checkout-provided commands
+        # before installing the pinned code-review extension.
+        run: |
+          rm -rf .gemini/commands
+          if find .gemini -path '*/commands/pr-code-review.toml' -print -quit 2>/dev/null | grep -q .; then
+            echo "::error::PR-local Gemini pr-code-review command override is still present."
+            exit 1
+          fi
       - name: Gemini Code Assist
         id: gemini
         continue-on-error: true


### PR DESCRIPTION
### Motivation

- Prevent PR-authored `.gemini/commands/*.toml` from shadowing the pinned code-review extension and hijacking the `/pr-code-review` command.
- Reduce attack surface by removing checkout-provided Gemini command files before installing or invoking the extension.

### Description

- Replace the broad `.gemini` cleanup with a focused step named `Remove PR-local Gemini command overrides` that removes ` .gemini/commands` before the Gemini step. 
- Add a guard that errors and stops the job if any `pr-code-review.toml` override remains under `.gemini`, ensuring PR-local commands cannot be used to override the pinned extension.
- Changes are in the GitHub Actions workflow file ` .github/workflows/gemini-code-assist.yml` and occur immediately before the `Gemini Code Assist` action runs.

### Testing

- Ran YAML parse validation with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "valid yaml"'` which succeeded. 
- Ran `git diff --check` which produced no issues. 
- Executed a Python assertion that verifies the new step and guard (`Remove PR-local Gemini command overrides`, `rm -rf .gemini/commands`, and `*/commands/pr-code-review.toml`) are present in the workflow file, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd47dfa71883208eeaa2b7e87e6517)