### PR TITLE
Restrict self-heal workflow runs to default-branch pushes

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,7 +16,11 @@ jobs:
   self-heal:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+      (
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == github.event.repository.default_branch
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -24,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
### Motivation
- Prevent the self-heal workflow from running against PR CI failures and producing fixes applied to the default branch instead of the code that actually failed.
- Ensure automatic self-heal runs check out the triggering run's commit so repairs are generated against the failing commit when appropriate.

### Description
- Update `.github/workflows/self-heal.yml` `if` condition to require `github.event.workflow_run.event == 'push'` and `github.event.workflow_run.head_branch == github.event.repository.default_branch` for automatic `workflow_run` executions.
- Add a `ref` parameter to the `actions/checkout` step: `ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}` to check out the triggering run's `head_sha` for automatic runs while preserving manual dispatch behavior.
- Keep the `workflow_run.workflows` target (the repo `ci` workflow) so the self-heal workflow listens to the existing CI workflow runs.

### Testing
- Ran `git diff --check` with no issues reported.
- Verified YAML parses by running `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002fe43bc08320bfc5e423ed775e84)