### PR TITLE
Skip forked workflow_run self-heal checkouts

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -18,12 +18,13 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
         github.event.workflow_run.pull_requests[0] == null
       )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Checkout failed workflow head
+      - name: Checkout target ref
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
### Motivation
- Prevent the self-heal job from attempting to checkout fork-only commits and from running untrusted PR head code in a privileged `workflow_run` execution.

### Description
- Add a same-repository guard `github.event.workflow_run.head_repository.full_name == github.repository` to the `self-heal` job `if` condition and rename the checkout step to `Checkout target ref`, leaving the existing `ref` expression unchanged.

### Testing
- Ran `git diff --check`, which succeeded, and attempted `actionlint .github/workflows/self-heal.yml` but `actionlint` was not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00300469308320b187007cf2cb375f)