### PR TITLE
ci: allow Gemini to create and submit PR reviews

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -15,7 +15,10 @@ permissions:
 
 concurrency:
   group: gemini-code-assist-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  # Do not cancel an in-flight review after it has opened a pending GitHub
+  # review. Canceling at that point can leave stale comments in the pending
+  # review, which a later run may reuse and submit against a newer PR revision.
+  cancel-in-progress: false
 
 jobs:
   preflight:

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -102,8 +102,10 @@ jobs:
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
+                    "create_pending_pull_request_review",
                     "pull_request_read",
-                    "pull_request_review_write"
+                    "pull_request_review_write",
+                    "submit_pending_pull_request_review"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"


### PR DESCRIPTION
### Motivation

- The Gemini-based `/pr-code-review` workflow needs the MCP review lifecycle tools so the CLI can create, populate, and submit pending pull request reviews instead of only adding comments to an existing pending review.

### Description

- Add `create_pending_pull_request_review` and `submit_pending_pull_request_review` to the `includeTools` allowlist in `.github/workflows/gemini-code-assist.yml` so normal runs can create and submit pending PR reviews.

### Testing

- Verified the change with `python3` text checks that assert the two tools are present, validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'`, and ran `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd47b6e10c8320b8ff666387772a22)