### PR TITLE
Expose Gemini PR review lifecycle tools

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -130,8 +130,10 @@ jobs:
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
+                    "create_pending_pull_request_review",
                     "pull_request_read",
-                    "pull_request_review_write"
+                    "pull_request_review_write",
+                    "submit_pending_pull_request_review"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"


### PR DESCRIPTION
### Motivation
- The code-review extension’s `/pr-code-review` flow needs the explicit pending-review lifecycle tools available so it can create a pending review, add inline comments, and then submit that pending review when triggered by a maintainer comment like `/review`.
- The existing `includeTools` allow-list only exposed the read/comment tool and the consolidated write tool which prevented the extension from reliably starting or submitting PR reviews.

### Description
- Added `create_pending_pull_request_review` and `submit_pending_pull_request_review` to the GitHub MCP `includeTools` allow-list in the Gemini workflow so the extension can run the full review lifecycle. 
- Kept the consolidated `pull_request_review_write` tool alongside the explicit lifecycle tools for compatibility with both write flows. 
- Left MCP server `env` and `extensions` configuration unchanged and forwarded the existing prompt/context to the Gemini runner.

### Testing
- Ran `git diff --check` to validate whitespace and patch hygiene, which completed successfully. 
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml')"`, which reported `YAML OK`.
- Extracted the `settings` JSON from the workflow and parsed it with `JSON.parse(...)` using Ruby, which reported `settings JSON OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011919d7d88320b1cc5794779a0eb1)