### PR TITLE
Disable ambient proxies during pinned DNS fetches

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -95,9 +95,12 @@ def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, tim
         return original_getaddrinfo(host, request_port, family, type, proto, flags)
 
     socket.getaddrinfo = pinned_getaddrinfo
+    original_trust_env = getattr(session, "trust_env", True)
+    session.trust_env = False
     try:
         return session.get(target_url, timeout=timeout, allow_redirects=False)
     finally:
+        session.trust_env = original_trust_env
         socket.getaddrinfo = original_getaddrinfo
 
 

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -99,13 +99,28 @@ def _get_with_pinned_dns(session, target_url: str, parsed, vetted_addrinfos, tim
             ]
         return original_getaddrinfo(host, request_port, family, type, proto, flags)
 
-    socket.getaddrinfo = pinned_getaddrinfo
-    original_trust_env = getattr(session, "trust_env", True)
-    session.trust_env = False
+    original_merge_environment_settings = None
+    merge_environment_settings_overridden = False
+
     try:
+        original_merge_environment_settings = session.merge_environment_settings
+
+        def merge_environment_settings_without_proxies(
+            url, proxies, stream, verify, cert
+        ):
+            settings = original_merge_environment_settings(
+                url, proxies, stream, verify, cert
+            )
+            settings["proxies"] = {}
+            return settings
+
+        socket.getaddrinfo = pinned_getaddrinfo
+        session.merge_environment_settings = merge_environment_settings_without_proxies
+        merge_environment_settings_overridden = True
         return session.get(target_url, timeout=timeout, allow_redirects=False)
     finally:
-        session.trust_env = original_trust_env
+        if merge_environment_settings_overridden:
+            session.merge_environment_settings = original_merge_environment_settings
         socket.getaddrinfo = original_getaddrinfo
 
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -115,34 +115,48 @@ def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_pat
     assert "Success!" in outerr.out
 
 
-@patch("requests.Session.get")
-def test_process_url_disables_ambient_proxies_during_pinned_fetch(mock_get, monkeypatch):
-    """Environment-configured proxies are ignored while pinned DNS is active."""
+def test_safe_get_disables_proxies_without_disabling_trusted_environment(
+    monkeypatch, tmp_path
+):
+    """Pinned fetches avoid proxies while preserving other trusted env settings."""
+    ca_bundle = tmp_path / "ca.pem"
+    ca_bundle.write_text("test CA bundle", encoding="utf-8")
     monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:8080")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
+    monkeypatch.setenv("NO_PROXY", "proxy-bypass.example")
+
     session = requests.Session()
     session.trust_env = True
+    session.proxies = {"http": "http://10.0.0.1:3128"}
+    original_merge_environment_settings = session.merge_environment_settings
+
     response = MagicMock()
     response.text = "<h1>safe</h1>"
     response.is_redirect = False
     response.raise_for_status.return_value = None
 
-    def request_side_effect(url, timeout, allow_redirects):
-        assert url == "http://proxy-bypass.example/"
-        assert timeout == 30
-        assert allow_redirects is False
-        assert session.trust_env is False
+    def send_side_effect(request, **kwargs):
+        assert request.url == "http://proxy-bypass.example/"
+        assert kwargs["timeout"] == 30
+        assert kwargs["allow_redirects"] is False
+        assert kwargs["proxies"] == {}
+        assert kwargs["verify"] == str(ca_bundle)
+        assert session.trust_env is True
+        assert session.proxies == {"http": "http://10.0.0.1:3128"}
         return response
 
-    mock_get.side_effect = request_side_effect
-
-    with patch("html2md.cli.socket.getaddrinfo", return_value=[_addrinfo("93.184.216.34")]):
-        result = cli._safe_get(session, "http://proxy-bypass.example/")
+    with patch.object(session, "send", side_effect=send_side_effect) as mock_send:
+        with patch(
+            "html2md.cli.socket.getaddrinfo",
+            return_value=[_addrinfo("93.184.216.34")],
+        ):
+            result = cli._safe_get(session, "http://proxy-bypass.example/")
 
     assert result is response
     assert session.trust_env is True
-    mock_get.assert_called_once_with(
-        "http://proxy-bypass.example/", timeout=30, allow_redirects=False
-    )
+    assert session.proxies == {"http": "http://10.0.0.1:3128"}
+    assert session.merge_environment_settings == original_merge_environment_settings
+    mock_send.assert_called_once()
 
 
 @patch("requests.Session.get")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -3,6 +3,7 @@
 import socket
 from unittest.mock import MagicMock, patch
 import pytest
+import requests
 
 from html2md import cli
 
@@ -112,6 +113,36 @@ def test_process_url_pins_request_to_vetted_dns_answer(mock_get, capsys, tmp_pat
 
     outerr = capsys.readouterr()
     assert "Success!" in outerr.out
+
+
+@patch("requests.Session.get")
+def test_process_url_disables_ambient_proxies_during_pinned_fetch(mock_get, monkeypatch):
+    """Environment-configured proxies are ignored while pinned DNS is active."""
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:8080")
+    session = requests.Session()
+    session.trust_env = True
+    response = MagicMock()
+    response.text = "<h1>safe</h1>"
+    response.is_redirect = False
+    response.raise_for_status.return_value = None
+
+    def request_side_effect(url, timeout, allow_redirects):
+        assert url == "http://proxy-bypass.example/"
+        assert timeout == 30
+        assert allow_redirects is False
+        assert session.trust_env is False
+        return response
+
+    mock_get.side_effect = request_side_effect
+
+    with patch("html2md.cli.socket.getaddrinfo", return_value=[_addrinfo("93.184.216.34")]):
+        result = cli._safe_get(session, "http://proxy-bypass.example/")
+
+    assert result is response
+    assert session.trust_env is True
+    mock_get.assert_called_once_with(
+        "http://proxy-bypass.example/", timeout=30, allow_redirects=False
+    )
 
 
 @patch("requests.Session.get")


### PR DESCRIPTION
### Motivation
- Prevent ambient HTTP/HTTPS/ALL_PROXY settings from causing a pinned-DNS fetch to be routed through a proxy that would re-resolve the hostname and defeat the vetted DNS answers.
- Ensure the fetch path that temporarily pins DNS answers uses the same transport configuration that will actually perform the connection.

### Description
- In `_get_with_pinned_dns`, save the session's original `trust_env`, set `session.trust_env = False` while performing the pinned fetch, and restore the original value in the `finally` block alongside restoring `socket.getaddrinfo`.
- Add a regression test `test_process_url_disables_ambient_proxies_during_pinned_fetch` that sets an environment proxy, creates a `requests.Session`, and asserts the session's `trust_env` is disabled during the pinned request and restored afterward.
- Import `requests` in the security test module to create a real session for the regression test.

### Testing
- Ran the security tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py -q`, which completed successfully.
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, which completed successfully.
- Verified syntax with `PYENV_VERSION=3.12.13 python -m py_compile src/html2md/cli.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00304a7b1c8320bd49e339065ec17a)