### PR TITLE
Fix Gemini workflow action target

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -23,9 +23,16 @@ jobs:
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@gemini-code-assist'))
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GEMINI_CLI_TRUST_WORKSPACE: "true"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+        if: env.GEMINI_API_KEY != ''
+        continue-on-error: true
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        with:
+          gemini_api_key: ${{ env.GEMINI_API_KEY }}


### PR DESCRIPTION
### Motivation
- The Gemini workflow referenced an unpublished action `google-gemini/code-assist-action@v1`, causing action resolution failures whenever the workflow ran.
- The workflow needs to reference a published, pinned action and restore the API key input so it can run successfully when the secret is configured.

### Description
- Updated `.github/workflows/gemini-code-assist.yml` to replace the unpublished step `uses: google-gemini/code-assist-action@v1` with the published pinned action `uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489` (v0.1.22).
- Restored environment variables `GEMINI_API_KEY` and `GEMINI_CLI_TRUST_WORKSPACE` and added the conditional `if: env.GEMINI_API_KEY != ''` so the step only runs when the secret is present.
- Added `continue-on-error: true` and passed the `gemini_api_key` input to the action so the workflow can resolve and execute safely when configured.

### Testing
- Verified the target action exists with `git ls-remote --exit-code https://github.com/google-github-actions/run-gemini-cli.git refs/tags/v0.1.22` which succeeded.
- Parsed the workflow YAML with `python3` (`yaml.safe_load`) to ensure it is valid which succeeded.
- Ran `git diff --check` and repository checks which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011968c1948320aa28b9cc00d1ca16)