### PR TITLE
Fix self-heal repair branch isolation

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -90,3 +90,4 @@ jobs:
             Please review the attached logs for details.
           labels: self-heal
           branch: auto-heal/fixes
+          branch-suffix: timestamp


### PR DESCRIPTION
### Motivation
- Prevent separate self-heal runs from reusing the same `auto-heal/fixes` branch, which can mix or overwrite independent repairs.

### Description
- Add `branch-suffix: timestamp` to the `peter-evans/create-pull-request` configuration in `.github/workflows/self-heal.yml` so each successful repair run creates an isolated branch instead of repeatedly reusing `auto-heal/fixes`.

### Testing
- Ran `git diff --check` and validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "ok"'`, both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44aff32c8320a4d1a918a3e58d18)