### PR TITLE
Keep self-heal manual until healthcheck is safe

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -2,10 +2,6 @@ name: Self-heal (auto-fix & PR)
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["ci"]
-    types:
-      - completed
 
 permissions:
   contents: write
@@ -14,9 +10,7 @@ permissions:
 
 jobs:
   self-heal:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
### Motivation
- Prevent the pnpm-based self-heal workflow from automatically running against this repository's `ci` failures because the current healthcheck assumes a pnpm workspace and can fail or produce incorrect repairs when run on this repo.

### Description
- Remove the `workflow_run` trigger from `.github/workflows/self-heal.yml` and simplify the job guard to `if: github.event_name == 'workflow_dispatch'` so the self-heal job only runs manually.

### Testing
- Ran `git diff --check` and committed the change with no diff/lint errors, and ran `node scripts/healthcheck.mjs` which failed with `--workspace-root may only be used inside a workspace`, confirming the healthcheck is incompatible with this repo layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002fec9d08832096f83f7f9ffc18e9)