### PR TITLE
Harden Jules comment listing checks

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -33,6 +33,7 @@ jobs:
           pr_number = os.environ["PR_NUMBER"]
           token = os.environ["GITHUB_TOKEN"]
           marker = "@google-labs-jules please review this pull request."
+          non_actionable_list_errors = {403, 404}
 
           headers = {
               "Accept": "application/vnd.github+json",
@@ -49,10 +50,11 @@ jobs:
                       link_header = list_response.headers.get("Link", "")
               except urllib.error.HTTPError as error:
                   body = error.read().decode("utf-8")
-                  # 403/404 are non-actionable (permissions, missing PR); log and skip
-                  # like the fork guard above. Surface every other failure so a transient
-                  # API error shows up as a red check the maintainer can retry.
-                  if error.code in (403, 404):
+                  # 403/404 are known non-actionable list failures (permission denied,
+                  # inaccessible/missing PR); log and skip like the fork guard above.
+                  # Surface every other failure so a transient API error shows up as a
+                  # red check the maintainer can retry.
+                  if error.code in non_actionable_list_errors:
                       print(
                           f"Could not list existing comments ({error.code}): {body}"
                       )
@@ -65,11 +67,14 @@ jobs:
                   )
                   raise
 
+              if not isinstance(comments, list):
+                  raise ValueError("Expected the comments API to return a list")
+
               for comment in comments:
                   user = comment.get("user") or {}
                   if user.get("login") != "github-actions[bot]":
                       continue
-                  if marker in (comment.get("body") or ""):
+                  if (comment.get("body") or "").strip() == marker:
                       print(
                           f"Review request already present on PR #{pr_number}; skipping."
                       )


### PR DESCRIPTION
### Motivation

- Prevent transient or malformed GitHub API responses from silently skipping the Jules review request so maintainers see a failing check they can retry instead of a missing comment. 
- Avoid hiding malformed/non-list API responses from GitHub/GHE by validating the response shape. 
- Prevent false-positive duplicate suppression when the marker text is quoted in discussion by matching the exact bot comment body and author.

### Description

- Add `non_actionable_list_errors = {403, 404}` and only log-and-skip listing failures for those known non-actionable codes while re-raising other `HTTPError`s. 
- Validate the comments API response with `if not isinstance(comments, list): raise ValueError(...)` so malformed responses fail loudly. 
- Tighten duplicate detection to require the exact marker body with `if (comment.get("body") or "").strip() == marker` while continuing to check `user.get("login") == "github-actions[bot]"` in `.github/workflows/request-jules-review.yml`.

### Testing

- Extracted and compiled the embedded workflow Python with `/usr/bin/python3` which succeeded. 
- Parsed the workflow YAML with `PyYAML` via `/usr/bin/python3` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4761ab6c83208a30d42513b17f15)