### PR TITLE
Fail closed when sensitive-file hook Python launcher is unavailable

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -49,11 +49,12 @@ def is_sensitive(path: str) -> bool:
 
 def _candidate_paths(tool_input: Dict[str, Any]) -> List[str]:
     """Collect path-like fields from a Claude Code tool input payload."""
-    return [
-        value
-        for key in PATH_KEYS
-        if isinstance((value := tool_input.get(key)), str) and value
-    ]
+    paths = []
+    for key in PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            paths.append(value)
+    return paths
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/.claude/hooks/run_protect_sensitive_files.js
+++ b/.claude/hooks/run_protect_sensitive_files.js
@@ -56,4 +56,4 @@ for (const candidate of candidates) {
 console.error(
   "protect-sensitive-files: no working Python 3 launcher found (tried python3, py -3, python)",
 );
-process.exit(1);
+process.exit(2);

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -16,7 +16,7 @@ import pytest
 HOOK_SCRIPT = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "protect_sensitive_files.py"
 
 
-def run_hook(payload: Union[Dict[str, object], str]) -> subprocess.CompletedProcess[str]:
+def run_hook(payload: Union[Dict[str, object], str]) -> subprocess.CompletedProcess:
     """Run the hook with a JSON payload or raw stdin text."""
     stdin = payload if isinstance(payload, str) else json.dumps(payload)
     return subprocess.run(
@@ -103,10 +103,37 @@ def test_node_launcher_blocks_sensitive_file_without_pyenv_version() -> None:
     assert "BLOCKED" in result.stderr
 
 
+def test_node_launcher_fails_closed_when_no_python_launcher(tmp_path: Path) -> None:
+    """The launcher should block protected tools when Python cannot start."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required to exercise the Claude Code hook launcher")
+
+    launcher_path = (
+        Path(__file__).resolve().parents[1]
+        / ".claude"
+        / "hooks"
+        / "run_protect_sensitive_files.js"
+    )
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+    result = subprocess.run(
+        [node, str(launcher_path)],
+        input=json.dumps(tool_payload("Write", ".env")),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 2
+    assert "no working Python 3 launcher found" in result.stderr
+
+
 def test_hook_settings_uses_node_launcher_and_project_dir() -> None:
     """Claude Code should use the Node launcher from the project root."""
     settings_path = Path(__file__).resolve().parents[1] / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text())
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
     command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
 
     assert command == 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/run_protect_sensitive_files.js"'
@@ -121,7 +148,7 @@ def test_node_launcher_prefers_python3_before_bare_python() -> None:
         / "hooks"
         / "run_protect_sensitive_files.js"
     )
-    launcher = launcher_path.read_text()
+    launcher = launcher_path.read_text(encoding="utf-8")
 
     python3_index = launcher.index('command: "python3"')
     py_index = launcher.index('command: "py"')


### PR DESCRIPTION
### Motivation
- Prevent the sensitive-file `PreToolUse` hook from silently failing open when no Python launcher can start, so protected edits are blocked instead of allowed. 
- Avoid depending on pyenv-local `python` shims that can make the launcher non-functional in some environments. 
- Improve cross-version Python compatibility by removing Python-3.8+/3.9+ specific syntax in the hook implementation and make test file reads deterministic across platforms.

### Description
- Change the Node launcher final failure path in `.claude/hooks/run_protect_sensitive_files.js` to call `process.exit(2)` so the hook fails closed when no Python 3 launcher is available. 
- Replace the walrus-based list comprehension in `.claude/hooks/protect_sensitive_files.py` with an explicit loop to collect candidate paths, avoiding the walrus operator for older Python support. 
- Update `tests/test_protect_sensitive_files_hook.py` to avoid `CompletedProcess[str]` typing, read configuration and launcher files with `read_text(encoding="utf-8")`, and add `test_node_launcher_fails_closed_when_no_python_launcher` which clears `PATH` to verify the launcher returns exit code `2` and emits the expected message. 

### Testing
- Installed package and test dependencies with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest` which completed successfully. 
- Ran the hook unit tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_protect_sensitive_files_hook.py -q` and they passed. 
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc93e958483208e00a54b691717d1)