### PR TITLE
Validate self-heal repairs on CI runner

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -28,8 +28,13 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
-    runs-on: ubuntu-latest
+    # Mirror .github/workflows/ci.yml so repairs are validated on the
+    # same OS family and default Python channel as the failing CI job.
+    runs-on: windows-latest
     timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install Python deps
         run: |


### PR DESCRIPTION
### Motivation
- The self-heal workflow validated repairs on `ubuntu-latest`/Python 3.11 while the repository CI runs on `windows-latest`/`python-version: '3.x'`, which can produce false-positive healthchecks for Windows-specific or Python-version-specific failures.
- Preserve existing `pipefail`-based logging semantics when running the repair steps on the CI runner by using a Bash-compatible shell on Windows.

### Description
- Change the self-heal job `runs-on` from `ubuntu-latest` to `windows-latest` and add an inline comment documenting the intent to mirror the CI job environment.
- Add a `defaults.run.shell: bash` so existing `set -o pipefail` logging and exit-code handling continue to work on the Windows runner.
- Align the Python setup to the CI channel by changing `python-version: '3.11'` to `python-version: '3.x'` so post-repair validation uses the same default Python family as the failing CI.

### Testing
- Ran `git diff --check` and a small validation command sequence: `python3 --version && node --check scripts/healthcheck.mjs && node --check scripts/self-heal.mjs && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "yaml ok"'`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4532b688832083394f658f6c2531)