### PR TITLE
Gate Gemini comment-triggered runs by trusted authors

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -17,11 +17,12 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@gemini-code-assist')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
+      github.event_name == 'pull_request' ||
+      ((github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
        contains(github.event.comment.body, '@gemini-code-assist'))
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- Prevent drive-by commenters from invoking `@gemini-code-assist` and running the workflow with write permissions by restricting mention-based triggers to trusted commenter associations.

### Description
- Update `.github/workflows/gemini-code-assist.yml` to require `github.event.comment.author_association` be `OWNER`, `MEMBER`, or `COLLABORATOR` for `pull_request_review_comment` and PR `issue_comment` mention-triggered runs while preserving automatic `pull_request` triggers.

### Testing
- Ran `git diff --check` and parsed the workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml')"` which succeeded, and linting with `actionlint` was not available in the environment so it was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ec19e17c8320abb1b572464d9834)