### PR TITLE
Keep self-heal logs out of repair PRs

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -57,17 +57,17 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          node scripts/healthcheck.mjs | tee "${{ runner.temp }}/selfheal-pre.txt"
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: node scripts/self-heal.mjs | tee "${{ runner.temp }}/selfheal-repair.txt"
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node scripts/healthcheck.mjs | tee "${{ runner.temp }}/selfheal-post.txt"
 
       - name: Collect logs
         if: always()
@@ -75,9 +75,9 @@ jobs:
         with:
           name: selfheal-logs
           path: |
-            selfheal-pre.txt
-            selfheal-repair.txt
-            selfheal-post.txt
+            ${{ runner.temp }}/selfheal-pre.txt
+            ${{ runner.temp }}/selfheal-repair.txt
+            ${{ runner.temp }}/selfheal-post.txt
 
       - name: Create PR with fixes
         if: steps.post.outcome == 'success'


### PR DESCRIPTION
### Motivation
- Prevent transient `selfheal-*.txt` diagnostics from being staged and committed into automated repair PRs by ensuring logs are not written into the repository checkout.

### Description
- Change the self-heal workflow to write pre-repair, repair, and post-repair logs to `${{ runner.temp }}` and update the artifact upload step to collect those files from `${{ runner.temp }}` in `.github/workflows/self-heal.yml`.

### Testing
- Ran `git diff --check` which passed, and validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "yaml ok"'`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44cac8408320adfc55c7ecf422de)