### PR TITLE
Fix self-heal log artifact staging

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -57,17 +57,17 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-pre.txt
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-pre.txt"
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: node scripts/self-heal.mjs | tee "$RUNNER_TEMP/selfheal-repair.txt"
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
         run: |
           set -o pipefail
-          node scripts/healthcheck.mjs | tee selfheal-post.txt
+          node scripts/healthcheck.mjs | tee "$RUNNER_TEMP/selfheal-post.txt"
 
       - name: Collect logs
         if: always()
@@ -75,9 +75,9 @@ jobs:
         with:
           name: selfheal-logs
           path: |
-            selfheal-pre.txt
-            selfheal-repair.txt
-            selfheal-post.txt
+            ${{ runner.temp }}/selfheal-pre.txt
+            ${{ runner.temp }}/selfheal-repair.txt
+            ${{ runner.temp }}/selfheal-post.txt
 
       - name: Create PR with fixes
         if: steps.post.outcome == 'success'


### PR DESCRIPTION
### Motivation

- Avoid accidentally committing transient `selfheal-*.txt` logs into auto-heal PRs because `create-pull-request` stages all new/modified files by default. 
- Preserve diagnostic logs as workflow artifacts while keeping the repository checkout clean so repairs are not polluted by generated files.

### Description

- Updated the self-heal workflow to write tee logs to the runner temp directory by changing the commands to use `"$RUNNER_TEMP/selfheal-*.txt"` in `.github/workflows/self-heal.yml`. 
- Updated the artifact upload `path` to collect logs from `${{ runner.temp }}` instead of the repository workspace in ` .github/workflows/self-heal.yml`.
- No changes to the repair or healthcheck scripts themselves; behavior of the PR creation step remains gated on the post-repair healthcheck outcome.

### Testing

- Validated the modified workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "yaml ok"'`, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/conflict issues, which returned cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4473d4288320b438e4525a58f567)