### PR TITLE
ci: expose Gemini PR review MCP tools

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -101,7 +101,9 @@ jobs:
                     "ghcr.io/github/github-mcp-server@sha256:a1d43076a36638ee24520fd6e83c3905ae41bc9850179081df1de2ba3a7afae0"
                   ],
                   "includeTools": [
+                    "create_pending_pull_request_review",
                     "add_comment_to_pending_review",
+                    "submit_pending_pull_request_review",
                     "pull_request_read",
                     "pull_request_review_write"
                   ],


### PR DESCRIPTION
### Motivation

- The Gemini code-review extension requires the full pending-review lifecycle (`create_pending_pull_request_review` and `submit_pending_pull_request_review`) to create, populate, and submit inline feedback instead of only appending comments to an existing pending review.  
- Without these tools the `/pr-code-review` flow could read diffs but not reliably post automated review comments, so the workflow must expose those MCP tools to the Gemini MCP server configuration.

### Description

- Update ` .github/workflows/gemini-code-assist.yml` to add `create_pending_pull_request_review` and `submit_pending_pull_request_review` to the `mcpServers.github.includeTools` list so the code-review extension can create and submit pending reviews.  
- Preserve the existing Gemini CLI invocation, `GITHUB_TOKEN`, PR context (`REPOSITORY` / `PULL_REQUEST_NUMBER`), `extensions` and `prompt: "/pr-code-review"` plumbing so review runs can post feedback.  
- Commit message and PR title are `ci: expose Gemini PR review MCP tools` describing the change.

### Testing

- Ran a Python assertion script to verify required plumbing and the new MCP tools are present in ` .github/workflows/gemini-code-assist.yml`, which succeeded.  
- Validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'`, which parsed successfully.  
- Ran `git diff --check` to ensure no whitespace/errors from the change, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4782191c83208ff1c96376a2ce18)