### PR TITLE
Skip forked self-heal workflow heads

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -14,16 +14,19 @@ permissions:
 
 jobs:
   self-heal:
+    # Skip pull-request workflow_run events, including forked heads, so this
+    # privileged job only checks out trusted repository refs.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
         github.event.workflow_run.pull_requests[0] == null
       )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout failed workflow head
+      - name: Checkout target ref
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
### Motivation
- Prevent the privileged self-heal job from checking out forked PR head commits when triggered by `workflow_run`, which can both fail the checkout and enable privilege escalation by running untrusted code.

### Description
- Add a `workflow_run` guard requiring `github.event.workflow_run.head_repository.full_name == github.repository` and a comment so pull-request `workflow_run` events (including forked heads) are skipped. 
- Rename the checkout step to `Checkout target ref` so the step name is correct for both `workflow_dispatch` and `workflow_run` paths.

### Testing
- Ran `git diff --check`, which succeeded. 
- Parsed the workflow with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'`, which returned `yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00300c52e88320a708e50fa0ca635f)