### PR TITLE
Fix self-heal validation runner

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -28,8 +28,11 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install Python deps
         run: |


### PR DESCRIPTION
### Motivation
- The self-heal workflow validated repairs on `ubuntu-latest` with `python-version: '3.11'` while the repository CI runs on `windows-latest` with `python-version: '3.x'`, allowing environment-mismatched healthchecks to produce false-positive auto-heal PRs. 
- The workflow relies on `set -o pipefail` logging semantics, which require a bash-compatible shell even when running on the Windows runner.

### Description
- Change the self-heal job `runs-on` from `ubuntu-latest` to `windows-latest` in `.github/workflows/self-heal.yml` to match the CI runner. 
- Update the Python setup in the self-heal job to use `python-version: '3.x'` so the verification environment matches `.github/workflows/ci.yml`. 
- Add `defaults.run.shell: bash` to ensure `set -o pipefail` and the existing logging commands behave correctly on the Windows runner. 
- Commit the updated `.github/workflows/self-heal.yml` to apply the fixes.

### Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "ok"'` succeeded. 
- `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_healthcheck_script.py` succeeded. 
- Full test run `PYENV_VERSION=3.11.15 python -m pytest -q` failed with one failing test: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check`, which is caused by the test patching `builtins.open` and interfering with Python gettext locale-file loading in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44e75b7c8320b878834fa977fdb3)