### PR TITLE
Guard Gemini workflow core-tool denylist

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -85,6 +85,9 @@ jobs:
           gemini_cli_version: '0.41.2'
           extensions: |
             ["${{ runner.temp }}/gemini-code-review-ext"]
+          # The action invokes `gemini --yolo`; disable core shell/file
+          # tools so secret-backed review runs can only use the GitHub MCP
+          # tools listed below.
           settings: |-
             {
               "tools": {

--- a/tests/test_workflows_security.py
+++ b/tests/test_workflows_security.py
@@ -6,13 +6,21 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _extract_gemini_settings(workflow_text):
-    marker = "          settings: |-\n"
-    start = workflow_text.index(marker) + len(marker)
+    name_pos = workflow_text.find("name: Gemini Code Assist")
+    # Search for the settings block specifically after the Gemini name
+    marker = "settings: |-"
+    try:
+        marker_pos = workflow_text.index(marker, name_pos if name_pos != -1 else 0)
+        start = workflow_text.find("\n", marker_pos) + 1
+    except ValueError:
+        raise ValueError("Could not find 'settings: |-' after Gemini name")
+
     settings_lines = []
     for line in workflow_text[start:].splitlines():
-        if not line.startswith("            "):
+        # Stop if we hit a non-empty line with less indentation than the JSON block
+        if line.strip() and not line.startswith("            "):
             break
-        settings_lines.append(line[12:])
+        settings_lines.append(line[12:] if len(line) >= 12 else "")
     return json.loads("\n".join(settings_lines))
 
 

--- a/tests/test_workflows_security.py
+++ b/tests/test_workflows_security.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _extract_gemini_settings(workflow_text):
+    marker = "          settings: |-\n"
+    start = workflow_text.index(marker) + len(marker)
+    settings_lines = []
+    for line in workflow_text[start:].splitlines():
+        if not line.startswith("            "):
+            break
+        settings_lines.append(line[12:])
+    return json.loads("\n".join(settings_lines))
+
+
+def test_gemini_code_assist_yolo_run_disables_core_tools():
+    workflow_text = (REPO_ROOT / ".github/workflows/gemini-code-assist.yml").read_text()
+
+    assert "name: Gemini Code Assist" in workflow_text
+    settings = _extract_gemini_settings(workflow_text)
+
+    assert settings["tools"]["core"] == []


### PR DESCRIPTION
### Motivation
- Prevent secret-backed Gemini review runs (which invoke `gemini --yolo`) from using default core shell/file tools so a prompt-injected diff cannot exfiltrate `GITHUB_TOKEN`/`GEMINI_API_KEY` and publish results via review tools.
- Add a small regression test to ensure the core-tool denylist is not accidentally removed in future edits.

### Description
- Keep and document the core-tool denylist by ensuring the workflow `settings` JSON contains `"tools": { "core": [] }` in `.github/workflows/gemini-code-assist.yml` and add an explanatory inline comment about `gemini --yolo` safety implications.
- Add `tests/test_workflows_security.py`, a regression test that extracts the embedded `settings` JSON from the workflow file and asserts `settings["tools"]["core"] == []`.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_workflows_security.py` and the new test passed.
- Ran the full suite with `PYENV_VERSION=3.12.13 python -m pytest` and observed a pre-existing unrelated failure in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` caused by that test's `builtins.open` mocking interfering with Python gettext `.mo` loading, not by these changes.
- Noted that running `python3 -m pytest tests/test_workflows_security.py` initially failed due to a missing `pytest` in the system Python, which was resolved by using the specified pyenv Python and installing project dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0119537b3c8320b61ce97995968c50)