### PR TITLE
Use pull request merge ref for self-heal

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -19,7 +19,8 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       github.event.workflow_run.pull_requests[0].number != null)
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -27,8 +28,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
-          repository: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name || github.repository }}
+          # pull_request CI runs test the synthetic merge commit on refs/pull/<n>/merge;
+          # replay that ref instead of the contributor head SHA so repairs validate
+          # against the same base-branch integration state that failed.
+          ref: ${{ github.event_name == 'workflow_run' && format('refs/pull/{0}/merge', github.event.workflow_run.pull_requests[0].number) || github.sha }}
+          repository: ${{ github.repository }}
 
       - name: Use Python 3.x
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Motivation
- Prevent the self-heal workflow from running privileged repair steps on fork or non-PR workflow_run events to reduce risk of executing untrusted code.
- Ensure repairs are validated against the same synthetic merge commit that `pull_request` CI tested so fixes actually reproduce the failing integration state.

### Description
- Added a guard to the `self-heal` job so `workflow_run` repairs only run when a PR number is present and the head repository matches the current repo by updating `if:` in `.github/workflows/self-heal.yml`.
- For `workflow_run` events, changed the checkout `ref` to `refs/pull/<number>/merge` and forced `repository: ${{ github.repository }}` so the job replays the same merge ref that `pull_request` CI uses.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch problems and it passed.
- Loaded the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/self-heal.yml')"` to verify it parses as valid YAML and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd45ba9ee08320b198b19ce3fa839f)