### PR TITLE
Assert escaped markdown output is not opened

### DIFF
--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -79,8 +79,8 @@ class TestCliExceptions(unittest.TestCase):
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)
                             opened_markdown_paths = [
-                                call.args[0]
-                                for call in m_open.call_args_list
-                                if call.args and str(call.args[0]).endswith('.md')
+                                p for call in m_open.call_args_list
+                                for p in [call.args[0] if call.args else call.kwargs.get('file')]
+                                if p and str(p).endswith('.md')
                             ]
                             self.assertEqual([], opened_markdown_paths)

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -78,3 +78,9 @@ class TestCliExceptions(unittest.TestCase):
 
                             output = captured_stderr.getvalue()
                             self.assertIn("Output path escapes output directory", output)
+                            opened_markdown_paths = [
+                                call.args[0]
+                                for call in m_open.call_args_list
+                                if call.args and str(call.args[0]).endswith('.md')
+                            ]
+                            self.assertEqual([], opened_markdown_paths)


### PR DESCRIPTION
### Motivation

- Restore the security-focused assertion in the containment test so the suite verifies that an escaped output path is not opened or written after the error is reported.

### Description

- Update `tests/test_cli_exceptions.py` to record `m_open.call_args_list`, filter calls whose first argument ends with `.md`, and assert the resulting list is empty.
- Keep the existing `custom_open` side effect and the check that the error message "Output path escapes output directory" is emitted.

### Testing

- An initial `pytest` collection run failed due to a missing `requests` dependency; dependencies were installed via editable install to resolve that error.
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_exceptions.py -q` and the modified test passed. 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd45b104788320bc8be09932b8e0d0)