### PR TITLE
Check AI transcript placeholder before accepting URLs

### DIFF
--- a/.github/workflows/ai-assisted-pr-guard.yml
+++ b/.github/workflows/ai-assisted-pr-guard.yml
@@ -33,11 +33,6 @@ jobs:
           body="${PR_BODY:-}"
           accepted_url_pattern='https?://(claude\.ai|cursor\.com|jules\.google\.com)([/:?#]|$)|https?://chatgpt\.com/codex([/?#]|$)'
 
-          if printf '%s' "$body" | grep -Eqi "$accepted_url_pattern"; then
-            echo "OK: PR body contains an agent chat URL."
-            exit 0
-          fi
-
           if printf '%s' "$body" | grep -qF '<CLAUDE_CHAT_URL>'; then
             if [[ "$PR_DRAFT" == "true" ]]; then
               echo "::warning::Draft PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before marking ready for review."
@@ -46,6 +41,11 @@ jobs:
 
             echo "::error::PR body still contains the <CLAUDE_CHAT_URL> placeholder. Replace it with the real chat URL before merging."
             exit 1
+          fi
+
+          if printf '%s' "$body" | grep -Eqi "$accepted_url_pattern"; then
+            echo "OK: PR body contains an agent chat URL."
+            exit 0
           fi
 
           echo "::error::PR title is tagged [AI-Assisted] but the body does not include a Claude chat URL (or accepted alternative). Add the URL or remove the tag."


### PR DESCRIPTION
### Motivation
- Prevent ready/non-draft `[AI-Assisted]` PRs from bypassing placeholder enforcement when the body contains both a real transcript URL and the stale `<CLAUDE_CHAT_URL>` placeholder.

### Description
- Reordered the check in `.github/workflows/ai-assisted-pr-guard.yml` so the literal `<CLAUDE_CHAT_URL>` placeholder is detected before accepting any matching transcript URL from `accepted_url_pattern`.
- Kept `PR_DRAFT` exported from `github.event.pull_request.draft` and preserved the existing behavior of emitting a warning for drafts while failing for non-draft PRs.
- Left the anchored `accepted_url_pattern` matching in place to continue validating allowed transcript hosts.

### Testing
- Loaded the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ai-assisted-pr-guard.yml")'` which succeeded.
- Extracted and executed the workflow step in a shell harness and observed expected exits for test cases: `untagged` -> `0`, `draft_placeholder` -> `0`, `ready_placeholder` -> `1`, `accepted_url` -> `0`, `ready_url_and_placeholder` -> `1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd472d0b2c8320b354d33d5a149697)