### PR TITLE
Reject IPv6 site-local and restricted global SSRF targets

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -25,7 +25,12 @@ def _hostname_resolves_to_global_addresses(hostname: str) -> bool:
         except (IndexError, ValueError):
             return False
 
-        if not ip_obj.is_global:
+        if (
+            not ip_obj.is_global
+            or ip_obj.is_multicast
+            or ip_obj.is_reserved
+            or getattr(ip_obj, "is_site_local", False)
+        ):
             return False
 
     return True

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -111,7 +111,7 @@ def test_process_url_blocks_any_non_global_address(mock_get, capsys, tmp_path):
 )
 @patch("requests.Session.get")
 def test_process_url_blocks_global_restricted_addresses(
-    mock_get, capsys, tmp_path, url, resolved_ip,
+    mock_get, capsys, tmp_path, url, resolved_ip
 ):
     """Restricted IP predicates are enforced even when is_global is True."""
     with patch(

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -99,6 +99,35 @@ def test_process_url_blocks_any_non_global_address(mock_get, capsys, tmp_path):
     mock_get.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "url, resolved_ip",
+    [
+        ("http://[fec0::1]/", "fec0::1"),
+        ("https://example.com", "fec0::abcd"),
+        ("http://224.0.0.1/", "224.0.0.1"),
+        ("http://[ff02::1]/", "ff02::1"),
+        ("http://[64:ff9b::808:808]/", "64:ff9b::8.8.8.8"),
+    ],
+)
+@patch("requests.Session.get")
+def test_process_url_blocks_explicitly_restricted_global_addresses(
+    mock_get, capsys, tmp_path, url, resolved_ip
+):
+    """Addresses with restricted predicates are blocked even if is_global."""
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        return_value=addrinfo(resolved_ip),
+    ):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert (
+        "Error: URL resolves to a restricted/private network address."
+        in outerr.err
+    )
+    mock_get.assert_not_called()
+
+
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""


### PR DESCRIPTION
### Motivation
- Strengthen the CLI SSRF guard so that certain addresses which `ipaddress` may still mark as `is_global` (e.g., multicast, reserved ranges, and deprecated IPv6 site-local `fec0::/10`) are still rejected.
- Provide regression tests that cover literal IPv6 site-local answers and other restricted-but-`is_global` cases to avoid a security regression when enabling IPv6 resolution.

### Description
- Tightened `_hostname_resolves_to_global_addresses` in `src/html2md/cli.py` to additionally reject addresses that are `is_multicast`, `is_reserved`, or (for IPv6) `is_site_local` while still requiring `is_global`, using `getattr(..., "is_site_local", False)` for cross-address-family compatibility.
- Added `test_process_url_blocks_explicitly_restricted_global_addresses` in `tests/test_cli_security.py` which parametrizes and asserts that deprecated IPv6 site-local, multicast, and reserved addresses are blocked even when `ipaddress` reports them as global.
- Kept deterministic DNS mocking by patching `socket.getaddrinfo` and preserved network call mocking via `@patch("requests.Session.get")` in tests to ensure no real network I/O.

### Testing
- Installed the package in editable mode with `PYENV_VERSION=3.12.13 python -m pip install -e .` and executed the focused test file with `PYENV_VERSION=3.12.13 pytest tests/test_cli_security.py -q`, which completed successfully.
- Ran the full suite with `PYENV_VERSION=3.12.13 pytest -q`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003057e2d48320a887318c3e5e2109)