### PR TITLE
Decouple get_host_port tests from Flask

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -1,12 +1,9 @@
 """Flask application for html2md."""
 
-import os
-
 from flask import Flask, jsonify
 
 from html2md import __version__
-
-DEFAULT_PORT = 10000
+from html2md.config import get_host_port
 
 app = Flask(__name__)
 
@@ -15,23 +12,6 @@ app = Flask(__name__)
 def health():
     """Return health status of the application."""
     return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
-
-
-def get_host_port():
-    """Get host and port from environment variables."""
-    default_port = 10000
-    port_str = os.environ.get('PORT')
-    try:
-        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
-    except ValueError:
-        print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
-        )
-        port_value = DEFAULT_PORT
-
-    hostname = os.environ.get('HOST', '0.0.0.0')
-    return hostname, port_value
 
 
 if __name__ == '__main__':

--- a/src/html2md/config.py
+++ b/src/html2md/config.py
@@ -1,0 +1,22 @@
+"""Configuration helpers for html2md."""
+
+import os
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 10000
+
+
+def get_host_port():
+    """Get host and port from environment variables."""
+    port_str = os.environ.get("PORT")
+    try:
+        port_value = int(port_str) if port_str is not None else DEFAULT_PORT
+    except ValueError:
+        print(
+            f"Warning: Invalid PORT environment variable value "
+            f"{port_str!r}; falling back to default {DEFAULT_PORT}."
+        )
+        port_value = DEFAULT_PORT
+
+    hostname = os.environ.get("HOST", DEFAULT_HOST)
+    return hostname, port_value

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,12 +1,6 @@
-"""Tests for the Flask application module."""
+"""Tests for application configuration helpers."""
 
-import os
-import pytest
-
-# Skip all tests in this module if flask is not installed
-pytest.importorskip("flask")
-
-from html2md.app import get_host_port
+from html2md.config import get_host_port
 
 
 def test_get_host_port_defaults(monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure `get_host_port()` can be tested in CI without installing the optional `deploy` extra (Flask) so coverage for the parser is exercised in the default workflow.
- Avoid module-level `pytest.importorskip("flask")` and unused imports that caused the entire test module to be skipped in CI.

### Description
- Add `src/html2md/config.py` containing `get_host_port()` as a Flask-free configuration helper that reads `HOST`/`PORT` and handles invalid `PORT` values.
- Update `src/html2md/app.py` to import and reuse `get_host_port()` from `html2md.config` so runtime behavior is unchanged.
- Update `tests/test_app.py` to import `get_host_port()` from `html2md.config` and remove the module-level `pytest.importorskip` and unused `os` import so the tests run without Flask.

### Testing
- Ran `python -m compileall src/html2md/config.py src/html2md/app.py` to verify the new module compiles successfully, which succeeded.
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_app.py` to exercise the added/modified tests, which passed.
- Ran the full suite `PYENV_VERSION=3.12.13 pytest -q` and observed an unrelated existing failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` due to that test mocking `open` interfering with `gettext` under Python 3.12.13, while the targeted `get_host_port` changes remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc99315b48320befc9d23c8acf267)