### PR TITLE
Validate self-heal on Windows CI runner

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -45,29 +45,30 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install Python deps
         run: |
-          set -euxo pipefail
           python -m pip install --upgrade pip
           python -m pip install -e . pytest black
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
         run: |
-          set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          node scripts/healthcheck.mjs 2>&1 | Tee-Object -FilePath selfheal-pre.txt
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: |
+          node scripts/self-heal.mjs 2>&1 | Tee-Object -FilePath selfheal-repair.txt
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
         run: |
-          set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node scripts/healthcheck.mjs 2>&1 | Tee-Object -FilePath selfheal-post.txt
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Collect logs
         if: always()


### PR DESCRIPTION
### Motivation

- Prevent auto-heal from producing PRs that pass an Ubuntu healthcheck but still fail the repository's Windows-based `ci` job by matching the runner and Python selector. 
- Ensure log capture preserves the original script exit codes so the workflow does not continue to PR creation when the repair step failed.

### Description

- Change `self-heal` workflow `runs-on` to `windows-latest` to match the `ci` job runner.
- Align Python setup with CI by switching `actions/setup-python` to `python-version: '3.x'`.
- Replace Bash `tee` pipelines with PowerShell `Tee-Object` plus a `if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }` check to propagate non-zero script exits on Windows.
- Remove Bash-only `set -o pipefail` usage from the Windows workflow and keep `pip install -e . pytest black` for installing test/formatting tooling used by the healthcheck and repair scripts.

### Testing

- Validated the modified workflow YAML parses successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/self-heal.yml'); puts 'YAML OK'"`, which returned `YAML OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd447c495883209725d94529ef8403)