### PR TITLE
Validate self-heal repairs on Windows

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -21,7 +21,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
-    runs-on: ubuntu-latest
+    # Match the ci workflow runner so repaired revisions are validated in the
+    # same OS environment before opening an auto-fix PR.
+    runs-on: windows-latest
     timeout-minutes: 25
     steps:
       - name: Checkout failing revision


### PR DESCRIPTION
### Motivation

- The repository CI `ci` job runs on `windows-latest`, while the self-heal job previously ran on Ubuntu, which can let Windows-specific failures be considered healed incorrectly when validated on a different OS.

### Description

- Change `.github/workflows/self-heal.yml` so the `self-heal` job uses `runs-on: windows-latest` and add an inline comment explaining the reason to mirror the CI runner.

### Testing

- Validated the modified workflow with `git diff --check` which reported no whitespace errors.
- Loaded both workflow YAML files with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/self-heal.yml'); YAML.load_file('.github/workflows/ci.yml')"` which returned `YAML ok` indicating both files parse correctly.
- The change was staged and committed locally as part of preparing the follow-up PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4605dc8083209a98785a1151e08b)