### PR TITLE
Mirror CI Python version in self-heal validation

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -28,8 +28,11 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install Python deps
         run: |


### PR DESCRIPTION
### Motivation
- The self-heal workflow validated repairs on `ubuntu-latest` with a pinned `python-version: '3.11'` while the repo CI runs on `windows-latest` with `python-version: '3.x'`, which could let a repair pass validation even though the original CI remains broken. 

### Description
- Changed the self-heal job `runs-on` to `windows-latest` to match the CI runner in `.github/workflows/self-heal.yml`. 
- Updated the self-heal job Python setup to use `python-version: '3.x'` so interpreter selection mirrors the CI workflow. 
- Added a job `defaults.run.shell: bash` so existing Bash-oriented `run` steps continue to work on the Windows runner. 
- The only modified file is `.github/workflows/self-heal.yml` and the changes are limited to runner/Python selection and the default shell.

### Testing
- Ran `git diff --check` to verify there are no trivial whitespace or diff errors and it succeeded. 
- Loaded the modified workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "ok"'` to validate YAML syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44bd850c8320bc6db5fb3f607664)