### PR TITLE
Guard self-heal repair step pipefail behavior

### DIFF
--- a/tests/test_self_heal_workflow.py
+++ b/tests/test_self_heal_workflow.py
@@ -1,0 +1,29 @@
+"""Regression tests for the self-heal GitHub Actions workflow."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SELF_HEAL_WORKFLOW = ROOT / ".github" / "workflows" / "self-heal.yml"
+
+
+def _workflow_step(name: str) -> str:
+    """Return the text block for a named workflow step."""
+    source = SELF_HEAL_WORKFLOW.read_text(encoding="utf-8")
+    marker = f"      - name: {name}\n"
+    start = source.index(marker)
+    next_step = source.find("\n      - name: ", start + len(marker))
+    if next_step == -1:
+        return source[start:]
+    return source[start:next_step]
+
+
+def test_self_heal_repair_step_preserves_command_failures():
+    """The repair command is piped through tee, so pipefail must preserve failures."""
+    repair_step = _workflow_step("Attempt self-heal repairs")
+
+    assert "set -o pipefail" in repair_step
+    assert "node scripts/self-heal.mjs | tee selfheal-repair.txt" in repair_step
+    assert repair_step.index("set -o pipefail") < repair_step.index(
+        "node scripts/self-heal.mjs | tee selfheal-repair.txt"
+    )


### PR DESCRIPTION
### Motivation
- Prevent the self-heal workflow from masking failures when the repair script is piped to `tee` so a non-zero exit from `node scripts/self-heal.mjs` is preserved and the job can fail appropriately.

### Description
- Add `tests/test_self_heal_workflow.py` which extracts the `Attempt self-heal repairs` workflow step and asserts that `set -o pipefail` appears before the `node scripts/self-heal.mjs | tee selfheal-repair.txt` command.
- The test ensures future changes do not remove or reorder the `pipefail` handling that would otherwise allow `tee` to hide the repair script's exit status.

### Testing
- Ran `pytest -q tests/test_self_heal_workflow.py tests/test_healthcheck_script.py`, which initially warned due to the local `.python-version` requiring `3.12.5` not installed. 
- Re-ran successfully with `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_self_heal_workflow.py tests/test_healthcheck_script.py`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44edd44483209850773d6fe59808)