### PR TITLE
Tighten SSRF address filtering

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -9,23 +9,31 @@ import ipaddress
 from urllib.parse import urlparse, unquote
 
 
+def _is_restricted_address(ip_obj) -> bool:
+    """Return True when an address is unsafe for outbound URL fetches."""
+    return (
+        not ip_obj.is_global
+        or ip_obj.is_private
+        or ip_obj.is_loopback
+        or ip_obj.is_link_local
+        or ip_obj.is_multicast
+        or ip_obj.is_reserved
+        or ip_obj.is_unspecified
+        or getattr(ip_obj, "is_site_local", False)
+    )
+
+
 def _hostname_resolves_to_global_addresses(hostname: str) -> bool:
-    """Return True only when all IPv4/IPv6 answers for hostname are global."""
-    try:
-        addrinfo = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
-    except socket.gaierror:
-        return False
+    """Return True only when all IPv4/IPv6 answers for hostname are safe."""
+    addrinfo = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
 
     if not addrinfo:
-        return False
+        raise socket.gaierror("No addresses found")
 
     for result in addrinfo:
-        try:
-            ip_obj = ipaddress.ip_address(result[4][0])
-        except (IndexError, ValueError):
-            return False
+        ip_obj = ipaddress.ip_address(result[4][0])
 
-        if not ip_obj.is_global:
+        if _is_restricted_address(ip_obj):
             return False
 
     return True
@@ -92,12 +100,20 @@ def main(argv=None):
                 return
 
             hostname = parsed.hostname
-            if hostname and not _hostname_resolves_to_global_addresses(hostname):
-                print(
-                    "Error: URL resolves to a restricted/private network address.",
-                    file=sys.stderr,
-                )
-                return
+            if hostname:
+                try:
+                    if not _hostname_resolves_to_global_addresses(hostname):
+                        print(
+                            "Error: URL resolves to a restricted/private network address.",
+                            file=sys.stderr,
+                        )
+                        return
+                except (socket.gaierror, ValueError, IndexError):
+                    print(
+                        "Error: Could not resolve hostname to a valid IP.",
+                        file=sys.stderr,
+                    )
+                    return
 
             print(f"Processing URL: {target_url}")
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -39,6 +39,10 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
         ("http://192.168.1.1/config", "192.168.1.1"),
         ("http://10.0.0.5/", "10.0.0.5"),
         ("http://100.64.0.1/", "100.64.0.1"),
+        ("http://224.0.0.1/", "224.0.0.1"),
+        ("http://[ff02::1]/", "ff02::1"),
+        ("http://[64:ff9b::808:808]/", "64:ff9b::808:808"),
+        ("http://[fec0::1]/", "fec0::1"),
     ],
 )
 @patch("requests.Session.get")
@@ -54,6 +58,40 @@ def test_process_url_ssrf_protection(mock_get, capsys, tmp_path, url, resolved_i
         "Error: URL resolves to a restricted/private network address."
         in outerr.err
     )
+    mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_reports_dns_resolution_failures_separately(
+    mock_get, capsys, tmp_path
+):
+    """Unresolvable hostnames should not be reported as restricted IPs."""
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        side_effect=cli.socket.gaierror("Name or service not known"),
+    ):
+        cli.main([
+            "--url",
+            "https://does-not-resolve.invalid",
+            "--outdir",
+            str(tmp_path),
+        ])
+
+    outerr = capsys.readouterr()
+    assert "Error: Could not resolve hostname to a valid IP." in outerr.err
+    assert "restricted/private" not in outerr.err
+    mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_reports_empty_dns_results_separately(mock_get, capsys, tmp_path):
+    """Empty resolver results should be treated as resolution failures."""
+    with patch("html2md.cli.socket.getaddrinfo", return_value=[]):
+        cli.main(["--url", "https://empty-dns.example", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: Could not resolve hostname to a valid IP." in outerr.err
+    assert "restricted/private" not in outerr.err
     mock_get.assert_not_called()
 
 


### PR DESCRIPTION
### Motivation
- The IPv6-aware hostname resolution added earlier allowed some restricted address classes (multicast, reserved, deprecated site-local, unspecified) because it relied solely on `is_global`, which regressed prior explicit checks. 
- DNS resolution failures were collapsed into the same failure path as restricted IPs, producing misleading error messages.
- Tests needed to be expanded to cover multicast, reserved, site-local IPv6, and resolution-failure/empty-resolver cases while keeping DNS deterministic via `getaddrinfo` mocking.

### Description
- Added `_is_restricted_address(ip_obj)` which explicitly rejects non-global, private, loopback, link-local, multicast, reserved, unspecified, and IPv6 `is_site_local` addresses. 
- Updated `_hostname_resolves_to_global_addresses(hostname)` to call `socket.getaddrinfo(...)`, raise on empty results, validate every returned A/AAAA answer with `_is_restricted_address`, and surface resolution errors instead of hiding them. 
- Updated `process_url` to call the new helper inside a `try/except` so DNS resolution errors (`socket.gaierror`, `ValueError`, `IndexError`) produce the dedicated "Could not resolve hostname to a valid IP." message and restricted-address results keep the "restricted/private network address" message. 
- Expanded `tests/test_cli_security.py` to mock `socket.getaddrinfo()` deterministically and added tests for multicast IPv4/IPv6, reserved IPv6 (`64:ff9b::`), deprecated site-local IPv6 (`fec0::/10`), DNS resolution failures, and empty resolver results; existing IPv6 and mixed-answer tests remain in place.

### Testing
- Installed the package in editable mode with `python -m pip install -e .` and ran the full suite with `PYENV_VERSION=3.12.13 pytest -q` after installing dependencies. 
- The test run completed successfully with all tests passing (pytest finished with no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003054471c83208e10c27abdc5dad6)