### PR TITLE
Run self-heal on Windows CI runner

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 25
     steps:
       - name: Checkout


### PR DESCRIPTION
### Motivation
- Ensure the self-heal validation runs on the same OS as the failing CI (the `ci` job uses `windows-latest`) so Windows-specific path/encoding/shell/filesystem failures can be reproduced and fixed.

### Description
- Update `.github/workflows/self-heal.yml` to change the job `runs-on` from `ubuntu-latest` to `windows-latest` so the repair/healthcheck steps run on Windows.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch problems and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd45a409cc8320bd26996fe502d230)