### PR TITLE
ci: pin Gemini code-review extension

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -63,7 +63,18 @@ jobs:
         # in Gemini CLI's loader, so a PR could plant a pr-code-review.toml
         # that hijacks /pr-code-review. We don't ship .gemini/ in the repo,
         # so wiping it is safe and removes the attack surface.
-        run: rm -rf .gemini
+        run: |
+          rm -rf .gemini
+          rm -rf .github/gemini-code-review-extension
+      - name: Checkout pinned code-review extension
+        uses: actions/checkout@v4
+        with:
+          repository: gemini-cli-extensions/code-review
+          # Pin the extension content so upstream default-branch changes do
+          # not silently alter automated PR review behavior.
+          ref: dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04
+          path: .github/gemini-code-review-extension
+          persist-credentials: false
       - name: Gemini Code Assist
         id: gemini
         continue-on-error: true
@@ -122,7 +133,7 @@ jobs:
             }
           extensions: |
             [
-              "https://github.com/gemini-cli-extensions/code-review"
+              "./.github/gemini-code-review-extension"
             ]
           prompt: "/pr-code-review"
       - name: Note Gemini API quota exhaustion


### PR DESCRIPTION
### Motivation

- Prevent the automated review workflow from executing a floating extension ref that can change behavior without repo changes by pinning the code-review extension to a known commit.
- Reduce supply-chain and attack-surface risk by removing any PR-supplied extension checkout that could shadow the pinned extension.
- Ensure the Gemini CLI installs the extension from a local, audited copy so review behavior is reproducible and auditable.

### Description

- Added a cleanup step that removes any project-local `.gemini` and `.github/gemini-code-review-extension` directories before the Gemini run to avoid PR-supplied overrides.
- Added a `Checkout pinned code-review extension` step that checks out `gemini-cli-extensions/code-review` at commit `dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04` into `./.github/gemini-code-review-extension` using `actions/checkout@v4`.
- Changed the `run-gemini-cli` action `extensions` input from the upstream URL to the pinned local path `./.github/gemini-code-review-extension` and added an inline comment documenting the pinning rationale.
- All edits are in ` .github/workflows/gemini-code-assist.yml` and preserve the existing preflight and Gemini invocation behavior.

### Testing

- Verified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'` (succeeded). 
- Ran `git diff --check` to ensure no whitespace/errors in the diff (succeeded).
- Confirmed the pinned extension ref resolves upstream with `git ls-remote https://github.com/gemini-cli-extensions/code-review HEAD | cut -f1` matching `dd1a10d2c9d07b2ebade866590fdfa59cd8f9d04` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd47c061a08320a6d3429733f030ac)