### PR TITLE
Disable checkout credential persistence for Gemini reviews

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Gemini Code Assist
         uses: google-github-actions/run-gemini-cli@v0
         env:


### PR DESCRIPTION
### Motivation
- Prevent the GitHub checkout token from being persisted to `.git/config` where Gemini read-only file tools (e.g., `read_file`) could expose it during PR reviews.

### Description
- Add `persist-credentials: false` to the `actions/checkout@v4` step in `.github/workflows/gemini-code-assist.yml` so the `GITHUB_TOKEN` is not written to the local git config before Gemini tools run.

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'`, a Ruby check that asserts `persist-credentials` is `false` in the checkout step, and `git diff --check`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01192d5a188320a4506e54f76bc499)