### PR TITLE
Include security-key SSH basenames

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -26,8 +26,12 @@ SENSITIVE_BASENAME_PATTERNS = (
     "id_rsa.pub",
     "id_ed25519",
     "id_ed25519.pub",
+    "id_ed25519_sk",
+    "id_ed25519_sk.pub",
     "id_ecdsa",
     "id_ecdsa.pub",
+    "id_ecdsa_sk",
+    "id_ecdsa_sk.pub",
     "id_dsa",
     "id_dsa.pub",
 )

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -15,6 +15,19 @@ HOOK_MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(HOOK_MODULE)
 
+EXPECTED_SENSITIVE_SSH_KEY_BASENAMES = (
+    "id_ed25519",
+    "id_ed25519.pub",
+    "id_ed25519_sk",
+    "id_ed25519_sk.pub",
+    "id_ecdsa",
+    "id_ecdsa.pub",
+    "id_ecdsa_sk",
+    "id_ecdsa_sk.pub",
+    "id_dsa",
+    "id_dsa.pub",
+)
+
 
 def run_hook(payload: Dict[str, Any]) -> subprocess.CompletedProcess:
     return subprocess.run(
@@ -64,15 +77,11 @@ def test_ignores_unprotected_tool() -> None:
 
 
 def test_blocks_common_ssh_private_key_basenames() -> None:
-    private_key_basenames = [
-        pattern
-        for pattern in HOOK_MODULE.SENSITIVE_BASENAME_PATTERNS
-        if pattern in {"id_ed25519", "id_ecdsa", "id_dsa"}
-    ]
+    assert set(EXPECTED_SENSITIVE_SSH_KEY_BASENAMES).issubset(
+        HOOK_MODULE.SENSITIVE_BASENAME_PATTERNS
+    )
 
-    assert private_key_basenames == ["id_ed25519", "id_ecdsa", "id_dsa"]
-
-    for basename in private_key_basenames:
+    for basename in EXPECTED_SENSITIVE_SSH_KEY_BASENAMES:
         target = f".ssh/{basename}"
         result = run_hook(
             {


### PR DESCRIPTION
### Motivation
- Hardware-backed OpenSSH keys (FIDO2/U2F) use `_sk` private key basenames by default and were not covered by the existing sensitive-file hook, allowing protected Write/Edit tools to overwrite them. 

### Description
- Add `id_ed25519_sk`, `id_ed25519_sk.pub`, `id_ecdsa_sk`, and `id_ecdsa_sk.pub` to `SENSITIVE_BASENAME_PATTERNS` in ` .claude/hooks/protect_sensitive_files.py` so `_sk` variants are treated as sensitive. 
- Introduce `EXPECTED_SENSITIVE_SSH_KEY_BASENAMES` as a module-level constant in `tests/test_protect_sensitive_files_hook.py` to list private, public, and `_sk` variants for testability. 
- Update the test `test_blocks_common_ssh_private_key_basenames` to assert the expected patterns are present (`set(...).issubset(...)`) and to iterate over every expected basename to verify the hook blocks `'.ssh/<basename>'` targets.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m py_compile .claude/hooks/protect_sensitive_files.py` and compilation succeeded. 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_protect_sensitive_files_hook.py` and the test(s) passed. 
- Ran `git diff --check` to validate whitespace/format and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc945ddc88320999630c79413e92b)