### PR TITLE
Handle malformed URL ports during SSRF validation

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -37,6 +37,9 @@ def _validated_addrinfo_for_url(target_url: str):
         addrinfo = socket.getaddrinfo(
             hostname, _port_for_url(parsed), type=socket.SOCK_STREAM
         )
+    except ValueError:
+        print("Error: URL contains an invalid port.", file=sys.stderr)
+        return None
     except socket.gaierror:
         print("Error: Could not resolve hostname to a valid IP.", file=sys.stderr)
         return None

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -31,6 +31,25 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
 
 
 @pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com:bad/",
+        "http://example.com:99999/",
+    ],
+)
+@patch("requests.Session.get")
+def test_process_url_rejects_malformed_ports(mock_get, capsys, tmp_path, url):
+    """Malformed URL ports are rejected before DNS lookup or fetch."""
+    with patch("html2md.cli.socket.getaddrinfo") as mock_resolve:
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: URL contains an invalid port." in outerr.err
+    mock_resolve.assert_not_called()
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize(
     "url, ip",
     [
         ("http://127.0.0.1:8080/admin", "127.0.0.1"),


### PR DESCRIPTION
### Motivation
- Prevent the CLI from crashing or reporting a generic conversion failure when `urlparse(...).port` raises `ValueError` for non-numeric or out-of-range ports by treating that case as a validation error.

### Description
- Catch `ValueError` in `_validated_addrinfo_for_url` and print `Error: URL contains an invalid port.` then return `None`, and add `test_process_url_rejects_malformed_ports` to `tests/test_cli_security.py` to verify malformed ports are rejected before DNS or HTTP fetch.

### Testing
- Installed the package with `python -m pip install -e .` and ran `PYENV_VERSION=3.11.15 PYTHONPATH=src pytest tests/test_cli_security.py -q` and `PYENV_VERSION=3.11.15 PYTHONPATH=src pytest -q`, and the test suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003031c8e08320b451333fefa1ef62)