### PR TITLE
Keep SSRF filter blocking multicast and site-local targets

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -54,7 +54,11 @@ def _validated_addrinfo_for_url(target_url: str):
         except ValueError:
             print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
             return None
-        if not ip_obj.is_global:
+        if (
+            not ip_obj.is_global
+            or ip_obj.is_multicast
+            or getattr(ip_obj, 'is_site_local', False)
+        ):
             print(
                 "Error: URL resolves to a restricted/private network address.",
                 file=sys.stderr,

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -39,6 +39,9 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
         ("http://10.0.0.5/", "10.0.0.5"),
         ("http://[::1]/", "::1"),
         ("http://100.64.0.1/", "100.64.0.1"),
+        ("http://224.0.0.1/", "224.0.0.1"),
+        ("http://[ff02::1]/", "ff02::1"),
+        ("http://[fec0::1]/", "fec0::1"),
     ],
 )
 @patch("requests.Session.get")


### PR DESCRIPTION
### Motivation
- The prior validation relied only on `ipaddress.ip_address(...).is_global`, which treats some multicast and deprecated IPv6 site-local addresses as global and can let restricted network destinations slip through the SSRF check.

### Description
- Updated `_validated_addrinfo_for_url` in `src/html2md/cli.py` to explicitly reject addresses where `not ip_obj.is_global or ip_obj.is_multicast or getattr(ip_obj, 'is_site_local', False)`.
- Extended `tests/test_cli_security.py` to include test cases for `224.0.0.1`, `ff02::1`, and `fec0::1` to cover IPv4 multicast, IPv6 multicast, and IPv6 site-local scenarios.
- Changes touch `src/html2md/cli.py` and `tests/test_cli_security.py` and were committed under the message "Keep blocking restricted global IP ranges".

### Testing
- Installed the package in editable mode with `PYENV_VERSION=3.11.15 python -m pip install -e .` which completed successfully.
- Executed the test suite with `PYENV_VERSION=3.11.15 pytest -q` and all tests passed.
- Ran `git diff --check` and there were no whitespace/diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003033a8008320a4bd91d78308256d)