### PR TITLE
Document reopened Jules review recovery trigger

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -2,6 +2,8 @@ name: Request Jules Review
 
 on:
   pull_request:
+    # Keep reopened as a recovery trigger for older PRs or failed initial runs;
+    # the existing-comment guard below prevents duplicate Jules requests.
     types: [opened, reopened]
 
 permissions:


### PR DESCRIPTION
### Motivation
- Clarify why `reopened` is intentionally kept in the `pull_request` trigger so older PRs or PRs with failed initial runs can still get a Jules request while relying on the existing-comment guard to prevent duplicates.

### Description
- Add inline explanatory comments above `types: [opened, reopened]` in `.github/workflows/request-jules-review.yml` documenting the `reopened` recovery trigger and the existing-comment guard that prevents duplicate `@google-labs-jules` requests.

### Testing
- Ran `git diff --check` and parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/request-jules-review.yml")'`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd477750fc83209ec64156ccf42368)