### PR TITLE
Use published Gemini CLI action in workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -29,9 +29,38 @@ jobs:
           fetch-depth: 0
       - name: Run Gemini CLI
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          ADDITIONAL_CONTEXT: ""
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          settings: |
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              }
+            }
           extensions: |
             [
               "https://github.com/gemini-cli-extensions/code-review"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -27,5 +27,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Gemini Code Assist
-        uses: google-gemini/code-assist-action@v1
+      - name: Run Gemini CLI
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: /pr-code-review


### PR DESCRIPTION
### Motivation
- Fix a broken/unpublished `uses:` target so Gemini-assisted PR reviews resolve and run correctly instead of failing during action resolution.
- Reduce supply-chain and reproducibility risk by pinning the third-party action to a specific commit SHA instead of a floating tag.
- Ensure the workflow has the inputs it needs to perform PR-focused code reviews via the Gemini CLI extension.

### Description
- Replaced `google-gemini/code-assist-action@v1` with `google-github-actions/run-gemini-cli` pinned to commit `f77273f4c914e4bf38440cf36a0369cb64a37489` (commented `v0.1.22`).
- Added `with:` inputs for `gemini_api_key: ${{ secrets.GEMINI_API_KEY }}`, `github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}`, `extensions` pointing to the `gemini-cli-extensions/code-review` URL, and `prompt: /pr-code-review`.
- Preserved existing triggers, permissions, and `actions/checkout@v4` with `fetch-depth: 0` so behavior remains PR-focused.

### Testing
- Ran `git diff --check` and it passed.
- Executed a Python assertion to verify the workflow now references the pinned `google-github-actions/run-gemini-cli` and no longer references the old action, which succeeded.
- Parsed the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml')"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ec148cdc8320a0d785641a297335)