### PR TITLE
Require CI-triggering token for self-heal PRs

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -79,10 +79,21 @@ jobs:
             selfheal-repair.txt
             selfheal-post.txt
 
+      - name: Verify CI-triggering PR token is configured
+        if: steps.post.outcome == 'success'
+        env:
+          SELF_HEAL_PR_TOKEN: ${{ secrets.SELF_HEAL_PR_TOKEN }}
+        run: |
+          if [ -z "$SELF_HEAL_PR_TOKEN" ]; then
+            echo "SELF_HEAL_PR_TOKEN must be configured with a PAT or GitHub App token so generated PRs trigger CI." >&2
+            exit 1
+          fi
+
       - name: Create PR with fixes
         if: steps.post.outcome == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.SELF_HEAL_PR_TOKEN }}
           commit-message: "chore: auto-fix lint/format and lockfiles"
           title: "🔧 Auto-healing fixes"
           body: |


### PR DESCRIPTION
### Motivation
- Ensure auto-heal PRs are created with a token that can trigger the repository's CI instead of relying on the default `GITHUB_TOKEN`, so generated fixes are validated by normal workflows.

### Description
- Add a preflight step that fails the self-heal job if `secrets.SELF_HEAL_PR_TOKEN` is not configured.
- Pass `SELF_HEAL_PR_TOKEN` to `peter-evans/create-pull-request` using the `token` input so the action uses a PAT or GitHub App token that triggers CI.

### Testing
- Parsed `.github/workflows/self-heal.yml` with `python3` and `yaml.safe_load()` to verify the workflow YAML still parses successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd448ad34c8320aa85846403643d3c)