### PR TITLE
ci: document pinned Gemini CLI package version

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -78,6 +78,8 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          # Pin the npm @google/gemini-cli package installed by the wrapper
+          # action so review behavior only changes when this workflow changes.
           gemini_cli_version: "0.41.2"
           # Resolves the PR number across all three supported triggers:
           # pull_request, pull_request_review_comment, and issue_comment.


### PR DESCRIPTION
### Motivation
- Make it explicit that the `gemini_cli_version` input pins the npm `@google/gemini-cli` package installed by the wrapper action so review behavior only changes when the workflow itself is updated.

### Description
- Add an inline comment next to the `gemini_cli_version` input in `.github/workflows/gemini-code-assist.yml` explaining that this pins the npm `@google/gemini-cli` package installed by the wrapper action.

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "valid yaml"'` and `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd478f79e8832093aebc272554bda8)