### PR TITLE
Keep self-heal logs out of generated PR diffs

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -57,29 +57,29 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          mkdir -p "$RUNNER_TEMP/selfheal-logs"
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-logs/selfheal-pre.txt"
 
       - name: Attempt self-heal repairs
         run: |
           set -o pipefail
-          node scripts/self-heal.mjs | tee selfheal-repair.txt
+          mkdir -p "$RUNNER_TEMP/selfheal-logs"
+          node scripts/self-heal.mjs | tee "$RUNNER_TEMP/selfheal-logs/selfheal-repair.txt"
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          mkdir -p "$RUNNER_TEMP/selfheal-logs"
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-logs/selfheal-post.txt"
 
       - name: Collect logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: selfheal-logs
-          path: |
-            selfheal-pre.txt
-            selfheal-repair.txt
-            selfheal-post.txt
+          path: ${{ runner.temp }}/selfheal-logs/*.txt
 
       - name: Create PR with fixes
         if: steps.post.outcome == 'success'


### PR DESCRIPTION
### Motivation
- Prevent self-heal run logs from appearing as untracked files in the repository root and being committed into automated repair PRs. 
- Avoid non-empty `git status` caused by runtime logs so the repair script's `git status --porcelain` output correctly reflects real source changes. 

### Description
- Write pre/repair/post self-heal logs to a temporary runner directory by creating `"$RUNNER_TEMP/selfheal-logs"` and piping to `tee "$RUNNER_TEMP/selfheal-logs/<name>.txt"` instead of writing into the checkout. 
- Update the artifact upload to collect logs from `${{ runner.temp }}/selfheal-logs/*.txt` so diagnostics remain available without creating repository-root files. 
- Keep existing `set -o pipefail` behavior on the piped steps so command failures are still propagated. 

### Testing
- Verified the workflow references the temp-directory log paths using a `python3` inline script that checked for the expected `$RUNNER_TEMP` paths. 
- Ran `git diff --check` to ensure there are no whitespace/patch errors and observed the updated workflow diff. 
- Parsed the updated YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'` to ensure the workflow remains valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44dbce508320ad6d5e0969e46d94)