### PR TITLE
Preserve self-heal pipeline exit codes

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -43,14 +43,17 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
+        shell: bash
         run: python scripts/healthcheck.py | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
+        shell: bash
         run: python scripts/self-heal.py | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
+        shell: bash
         run: python scripts/healthcheck.py | tee selfheal-post.txt
 
       - name: Collect logs


### PR DESCRIPTION
### Motivation

- Prevent `tee` from masking nonzero exits of the healthcheck and self-heal scripts by ensuring the steps run under Bash with `pipefail` enabled so the workflow observes the real script exit codes.

### Description

- Add `shell: bash` to the three workflow steps that pipe script output through `tee` in `.github/workflows/self-heal.yml` (`Run healthcheck (pre-repair)`, `Attempt self-heal repairs`, and `Run healthcheck (post-repair)`), so the pipeline preserves the exit status of the first command in each pipeline.

### Testing

- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'` which returned `YAML OK`.
- `actionlint` was not available in the environment so a full lint check was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd459b4a848320954de04af8304a3e)