### PR TITLE
ci: remove Gemini shell command tools from review workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -116,11 +116,7 @@ jobs:
                   "read_many_files",
                   "list_directory",
                   "glob",
-                  "grep_search",
-                  "run_shell_command(cat)",
-                  "run_shell_command(grep)",
-                  "run_shell_command(head)",
-                  "run_shell_command(tail)"
+                  "grep_search"
                 ]
               }
             }


### PR DESCRIPTION
### Motivation
- The Gemini code-assist step previously allowed `run_shell_command(cat|grep|head|tail)`, which can be used to read absolute paths like `/proc/self/environ` and leak CI secrets present in the step environment to PR review comments. 
- Restricting tools to repository-scoped file/search primitives preserves review usefulness while closing this secret-exposure vector.

### Description
- Removed the `run_shell_command(cat)`, `run_shell_command(grep)`, `run_shell_command(head)`, and `run_shell_command(tail)` entries from the `tools.core` allowlist in `.github/workflows/gemini-code-assist.yml`.
- Preserved repository-scoped inspection tools: `read_file`, `read_many_files`, `list_directory`, `glob`, and `grep_search`.
- Updated the workflow YAML, committed the change, and opened this follow-up PR to fix the security issue.

### Testing
- Successfully parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'`.
- Verified there are no `run_shell_command(` occurrences using `rg` (search succeeded with no matches).
- Ran `git diff --check` to ensure no whitespace or diff issues and committed the change (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0119274d7c83209ce6a74007f1d7d6)