### PR TITLE
Harden self-heal workflow_run guard against PR heads

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -18,12 +18,13 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'failure' &&
-        github.event.workflow_run.pull_requests[0] == null
+        github.event.workflow_run.event != 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
       )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout failed workflow head
+      - name: Checkout target ref
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
### Motivation
- Prevent the privileged self-heal job from checking out or executing untrusted PR/fork head code by only allowing `workflow_run` handling for failed runs that are not `pull_request` events and originate from the same repository.

### Description
- Update `.github/workflows/self-heal.yml` job guard to require `github.event.workflow_run.event != 'pull_request'` and `github.event.workflow_run.head_repository.full_name == github.repository`, and rename the checkout step to `Checkout target ref` while keeping the conditional `ref` expression.

### Testing
- Ran `git diff --check`, which succeeded, and validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "yaml ok"'`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003009cf0483209ab589f70f99e95d)