### PR TITLE
Resolve Python interpreter before healthcheck pytest

### DIFF
--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -39,10 +39,11 @@ const pyenvVersionCandidates = () => {
       ? readFileSync(".python-version", "utf8").trim()
       : null;
     const pinnedSeries = pinned?.split(".").slice(0, 2).join(".");
-    const sorted = pinnedSeries
+    const sorted = pinned
       ? [
-          ...versions.filter((version) => version.startsWith(`${pinnedSeries}.`)),
-          ...versions.filter((version) => !version.startsWith(`${pinnedSeries}.`)),
+          ...versions.filter((v) => v === pinned),
+          ...versions.filter((v) => v !== pinned && pinnedSeries && (v === pinnedSeries || v.startsWith(`${pinnedSeries}.`))),
+          ...versions.filter((v) => v !== pinned && (!pinnedSeries || (v !== pinnedSeries && !v.startsWith(`${pinnedSeries}.`)))),
         ]
       : versions;
 

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -4,11 +4,13 @@
    - optionally run root package scripts, without pnpm workspace flags
    - in real pnpm workspaces only, smoke build packages that declare build
 */
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const run = (cmd, opts = {}) => execSync(cmd, { stdio: "inherit", ...opts });
+const runFile = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { stdio: "inherit", ...opts });
 const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
 const rootPkgPath = join(process.cwd(), "package.json");
 const rootPkg = existsSync(rootPkgPath) ? readJson(rootPkgPath) : {};
@@ -21,13 +23,108 @@ const tryRun = (name, cmd) => {
   run(cmd);
 };
 
+const pyenvVersionCandidates = () => {
+  try {
+    const output = execFileSync("pyenv", ["versions", "--bare"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const versions = output
+      .split("\n")
+      .map((version) => version.trim())
+      .filter(Boolean);
+    if (!versions.length) return [];
+
+    const pinned = existsSync(".python-version")
+      ? readFileSync(".python-version", "utf8").trim()
+      : null;
+    const pinnedSeries = pinned?.split(".").slice(0, 2).join(".");
+    const sorted = pinnedSeries
+      ? [
+          ...versions.filter((version) => version.startsWith(`${pinnedSeries}.`)),
+          ...versions.filter((version) => !version.startsWith(`${pinnedSeries}.`)),
+        ]
+      : versions;
+
+    return sorted.map((version) => ({
+      command: "pyenv",
+      args: ["exec", "python"],
+      env: { ...process.env, PYENV_VERSION: version },
+    }));
+  } catch {
+    return [];
+  }
+};
+
+const pythonCandidates = () => {
+  const candidates = [];
+  if (process.env.PYTHON) {
+    candidates.push({ command: process.env.PYTHON, args: [], env: process.env });
+  }
+  candidates.push(
+    { command: "python3", args: [], env: process.env },
+    ...pyenvVersionCandidates(),
+    { command: "python", args: [], env: process.env },
+    { command: "py", args: ["-3"], env: process.env },
+  );
+  return candidates;
+};
+
+const isSupportedPython = ({ command, args, env }) => {
+  const check =
+    "import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)";
+  try {
+    execFileSync(command, [...args, "-c", check], { env, stdio: "ignore" });
+    execFileSync(command, [...args, "-m", "pip", "--version"], {
+      env,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const resolvePython = () => {
+  const seen = new Set();
+  for (const candidate of pythonCandidates()) {
+    const key = [candidate.env?.PYENV_VERSION, candidate.command, ...candidate.args].join(
+      " ",
+    );
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (isSupportedPython(candidate)) return candidate;
+  }
+
+  throw new Error(
+    "No supported Python interpreter found. Install Python >=3.8 or set PYTHON " +
+      "to a working interpreter before running the healthcheck.",
+  );
+};
+
+const tryRunPython = (name, python, args) => {
+  console.log(`\n==> ${name}`);
+  runFile(python.command, [...python.args, ...args], { env: python.env });
+};
+
 const runPythonTests = () => {
   if (!existsSync("tests")) return;
 
+  const python = resolvePython();
+
   // Match CI's Python setup before invoking pytest so clean self-heal runners
-  // have pytest and the src-layout package installed.
-  tryRun("Python test dependencies", "python -m pip install -e . pytest");
-  tryRun("Python tests", "python -m pytest -q");
+  // have pytest and the src-layout package installed. Resolve an available
+  // interpreter first instead of relying on pyenv's bare `python` shim matching
+  // the exact version pinned in .python-version.
+  tryRunPython("Python test dependencies", python, [
+    "-m",
+    "pip",
+    "install",
+    "-e",
+    ".",
+    "pytest",
+  ]);
+  tryRunPython("Python tests", python, ["-m", "pytest", "-q"]);
 };
 
 try {
@@ -50,10 +147,10 @@ try {
         const dir = join(base, name);
         const pkgPath = join(dir, "package.json");
         if (!statSync(dir).isDirectory() || !existsSync(pkgPath)) continue;
-        const pkg = readJson(pkgPath);
-        if (!pkg.scripts?.build) continue;
         try {
-          execSync("pnpm run --if-present build", { cwd: dir, stdio: "inherit" });
+          const pkg = readJson(pkgPath);
+          if (!pkg.scripts?.build) continue;
+          run("pnpm run build", { cwd: dir });
         } catch (e) {
           console.error(`[healthcheck] build failed in ${dir}`);
           process.exitCode = 1;


### PR DESCRIPTION
### Motivation
- The healthcheck assumed a working bare `python` shim which fails in environments pinned with `.python-version` or missing `pip`, causing self-heal to abort before exercising the Python CI gate.
- Workspace-wide `pnpm -w` invocations and package parsing could prematurely abort the healthcheck when a package JSON is malformed or the repo is not a pnpm workspace.

### Description
- Augmented `scripts/healthcheck.mjs` to resolve a usable Python interpreter instead of invoking the bare `python`, preferring `PYTHON`, `python3`, pyenv-managed interpreters, `python`, and the Windows `py -3` launcher.
- Validate each candidate for Python >= 3.8 and a usable `pip` before using it, and run Python dependency installation and `pytest` via `execFileSync` with the candidate's environment.
- Keep per-package `package.json` parsing inside the per-package `try/catch` and replace `pnpm run --if-present build` with the shared `run` helper for consistent invocation.
- Minor helpers added: `runFile`, `pyenvVersionCandidates`, `pythonCandidates`, `isSupportedPython`, `resolvePython`, and `tryRunPython` in `scripts/healthcheck.mjs` to implement the above behavior.

### Testing
- Ran `node --check scripts/healthcheck.mjs` which succeeded.
- Ran `node --check scripts/self-heal.mjs` which succeeded.
- Executed the updated healthcheck with `node scripts/healthcheck.mjs`; the script resolved a pyenv Python, installed package test dependencies (`-e .` and `pytest`) and then ran `pytest`, which completed but reported a failing test: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` (pytest run failed overall).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002ffa499c83209ca908a291b8e689)