### PR TITLE
Avoid GCA mode when Gemini API key is configured

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
-          use_gemini_code_assist: ${{ env.GOOGLE_GENAI_USE_GCA }}
+          use_gemini_code_assist: ${{ env.GEMINI_API_KEY == '' && env.GOOGLE_GENAI_USE_GCA == 'true' }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           extensions: |
             [


### PR DESCRIPTION
### Motivation
- Prevent `run-gemini-cli` from receiving conflicting authentication inputs when a repository has a `GEMINI_API_KEY` secret and later enables `GOOGLE_GENAI_USE_GCA`, which causes the action/CLI validation to fail.

### Description
- Update the `use_gemini_code_assist` input in `.github/workflows/gemini-code-assist.yml` to `
${{ env.GEMINI_API_KEY == '' && env.GOOGLE_GENAI_USE_GCA == 'true' }}` so GCA mode is enabled only when no `GEMINI_API_KEY` is present, while preserving the existing step-level `if` guard.

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'` and `git diff --check`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00302a2cf883209c68dfa631c16f20)