### PR TITLE
Assert escaped output paths are not opened

### DIFF
--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -4,14 +4,6 @@ from unittest.mock import patch, MagicMock, mock_open
 import io
 import requests  # type: ignore[import-untyped]
 from html2md.cli import main
-import builtins
-
-original_open = builtins.open
-
-def custom_open(*args, **kwargs):
-    if args and str(args[0]).endswith('.md'):
-        return mock_open()(*args, **kwargs)
-    return original_open(*args, **kwargs)
 
 
 class TestCliExceptions(unittest.TestCase):
@@ -67,7 +59,7 @@ class TestCliExceptions(unittest.TestCase):
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
                     with patch('os.path.exists', return_value=True):
-                        with patch('builtins.open', side_effect=custom_open) as m_open:
+                        with patch('html2md.cli.open', mock_open(), create=True) as m_open:
                             def fake_realpath(path):
                                 if str(path).endswith('.md'):
                                     return '/tmp/outside/a.md'
@@ -78,3 +70,4 @@ class TestCliExceptions(unittest.TestCase):
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)
+                            m_open.assert_not_called()


### PR DESCRIPTION
### Motivation
- Prevent brittle global `builtins.open` mocking that caused unrelated file opens to count against the test, and scope the mock to the code under test.
- Preserve the security-sensitive assertion that an escaped output path is never opened so the test continues to catch path traversal regressions.

### Description
- Removed the global `custom_open` shim and related `builtins.open` override from `tests/test_cli_exceptions.py`.
- Patch `open` specifically in the CLI module with `with patch('html2md.cli.open', mock_open(), create=True) as m_open:` to isolate the mock to `html2md.cli`.
- Restored the assertion `m_open.assert_not_called()` to ensure no write/open is attempted when the containment check fails.
- Committed the updated test file with a focused change and message `Assert escaped output paths are not opened`.

### Testing
- Ran dependency install and test run with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest requests markdownify` which completed successfully.
- Ran the focused test with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_exceptions.py -q` and it passed.
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd45de6e908320be627bf88a2282f8)