### PR TITLE
ci: strip PR Gemini workspace overrides

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -60,13 +60,15 @@ jobs:
           persist-credentials: false
       - name: Remove PR-local Gemini configuration overrides
         # Project-local Gemini commands, workspace extensions, and .env files
-        # can alter Gemini CLI behavior before the pinned code-review extension
-        # runs. Remove these checkout-provided control surfaces so a PR cannot
+        # (including the repository-root .env that Gemini loads from the
+        # current working directory) can alter Gemini CLI behavior before the
+        # pinned code-review extension runs. Remove these checkout-provided
+        # control surfaces so a PR cannot
         # hijack /pr-code-review, load attacker-controlled MCP servers, or
         # replace Gemini-specific environment settings such as GEMINI_SYSTEM_MD.
         run: |
           rm -rf .gemini/commands .gemini/extensions
-          rm -f .gemini/.env .gemini/.env.*
+          rm -f .env .env.* .gemini/.env .gemini/.env.*
           if find .gemini -path '*/commands/pr-code-review.toml' -print -quit 2>/dev/null | grep -q .; then
             echo "::error::PR-local Gemini pr-code-review command override is still present."
             exit 1
@@ -75,8 +77,12 @@ jobs:
             echo "::error::PR-local Gemini workspace extension is still present."
             exit 1
           fi
+          if find . -maxdepth 1 -name '.env*' -print -quit | grep -q .; then
+            echo "::error::PR-local repository-root Gemini .env file is still present."
+            exit 1
+          fi
           if find .gemini -maxdepth 1 -name '.env*' -print -quit 2>/dev/null | grep -q .; then
-            echo "::error::PR-local Gemini .env file is still present."
+            echo "::error::PR-local Gemini .gemini/.env file is still present."
             exit 1
           fi
       - name: Gemini Code Assist

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -58,15 +58,25 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Remove PR-local Gemini command overrides
-        # Project-local .gemini/commands/*.toml can shadow extension commands
-        # in Gemini CLI's loader, so a PR could plant a pr-code-review.toml
-        # that hijacks /pr-code-review. Remove checkout-provided commands
-        # before installing the pinned code-review extension.
+      - name: Remove PR-local Gemini configuration overrides
+        # Project-local Gemini commands, workspace extensions, and .env files
+        # can alter Gemini CLI behavior before the pinned code-review extension
+        # runs. Remove these checkout-provided control surfaces so a PR cannot
+        # hijack /pr-code-review, load attacker-controlled MCP servers, or
+        # replace Gemini-specific environment settings such as GEMINI_SYSTEM_MD.
         run: |
-          rm -rf .gemini/commands
+          rm -rf .gemini/commands .gemini/extensions
+          rm -f .gemini/.env .gemini/.env.*
           if find .gemini -path '*/commands/pr-code-review.toml' -print -quit 2>/dev/null | grep -q .; then
             echo "::error::PR-local Gemini pr-code-review command override is still present."
+            exit 1
+          fi
+          if find .gemini -path '*/extensions/*/gemini-extension.json' -print -quit 2>/dev/null | grep -q .; then
+            echo "::error::PR-local Gemini workspace extension is still present."
+            exit 1
+          fi
+          if find .gemini -maxdepth 1 -name '.env*' -print -quit 2>/dev/null | grep -q .; then
+            echo "::error::PR-local Gemini .env file is still present."
             exit 1
           fi
       - name: Gemini Code Assist


### PR DESCRIPTION
### Motivation

- Prevent PR-authored Gemini workspace control surfaces from altering the pinned code-review extension or starting attacker-controlled MCP servers. 
- The previous cleanup removed only `.gemini/commands` which left workspace extensions and `.gemini/.env*` files in place and able to influence Gemini CLI behavior.

### Description

- Update `.github/workflows/gemini-code-assist.yml` to replace the old cleanup step with `Remove PR-local Gemini configuration overrides` and broaden the removal to workspace extensions and env files.
- Remove checkout-provided control surfaces with `rm -rf .gemini/commands .gemini/extensions` and `rm -f .gemini/.env .gemini/.env.*` before running the Gemini action.
- Add explicit guards that fail the job if a PR-local `*/commands/pr-code-review.toml`, `*/extensions/*/gemini-extension.json`, or `.gemini/.env*` file remains after cleanup.

### Testing

- Ran YAML parse validation with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "valid yaml"'` which succeeded.
- Ran `git diff --check` which produced no issues.
- Executed an assertion script with `/usr/bin/python3` that verifies the new step name and guard strings (`Remove PR-local Gemini configuration overrides`, `rm -rf .gemini/commands .gemini/extensions`, `rm -f .gemini/.env .gemini/.env.*`, `*/commands/pr-code-review.toml`, `*/extensions/*/gemini-extension.json`, and `-maxdepth 1 -name '.env*'`) are present and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0119269e648320a670a9d6e16c4d66)