### PR TITLE
Make app config tests run without Flask

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,58 +1,70 @@
 """Tests for the Flask application module."""
 
+from __future__ import annotations
+
+import importlib
 import os
+import sys
 from unittest import mock
 
-import pytest
 
-pytest.importorskip("flask")
-
-from html2md.app import get_host_port, DEFAULT_PORT
+def _load_app_module():
+    """Import html2md.app with a stub Flask module for CI environments."""
+    sys.modules.pop("html2md.app", None)
+    flask_stub = mock.MagicMock()
+    flask_stub.Flask.return_value.route.return_value = lambda func: func
+    with mock.patch.dict(sys.modules, {"flask": flask_stub}, clear=False):
+        return importlib.import_module("html2md.app")
 
 
 def test_get_host_port_defaults():
     """Test get_host_port with no environment variables set."""
+    app = _load_app_module()
     with mock.patch.dict(os.environ, {}, clear=True):
-        host, port = get_host_port()
+        host, port = app.get_host_port()
         assert host == "0.0.0.0"
-        assert port == DEFAULT_PORT
+        assert port == app.DEFAULT_PORT
 
 
 def test_get_host_port_valid_port():
     """Test get_host_port with a valid PORT environment variable."""
+    app = _load_app_module()
     with mock.patch.dict(os.environ, {"PORT": "8080"}, clear=True):
-        host, port = get_host_port()
+        host, port = app.get_host_port()
         assert host == "0.0.0.0"
         assert port == 8080
 
 
 def test_get_host_port_invalid_port(capsys):
     """Test get_host_port with an invalid PORT falls back to default and warns."""
+    app = _load_app_module()
     with mock.patch.dict(os.environ, {"PORT": "invalid"}, clear=True):
-        host, port = get_host_port()
+        host, port = app.get_host_port()
 
         # Check return values
         assert host == "0.0.0.0"
-        assert port == DEFAULT_PORT
+        assert port == app.DEFAULT_PORT
 
         # Check stdout for the warning message
         captured = capsys.readouterr()
         assert "Warning: Invalid PORT environment variable value" in captured.out
         assert "'invalid'" in captured.out
-        assert str(DEFAULT_PORT) in captured.out
+        assert str(app.DEFAULT_PORT) in captured.out
 
 
 def test_get_host_port_custom_host():
     """Test get_host_port with a custom HOST environment variable."""
+    app = _load_app_module()
     with mock.patch.dict(os.environ, {"HOST": "127.0.0.1"}, clear=True):
-        host, port = get_host_port()
+        host, port = app.get_host_port()
         assert host == "127.0.0.1"
-        assert port == DEFAULT_PORT
+        assert port == app.DEFAULT_PORT
 
 
 def test_get_host_port_custom_host_and_port():
     """Test get_host_port with both HOST and valid PORT environment variables."""
+    app = _load_app_module()
     with mock.patch.dict(os.environ, {"HOST": "localhost", "PORT": "5000"}, clear=True):
-        host, port = get_host_port()
+        host, port = app.get_host_port()
         assert host == "localhost"
         assert port == 5000


### PR DESCRIPTION
### Motivation
- The CI job installs only the base package and `pytest` (Flask is an optional `deploy` extra), so the previous `pytest.importorskip("flask")` at module import caused the `get_host_port()` tests to be skipped and left a coverage gap.
- The tests need to exercise `get_host_port()` in the default CI environment without requiring the `flask` dependency.

### Description
- Replace the module-level `pytest.importorskip("flask")` by adding a `_load_app_module()` helper that injects a stub `flask` into `sys.modules` and imports `html2md.app` with `importlib.import_module` so the app module can be loaded without the real Flask package.
- Update tests in `tests/test_app.py` to call `app.get_host_port()` and use `app.DEFAULT_PORT` from the dynamically imported module instead of relying on a direct import that requires Flask.
- Preserve existing assertions and warning checks (the tests still capture the printed warning on stdout); logging-to-`app.logger` was suggested separately but not changed here.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_app.py`, which passed.
- Ran `PYENV_VERSION=3.12.13 python -m pip install -e . pytest` to ensure dependencies and editable install succeeded.
- Ran the full suite with `PYENV_VERSION=3.12.13 python -m pytest -q`, which failed due to an unrelated existing test `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` raising a `TypeError` in `gettext` because that test's `builtins.open` mock intercepts `gettext` file loading during `argparse` initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2405f6d88320ba865824a0d9dc0a)