### PR TITLE
Require WIF credentials for GCA auth

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   issues: write
 
@@ -29,19 +30,30 @@ jobs:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       GEMINI_CLI_TRUST_WORKSPACE: "true"
       GOOGLE_GENAI_USE_GCA: ${{ vars.GOOGLE_GENAI_USE_GCA }}
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != '' || env.GOOGLE_GENAI_USE_GCA == 'true'
+        if: >
+          env.GEMINI_API_KEY != '' ||
+          (env.GOOGLE_GENAI_USE_GCA == 'true' &&
+           env.GCP_PROJECT_ID != '' &&
+           env.GCP_SERVICE_ACCOUNT != '' &&
+           env.GCP_WORKLOAD_IDENTITY_PROVIDER != '')
         continue-on-error: true
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
-          use_gemini_code_assist: ${{ env.GOOGLE_GENAI_USE_GCA }}
+          gcp_project_id: ${{ env.GEMINI_API_KEY == '' && env.GOOGLE_GENAI_USE_GCA == 'true' && env.GCP_PROJECT_ID || '' }}
+          gcp_service_account: ${{ env.GEMINI_API_KEY == '' && env.GOOGLE_GENAI_USE_GCA == 'true' && env.GCP_SERVICE_ACCOUNT || '' }}
+          gcp_workload_identity_provider: ${{ env.GEMINI_API_KEY == '' && env.GOOGLE_GENAI_USE_GCA == 'true' && env.GCP_WORKLOAD_IDENTITY_PROVIDER || '' }}
+          use_gemini_code_assist: ${{ env.GEMINI_API_KEY == '' && env.GOOGLE_GENAI_USE_GCA == 'true' }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
           extensions: |
             [


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated Gemini Code Assist (GCA) runs when `GOOGLE_GENAI_USE_GCA` is enabled without real Google credentials. 
- Avoid conflicting auth modes that break the existing API-key path by ensuring GCA is only enabled when WIF inputs are provided. 
- Ensure the workflow can obtain OIDC tokens for Workload Identity Federation when the GCA path is used.

### Description
- Added `id-token: write` permission so the job can request OIDC tokens for Workload Identity Federation. 
- Exposed `GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, and `GCP_WORKLOAD_IDENTITY_PROVIDER` from repo `vars` into the job `env` so WIF inputs are available. 
- Tightened the step `if` guard to run when either `GEMINI_API_KEY` is present or `GOOGLE_GENAI_USE_GCA == 'true'` and all required WIF variables are non-empty. 
- Passed `gcp_project_id`, `gcp_service_account`, and `gcp_workload_identity_provider` to the `run-gemini-cli` action only when the API-key path is not in use, and made `use_gemini_code_assist` conditional on the API key being empty to avoid auth conflicts. 

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'` which succeeded. 
- Ran `git diff --check` which produced no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00302446c083209ce338c602f276cd)