### PR TITLE
Restore escape-path open assertion in outdir containment test

### DIFF
--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -4,14 +4,6 @@ from unittest.mock import patch, MagicMock, mock_open
 import io
 import requests  # type: ignore[import-untyped]
 from html2md.cli import main
-import builtins
-
-original_open = builtins.open
-
-def custom_open(*args, **kwargs):
-    if args and str(args[0]).endswith('.md'):
-        return mock_open()(*args, **kwargs)
-    return original_open(*args, **kwargs)
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -67,7 +59,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open', side_effect=custom_open) as m_open:
+                        with patch('html2md.cli.open', mock_open(), create=True) as m_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'
@@ -78,3 +70,4 @@ class TestCliExceptions(unittest.TestCase):
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)
+                            m_open.assert_not_called()


### PR DESCRIPTION
### Motivation
- Ensure the outdir containment test continues to catch security regressions by verifying that no `.md` output file is opened/written when the resolved output path escapes the requested output directory.

### Description
- Replace the brittle global `builtins.open` side-effect with a targeted patch of `html2md.cli.open` using `mock_open()` and restore an assertion `m_open.assert_not_called()` so the test fails if an escaped `.md` path is opened.

### Testing
- Installed the package and dependencies and ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_exceptions.py` and `PYENV_VERSION=3.12.13 python -m pytest`, both of which completed successfully (`3 passed` for the file, and `20 passed` for the full suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd461b665c832099372ae465900c37)