### PR TITLE
Secure self-heal workflow write-token boundary

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -25,8 +25,7 @@ jobs:
         )
       )
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -57,32 +56,71 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          mkdir -p "$RUNNER_TEMP/selfheal-logs"
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-logs/selfheal-pre.txt"
 
       - name: Attempt self-heal repairs
         run: |
           set -o pipefail
-          node scripts/self-heal.mjs | tee selfheal-repair.txt
+          node scripts/self-heal.mjs | tee "$RUNNER_TEMP/selfheal-logs/selfheal-repair.txt"
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-logs/selfheal-post.txt"
+
+      - name: Create repair patch
+        if: steps.post.outcome == 'success'
+        run: |
+          set -euxo pipefail
+          git diff --binary > "$RUNNER_TEMP/selfheal.patch"
+          test -s "$RUNNER_TEMP/selfheal.patch"
+
+      - name: Upload repair patch
+        if: steps.post.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfheal-patch
+          path: ${{ runner.temp }}/selfheal.patch
+          if-no-files-found: error
 
       - name: Collect logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: selfheal-logs
-          path: |
-            selfheal-pre.txt
-            selfheal-repair.txt
-            selfheal-post.txt
+          path: ${{ runner.temp }}/selfheal-logs/*.txt
+
+  create-repair-pr:
+    needs: self-heal
+    if: needs.self-heal.result == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repaired source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Download repair patch
+        uses: actions/download-artifact@v4
+        with:
+          name: selfheal-patch
+          path: ${{ runner.temp }}/selfheal-patch
+
+      - name: Apply repair patch
+        run: |
+          set -euxo pipefail
+          git apply --binary "$RUNNER_TEMP/selfheal-patch/selfheal.patch"
 
       - name: Create PR with fixes
-        if: steps.post.outcome == 'success'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore: auto-fix lint/format and lockfiles"


### PR DESCRIPTION
### Motivation
- Prevent branch-controlled repair code from running with repository write tokens by separating read-only repair execution from write-scoped PR creation.

### Description
- Change `self-heal` job permissions to read-only and keep healthcheck/repair steps in that job so untrusted branch code never runs with write-scoped tokens in `.github/workflows/self-heal.yml`.
- Write healthcheck and repair logs to `$RUNNER_TEMP/selfheal-logs` instead of the repo checkout and upload them as artifacts to avoid polluting PR diffs.
- Produce a binary patch with `git diff --binary` and upload it as an artifact when post-repair healthcheck succeeds, then add a new `create-repair-pr` job that downloads and applies the patch and runs the write-scoped `create-pull-request` step.
- Keep `peter-evans/create-pull-request` pinned and ensure the write-scoped job holds the minimal `contents: write` / `pull-requests: write` permissions required to create the PR.

### Testing
- Verified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "yaml ok"'` (success).
- Ran `git diff --check` to ensure no whitespace or diff problems (success).
- Checked runtime sanity with `python3 --version && node --check scripts/healthcheck.mjs && node --check scripts/self-heal.mjs` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4545a5948320b68a5d7faad253a7)