### PR TITLE
Install Python dependencies before self-heal healthchecks

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -36,6 +36,18 @@ jobs:
         with:
           version: 9
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python deps
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -e .
+          python -m pip install pytest
+
       - name: Install deps (best-effort frozen)
         id: install_try_frozen
         run: |


### PR DESCRIPTION
### Motivation
- The self-heal job runs `node scripts/healthcheck.mjs`, which now invokes `pytest`, but the self-heal workflow previously only provisioned Node/pnpm and could fail with `ModuleNotFoundError` for `pytest` or missing project deps.  
- Provisioning Python and installing the project/test deps before the healthcheck ensures the pytest gate can run on clean runners just like CI does.

### Description
- Added a `Set up Python` step using `actions/setup-python@v5` to `.github/workflows/self-heal.yml`.  
- Added an `Install Python deps` step that runs `python -m pip install --upgrade pip wheel setuptools`, `python -m pip install -e .`, and `python -m pip install pytest` prior to pnpm installation.  
- The change is limited to `.github/workflows/self-heal.yml` so the self-heal job now mirrors the CI Python setup before executing the healthcheck.

### Testing
- Ran `node --check scripts/healthcheck.mjs` and it succeeded.  
- Ran `node --check scripts/self-heal.mjs` and it succeeded.  
- Ran `git diff --check` to validate the patch format and it produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002ff81ee48320a612a666b2acd4d8)