### PR TITLE
Add regression test for streamed response cleanup on status errors

### DIFF
--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -144,6 +144,19 @@ class TestCliStreamingResponses(unittest.TestCase):
         self.assertIn("Network error", captured_stderr.getvalue())
         self.assertTrue(response.closed)
 
+    def test_status_error_closes_mocked_streamed_response(self):
+        """Mocked streamed responses should close when status checks fail."""
+        response = MagicMock()
+        response.raise_for_status.side_effect = requests.HTTPError("bad status")
+        captured_stderr = io.StringIO()
+
+        with patch('sys.stderr', captured_stderr):
+            with patch('requests.Session.get', return_value=response):
+                html2md.cli.main(['--url', 'http://example.com'])
+
+        self.assertIn("Network error: bad status", captured_stderr.getvalue())
+        response.close.assert_called_once_with()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure streamed HTTP responses are deterministically closed when `raise_for_status()` raises on mocked responses to prevent connection leaks during error handling.

### Description
- Adds a unit test `test_status_error_closes_mocked_streamed_response` in `tests/test_cli_error.py` that mocks a response whose `raise_for_status()` raises `requests.HTTPError` and asserts the CLI prints the network error and calls `response.close()` once.

### Testing
- Installed project dependencies and test tools with `PYENV_VERSION=3.12.13 python -m pip install -e '.[deploy]' pytest` which succeeded.
- Ran the test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` and all tests passed.
- Ran `git diff --check` to verify no spacing or trailing-whitespace issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ec2a6d70832099f3b5b07808e7c0)