### PR TITLE
Avoid global resolver swaps for vetted URL fetches

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -34,7 +34,7 @@ def _is_allowed_public_ip(ip: str) -> bool:
 
 def _normalize_hostname_for_dns_pin(hostname: str) -> str:
     """Normalize hostnames to the IDNA form used by urllib3 before connecting."""
-    return str(hostname).rstrip('.').lower().encode('idna').decode('ascii').lower()
+    return str(hostname).rstrip('.').lower().encode('idna').decode('ascii')
 
 
 def _resolve_vetted_addresses(hostname: str, port: int):

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -179,8 +179,18 @@ def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, tim
     pinned_session.trust_env = False
     pinned_session.headers.update(session.headers)
     pinned_session.cookies.update(session.cookies)
-    pinned_session.mount(f"{parsed.scheme}://", _build_pinned_dns_adapter(vetted_addrinfos))
-    return pinned_session.get(target_url, timeout=timeout, allow_redirects=False)
+    pinned_session.mount(
+        f"{parsed.scheme}://", _build_pinned_dns_adapter(vetted_addrinfos)
+    )
+    try:
+        response = pinned_session.get(
+            target_url, timeout=timeout, allow_redirects=False
+        )
+    except requests.RequestException:
+        pinned_session.close()
+        raise
+    session.cookies.update(pinned_session.cookies)
+    return response
 
 
 def _safe_get(session, target_url: str, timeout: int = 30):

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,7 @@ import os
 import sys
 import socket
 import ipaddress
+from functools import partial
 from urllib.parse import urljoin, urlparse, unquote
 
 _RESTRICTED_ADDRESS_ERROR = "Error: URL resolves to a restricted/private network address."
@@ -71,34 +72,110 @@ def _validate_url_target(target_url: str):
     return parsed, _resolve_vetted_addresses(hostname, port)
 
 
+def _build_pinned_dns_adapter(vetted_addrinfos):
+    """Build a requests adapter whose connections use pre-vetted DNS answers."""
+    from requests.adapters import HTTPAdapter  # pylint: disable=import-outside-toplevel
+
+    from urllib3 import PoolManager  # pylint: disable=import-outside-toplevel
+    from urllib3.connection import (  # pylint: disable=import-outside-toplevel
+        HTTPConnection,
+        HTTPSConnection,
+    )
+    from urllib3.connectionpool import (  # pylint: disable=import-outside-toplevel
+        HTTPConnectionPool,
+        HTTPSConnectionPool,
+    )
+    from urllib3.poolmanager import (  # pylint: disable=import-outside-toplevel
+        PoolKey,
+        _default_key_normalizer,
+    )
+    from urllib3.exceptions import NewConnectionError  # pylint: disable=import-outside-toplevel
+    from urllib3.util.connection import _set_socket_options  # pylint: disable=import-outside-toplevel
+
+    pinned_addrinfos = tuple(vetted_addrinfos)
+
+    class _PinnedConnectionMixin:
+        """Open sockets against vetted addresses without changing global DNS."""
+
+        def __init__(self, *args, pinned_addrinfos=None, **kwargs):
+            self._pinned_addrinfos = tuple(pinned_addrinfos or ())
+            super().__init__(*args, **kwargs)
+
+        def _new_conn(self):
+            err = None
+            for family, socktype, proto, _canonname, sockaddr in self._pinned_addrinfos:
+                sock = None
+                try:
+                    sock = socket.socket(family, socktype, proto)
+                    _set_socket_options(sock, self.socket_options)
+                    sock.settimeout(self.timeout)
+                    if self.source_address:
+                        sock.bind(self.source_address)
+                    sock.connect(sockaddr)
+                    return sock
+                except OSError as exc:
+                    err = exc
+                    if sock is not None:
+                        sock.close()
+
+            message = "getaddrinfo returned an empty list" if err is None else str(err)
+            raise NewConnectionError(
+                self,
+                f"Failed to establish a new connection to a vetted address: {message}",
+            ) from err
+
+    class _PinnedHTTPConnection(_PinnedConnectionMixin, HTTPConnection):
+        pass
+
+    class _PinnedHTTPSConnection(_PinnedConnectionMixin, HTTPSConnection):
+        pass
+
+    class _PinnedHTTPConnectionPool(HTTPConnectionPool):
+        ConnectionCls = _PinnedHTTPConnection
+
+    class _PinnedHTTPSConnectionPool(HTTPSConnectionPool):
+        ConnectionCls = _PinnedHTTPSConnection
+
+    def _pinned_key_normalizer(key_class, request_context):
+        context = request_context.copy()
+        context.pop("pinned_addrinfos", None)
+        return _default_key_normalizer(key_class, context)
+
+    class _PinnedPoolManager(PoolManager):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.pool_classes_by_scheme = {
+                "http": _PinnedHTTPConnectionPool,
+                "https": _PinnedHTTPSConnectionPool,
+            }
+            self.key_fn_by_scheme = {
+                "http": partial(_pinned_key_normalizer, PoolKey),
+                "https": partial(_pinned_key_normalizer, PoolKey),
+            }
+
+    class _PinnedDNSAdapter(HTTPAdapter):
+        def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+            pool_kwargs["pinned_addrinfos"] = pinned_addrinfos
+            self.poolmanager = _PinnedPoolManager(
+                num_pools=connections,
+                maxsize=maxsize,
+                block=block,
+                **pool_kwargs,
+            )
+
+    return _PinnedDNSAdapter()
+
+
 def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, timeout: int):
-    """Fetch a URL while forcing socket resolution to reuse vetted DNS answers."""
-    original_getaddrinfo = socket.getaddrinfo
-    hostname = parsed.hostname
-    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    """Fetch a URL through per-connection sockets bound to vetted DNS answers."""
+    import requests  # type: ignore  # pylint: disable=import-outside-toplevel
 
-    def pinned_getaddrinfo(host, request_port, family=0, type=0, proto=0, flags=0):
-        try:
-            request_port_matches = request_port is None or int(request_port) == port
-        except (TypeError, ValueError):
-            request_port_matches = False
-
-        if (
-            str(host).rstrip('.').lower() == hostname.rstrip('.').lower()
-            and request_port_matches
-        ):
-            return [
-                addrinfo for addrinfo in vetted_addrinfos
-                if (family in (0, addrinfo[0]) and type in (0, addrinfo[1]) and
-                    proto in (0, addrinfo[2]))
-            ]
-        return original_getaddrinfo(host, request_port, family, type, proto, flags)
-
-    socket.getaddrinfo = pinned_getaddrinfo
-    try:
-        return session.get(target_url, timeout=timeout, allow_redirects=False)
-    finally:
-        socket.getaddrinfo = original_getaddrinfo
+    pinned_session = requests.Session()
+    pinned_session.trust_env = False
+    pinned_session.headers.update(session.headers)
+    pinned_session.cookies.update(session.cookies)
+    pinned_session.mount(f"{parsed.scheme}://", _build_pinned_dns_adapter(vetted_addrinfos))
+    return pinned_session.get(target_url, timeout=timeout, allow_redirects=False)
 
 
 def _safe_get(session, target_url: str, timeout: int = 30):
@@ -112,7 +189,12 @@ def _safe_get(session, target_url: str, timeout: int = 30):
         except _UrlValidationError:
             raise
         except ValueError as exc:
-            raise _UrlValidationError(_RESTRICTED_ADDRESS_ERROR) from exc
+            error = (
+                _RESOLUTION_ERROR
+                if "No addresses found" in str(exc)
+                else _RESTRICTED_ADDRESS_ERROR
+            )
+            raise _UrlValidationError(error) from exc
 
         response = _get_with_pinned_dns(session, current_url, parsed, vetted_addrinfos, timeout)
         if getattr(response, 'is_redirect', False) is not True:
@@ -121,6 +203,7 @@ def _safe_get(session, target_url: str, timeout: int = 30):
         location = response.headers.get('Location')
         if not location:
             return response
+        response.close()
         current_url = urljoin(current_url, location)
 
     raise _UrlValidationError("Error: Too many redirects.")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -244,6 +244,45 @@ def test_redirect_response_is_closed_before_next_hop(mock_get):
     redirect_response.close.assert_called_once_with()
 
 
+@patch("requests.Session.get", autospec=True)
+def test_redirect_set_cookie_is_preserved_for_next_hop(mock_get):
+    """Cookies learned from redirect responses are available to later hops."""
+    import requests
+
+    redirect_response = MagicMock()
+    redirect_response.is_redirect = True
+    redirect_response.headers = {"Location": "http://next.example/"}
+
+    final_response = MagicMock()
+    final_response.is_redirect = False
+    final_response.headers = {}
+
+    def request_side_effect(pinned_session, url, timeout, allow_redirects):
+        assert timeout == 30
+        assert allow_redirects is False
+        if url == "http://public.example/":
+            assert pinned_session.cookies.get("redirect_token") is None
+            pinned_session.cookies.set("redirect_token", "secret")
+            return redirect_response
+        if url == "http://next.example/":
+            assert pinned_session.cookies.get("redirect_token") == "secret"
+            return final_response
+        raise AssertionError(f"unexpected URL: {url}")
+
+    mock_get.side_effect = request_side_effect
+
+    def resolver(host, port, *args, **kwargs):
+        if host in {"public.example", "next.example"}:
+            return [_addrinfo("93.184.216.34", port=port)]
+        raise socket.gaierror(host)
+
+    session = requests.Session()
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=resolver):
+        assert cli._safe_get(session, "http://public.example/") is final_response
+
+    assert session.cookies.get("redirect_token") == "secret"
+
+
 @patch("requests.Session.get")
 def test_empty_dns_answer_reports_resolution_error(mock_get, capsys, tmp_path):
     """An empty DNS response is reported as a resolution failure, not SSRF."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -180,10 +180,9 @@ def test_process_url_pins_idna_normalized_hostname(mock_get, capsys, tmp_path):
         assert url == "http://éxample.com/"
         assert timeout == 30
         assert allow_redirects is False
-        # urllib3 resolves the IDNA/punycode form during connection setup. The
-        # pinned resolver must still return the public answer vetted for the
-        # original Unicode hostname, not a rebound private address.
-        assert cli.socket.getaddrinfo("xn--xample-9ua.com", 80) == [public_addrinfo]
+        # The global resolver is not monkey-patched; adapter-level pinning keeps
+        # DNS binding scoped to the request transport only.
+        assert cli.socket.getaddrinfo("xn--xample-9ua.com", 80) == [rebound_addrinfo]
         response = MagicMock()
         response.text = "<h1>safe</h1>"
         response.is_redirect = False

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -180,8 +180,8 @@ def test_process_url_pins_idna_normalized_hostname(mock_get, capsys, tmp_path):
         assert url == "http://éxample.com/"
         assert timeout == 30
         assert allow_redirects is False
-        # The global resolver is not monkey-patched; adapter-level pinning keeps
-        # DNS binding scoped to the request transport only.
+        # The global resolver is not monkey-patched; in this deterministic
+        # rebinding stub, the second lookup returns the rebound address.
         assert cli.socket.getaddrinfo("xn--xample-9ua.com", 80) == [rebound_addrinfo]
         response = MagicMock()
         response.text = "<h1>safe</h1>"

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -78,8 +78,8 @@ def test_process_url_allows_public_ipv6(mock_get, capsys, tmp_path):
 
 
 @patch("requests.Session.get")
-def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_path):
-    """The request uses vetted addresses instead of re-resolving a rebound hostname."""
+def test_process_url_does_not_swap_global_resolver(mock_get, capsys, tmp_path):
+    """Fetching with pinned DNS must not monkey-patch socket.getaddrinfo globally."""
     public_addrinfo = _addrinfo("93.184.216.34")
     rebound_addrinfo = _addrinfo("127.0.0.1")
     real_getaddrinfo = cli.socket.getaddrinfo
@@ -96,9 +96,8 @@ def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_pat
         assert url == "http://rebind.example/"
         assert timeout == 30
         assert allow_redirects is False
-        # If DNS pinning is not active here, the resolver would now return the
-        # private rebound address. The active request must still see the vetted IP.
-        assert cli.socket.getaddrinfo("rebind.example", 80) == [public_addrinfo]
+        # The global resolver remains untouched; pinning is scoped to the adapter.
+        assert cli.socket.getaddrinfo("rebind.example", 80) == [rebound_addrinfo]
         response = MagicMock()
         response.text = "<h1>safe</h1>"
         response.is_redirect = False
@@ -112,6 +111,54 @@ def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_pat
 
     outerr = capsys.readouterr()
     assert "Success!" in outerr.out
+
+
+def test_pinned_adapter_connects_to_vetted_address_without_dns_lookup():
+    """The adapter opens sockets to vetted addresses without resolving the host again."""
+    public_addrinfo = _addrinfo("93.184.216.34")
+    created_sockets = []
+
+    class FakeSocket:
+        def __init__(self, family, socktype, proto):
+            self.family = family
+            self.socktype = socktype
+            self.proto = proto
+            self.connected_to = None
+            self.closed = False
+
+        def setsockopt(self, *args):
+            pass
+
+        def settimeout(self, timeout):
+            self.timeout = timeout
+
+        def bind(self, source_address):
+            self.source_address = source_address
+
+        def connect(self, sockaddr):
+            self.connected_to = sockaddr
+
+        def close(self):
+            self.closed = True
+
+    def fake_socket(family, socktype, proto):
+        sock = FakeSocket(family, socktype, proto)
+        created_sockets.append(sock)
+        return sock
+
+    adapter = cli._build_pinned_dns_adapter([public_addrinfo])
+    pool = adapter.poolmanager.connection_from_url("http://rebind.example/")
+    connection = pool._new_conn()
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        side_effect=AssertionError("unexpected DNS lookup"),
+    ):
+        with patch("html2md.cli.socket.socket", side_effect=fake_socket):
+            sock = connection._new_conn()
+
+    assert sock is created_sockets[0]
+    assert sock.connected_to == public_addrinfo[4]
 
 
 @patch("requests.Session.get")
@@ -135,6 +182,41 @@ def test_process_url_validates_redirect_targets(mock_get, capsys, tmp_path):
     outerr = capsys.readouterr()
     assert "Error: URL resolves to a restricted/private network address." in outerr.err
     mock_get.assert_called_once_with("http://public.example/", timeout=30, allow_redirects=False)
+
+
+@patch("requests.Session.get")
+def test_redirect_response_is_closed_before_next_hop(mock_get):
+    """Redirect responses that are not returned are closed before following."""
+    redirect_response = MagicMock()
+    redirect_response.is_redirect = True
+    redirect_response.headers = {"Location": "http://next.example/"}
+
+    final_response = MagicMock()
+    final_response.is_redirect = False
+    final_response.headers = {}
+    mock_get.side_effect = [redirect_response, final_response]
+
+    def resolver(host, port, *args, **kwargs):
+        if host in {"public.example", "next.example"}:
+            return [_addrinfo("93.184.216.34", port=port)]
+        raise socket.gaierror(host)
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=resolver):
+        assert cli._safe_get(MagicMock(), "http://public.example/") is final_response
+
+    redirect_response.close.assert_called_once_with()
+
+
+@patch("requests.Session.get")
+def test_empty_dns_answer_reports_resolution_error(mock_get, capsys, tmp_path):
+    """An empty DNS response is reported as a resolution failure, not SSRF."""
+    with patch("html2md.cli.socket.getaddrinfo", return_value=[]):
+        cli.main(["--url", "http://empty.example/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: Could not resolve hostname to a valid IP." in outerr.err
+    assert "restricted/private" not in outerr.err
+    mock_get.assert_not_called()
 
 
 @patch("requests.Session.get")


### PR DESCRIPTION
### Motivation
- Prevent process-wide races and DNS rebinding by avoiding global monkey-patching of `socket.getaddrinfo` during safe fetches.
- Ensure fetches remain correct for IPv4/IPv6 multi-record hosts and that redirect targets are revalidated before following them.
- Avoid leaking open redirect responses which can exhaust connection pools.

### Description
- Replaced global resolver monkey-patch with a per-request pinned requests adapter built by `_build_pinned_dns_adapter` that opens sockets directly to vetted `getaddrinfo` answers. (`src/html2md/cli.py`)
- Changed `_get_with_pinned_dns` to create a temporary session with `trust_env = False`, preserve caller headers/cookies, mount the pinned adapter, and perform the fetch through that session. (`src/html2md/cli.py`)
- Made redirect handling safer by explicitly calling `response.close()` before following validated `Location` hops and by mapping empty DNS answer errors to a distinct resolution error message. (`src/html2md/cli.py`)
- Updated and added security tests to assert that the global resolver is not swapped, that the adapter connects to vetted addresses without additional DNS lookups, that redirect responses are closed, and that empty DNS answers are reported as resolution failures. (`tests/test_cli_security.py`)

### Testing
- Ran unit tests with `PYENV_VERSION=3.11.15 python -m pytest -q` and all tests completed successfully (no failures).
- Verified the module compiles with `python -m py_compile src/html2md/cli.py` with no syntax errors.
- Added/updated tests in `tests/test_cli_security.py` covering global resolver preservation, adapter-level pinned connects, redirect cleanup, and empty-DNS error reporting, and they passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00304f0fb483209704a11cd3b5d800)