### PR TITLE
Set explicit `base` for self-heal create-pull-request on workflow_run

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -92,3 +92,4 @@ jobs:
             Please review the attached logs for details.
           labels: self-heal
           branch: auto-heal/fixes
+          base: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}


### PR DESCRIPTION
### Motivation
- Automatic `workflow_run` checkouts use `github.event.workflow_run.head_sha`, which yields a detached commit and can make `peter-evans/create-pull-request` target the wrong base or fail when no branch is checked out.

### Description
- Add an explicit `base` input to the `peter-evans/create-pull-request` step in `.github/workflows/self-heal.yml` so automatic runs use `github.event.workflow_run.head_branch` and manual runs fall back to `github.ref_name`.

### Testing
- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml")'` (succeeded).
- Verified Node scripts syntax with `node --check scripts/healthcheck.mjs` and `node --check scripts/self-heal.mjs` (both succeeded).
- Ran `git diff --check` to ensure no trailing/merge issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44c389cc8320993c5f977de89b47)