### PR TITLE
Avoid pytest-mock fixture in batch CLI tests

### DIFF
--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -1,5 +1,9 @@
 """Tests for CLI batch URL processing."""
 
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from html2md import cli
 
 
@@ -40,7 +44,7 @@ def test_ordered_bounded_map_caps_submitted_futures_before_first_result():
     assert executor.max_in_flight == 3
 
 
-def test_batch_outputs_results_in_input_order(mocker, capsys, tmp_path):
+def test_batch_outputs_results_in_input_order(monkeypatch, capsys, tmp_path):
     """Batch mode keeps deterministic output ordering across multiple URLs."""
     batch_file = tmp_path / "urls.txt"
     batch_file.write_text(
@@ -48,19 +52,24 @@ def test_batch_outputs_results_in_input_order(mocker, capsys, tmp_path):
         encoding="utf-8",
     )
 
-    session = mocker.MagicMock()
+    session = MagicMock()
 
     def fake_get(url, timeout):
-        response = mocker.MagicMock()
+        response = MagicMock()
         response.text = f"<h1>{url.rsplit('/', 1)[-1]}</h1>"
         response.raise_for_status.return_value = None
         return response
 
     session.get.side_effect = fake_get
-    mocker.patch("requests.Session", return_value=session)
-    mocker.patch(
-        "markdownify.markdownify",
-        side_effect=lambda html, heading_style: html,
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        SimpleNamespace(Session=lambda: session, RequestException=Exception),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "markdownify",
+        SimpleNamespace(markdownify=lambda html, heading_style: html),
     )
 
     assert cli.main(["--batch", str(batch_file)]) == 0


### PR DESCRIPTION
### Motivation
- Prevent test collection failures in a clean checkout/CI by avoiding the undeclared `mocker` fixture from `pytest-mock` and making the batch test self-contained.

### Description
- Replaced the `mocker` fixture usage in `tests/test_cli_batch.py` with pytest's built-in `monkeypatch` and `unittest.mock.MagicMock` to remove the implicit `pytest-mock` dependency.
- Injected lightweight fake `requests` and `markdownify` modules via `sys.modules` (using `SimpleNamespace`) so the batch ordering test does not require real runtime network dependencies.
- Adjusted imports and the test signature to `def test_batch_outputs_results_in_input_order(monkeypatch, capsys, tmp_path):` in `tests/test_cli_batch.py`.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_cli_batch.py` and the tests passed (`..`).
- Attempted `PYTHONPATH=src pytest -q` but collection fails in this checkout due to unrelated missing runtime dependencies (e.g., `requests`) in other tests, so full-suite results are not reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4550b9108320b18536745e169733)