### PR TITLE
ci: pass Gemini PR number for comment-triggered runs

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -14,7 +14,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: gemini-code-assist-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: gemini-code-assist-${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -75,15 +75,15 @@ jobs:
           # Consumed by the code-review extension's /pr-code-review prompt
           # template via $REPOSITORY and $PULL_REQUEST_NUMBER expansions.
           REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PULL_REQUEST_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_cli_version: "0.41.2"
-          # Resolves the PR number across all three supported triggers:
-          # pull_request, pull_request_review_comment, and issue_comment.
-          # The first two populate github.event.pull_request.number; the
-          # last populates github.event.issue.number.
-          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # Pass the target PR number explicitly for every trigger.
+          # pull_request and pull_request_review_comment expose it as
+          # github.event.pull_request.number, while issue_comment exposes
+          # the PR number as github.event.issue.number.
+          github_pr_number: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
           settings: |-
             {
               "model": {


### PR DESCRIPTION
### Motivation

- Ensure the Gemini CLI receives the correct pull request context when the workflow is invoked via `issue_comment`, because `issue_comment` exposes the PR number as `github.event.issue.number` rather than `github.event.pull_request.number`.

### Description

- Update the workflow concurrency key to use a trigger-aware PR expression: `${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}`.
- Pass the same trigger-aware expression into the Gemini environment as `PULL_REQUEST_NUMBER` and into the `run-gemini-cli` `github_pr_number` input so comment-triggered runs resolve the target PR explicitly.
- Update the inline documentation in the workflow to explain the trigger-aware `github_pr_number` selection.

### Testing

- Validate workflow YAML parsing with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'` which succeeded.
- Run a Python check that asserts the new `github_pr_number` expression is present and the old expression is not, which passed.
- Run `git diff --check` to verify no whitespace/errors, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd479bae4c8320874270b9af7a67b1)