### PR TITLE
Wire --whole-page into conversion and GUI single-URL path

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -380,8 +380,6 @@ $ConvertBtn.Add_Click({
             $wholePageArg = " --whole-page"
         }
 
-        $wholePageArg = if ($WholePageChk.IsChecked) { " --whole-page" } else { "" }
-
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
             $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir'$wholePageArg`""

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -376,13 +376,15 @@ $ConvertBtn.Add_Click({
         $safeVenvExe = $venvExe -replace "'", "''"
         $safePyScript = $pyScript -replace "'", "''"
 
+        $wholePageArg = if ($WholePageChk.IsChecked) { " --whole-page" } else { "" }
+
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir'`""
+            $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir'$wholePageArg`""
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir'`""
+            $psi.Arguments = "-NoExit -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir'$wholePageArg`""
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,17 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
+from bs4 import BeautifulSoup
+
+
+def _remove_page_chrome(html: str) -> str:
+    """Remove document chrome omitted by default URL conversions."""
+    soup = BeautifulSoup(html, 'html.parser')
+    for tag in soup.find_all(('header', 'footer')):
+        tag.decompose()
+    return str(soup)
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -78,7 +89,12 @@ def main(argv=None):
                 response.raise_for_status()
 
                 print("Converting to Markdown...")
-                md_content = md(response.text, heading_style="ATX")
+                html = (
+                    response.text
+                    if args.whole_page
+                    else _remove_page_chrome(response.text)
+                )
+                md_content = md(html, heading_style="ATX")
 
                 if args.outdir:
                     if not os.path.exists(args.outdir):

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,11 +6,10 @@ import os
 import sys
 from urllib.parse import urlparse, unquote
 
-from bs4 import BeautifulSoup
-
 
 def _remove_page_chrome(html: str) -> str:
     """Remove document chrome omitted by default URL conversions."""
+    from bs4 import BeautifulSoup  # pylint: disable=import-outside-toplevel
     soup = BeautifulSoup(html, 'html.parser')
     for tag in soup.find_all(('header', 'footer')):
         tag.decompose()

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -53,9 +53,43 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     assert not (tmp_path / "secret.txt.md").exists()
 
 
-def test_whole_page_option_is_accepted_for_gui_batch_mode(capsys):
-    """GUI batch mode may pass --whole-page through to the CLI."""
-    rc = cli.main(["--whole-page", "--help-only"])
+@patch("requests.Session.get")
+def test_whole_page_option_includes_header_and_footer(mock_get, capsys):
+    """--whole-page includes document chrome that defaults omit."""
+    response = MagicMock()
+    response.text = (
+        "<header><h1>Site Header</h1></header>"
+        "<main><p>Main body</p></main>"
+        "<footer>Site Footer</footer>"
+    )
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    rc = cli.main(["--url", "https://example.com", "--whole-page"])
     outerr = capsys.readouterr()
+
     assert rc == 0
-    assert "--whole-page" in outerr.out
+    assert "Site Header" in outerr.out
+    assert "Main body" in outerr.out
+    assert "Site Footer" in outerr.out
+
+
+@patch("requests.Session.get")
+def test_default_url_conversion_omits_header_and_footer(mock_get, capsys):
+    """The default GUI/CLI URL conversion excludes page chrome."""
+    response = MagicMock()
+    response.text = (
+        "<header><h1>Site Header</h1></header>"
+        "<main><p>Main body</p></main>"
+        "<footer>Site Footer</footer>"
+    )
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    rc = cli.main(["--url", "https://example.com"])
+    outerr = capsys.readouterr()
+
+    assert rc == 0
+    assert "Site Header" not in outerr.out
+    assert "Main body" in outerr.out
+    assert "Site Footer" not in outerr.out


### PR DESCRIPTION
### Motivation
- The GUI forwarded a `--whole-page` flag for batch runs but the CLI accepted the flag without changing conversion output, so the "Convert Whole Page" checkbox had no effect for single-URL or packaged executable flows.
- The `markdownify` `strip` parameter did not reliably remove header/footer content in practice, so a robust approach was needed to omit page chrome by default.

### Description
- Wire `--whole-page` through the conversion path in `src/html2md/cli.py` by adding a `--whole-page` argument and using a helper `_remove_page_chrome()` to strip `<header>`/`<footer>` when the flag is not set, implemented with `bs4.BeautifulSoup` to reliably remove document chrome.
- Update the GUI single-URL flow in `gui-url-convert.ps1` to append `--whole-page` when the `WholePageChk` checkbox is checked so single-URL conversions match the existing batch behavior.
- Replace the previous help-only regression test with integration-style unit tests in `tests/test_cli_security.py` that mock `requests.Session.get` and assert that default conversions omit headers/footers while `--whole-page` preserves them.

### Testing
- Installed the package editable with `python -m pip install -e .` which completed successfully with dependencies resolved.
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` and all tests passed (`... [100%]`).
- Ran `git diff --check` and verified no whitespace or conflict errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd467e41348320b07fd696a47993d8)