### PR TITLE
Restore GUI batch and single conversion flags

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -24,8 +24,7 @@ if ($BatchFile) {
         $url = $_.Trim()
         if (-not [string]::IsNullOrWhiteSpace($url)) {
             Write-Host "Processing: $url"
-            $argsList = @("--url", "$url", "--outdir", "$outDir", "--all-formats")
-            if (-not $BatchWholePage) { $argsList += "--main-content" }
+            $argsList = @("--url", "$url", "--outdir", "$outDir")
 
             if (Test-Path -LiteralPath $venvExe) {
                 & $venvExe $argsList
@@ -358,9 +357,6 @@ $ConvertBtn.Add_Click({
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
-        # If Whole Page is unchecked, only convert the main content.
-        $optArg = if (-not $WholePageChk.IsChecked) { " --main-content" } else { "" }
-
         # Sanitize inputs for single-quoted string interpolation in PowerShell
         $safeUrl = $url -replace "'", "''"
         $safeOutDir = $outdir -replace "'", "''"
@@ -369,11 +365,11 @@ $ConvertBtn.Add_Click({
 
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir'`""
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir'`""
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -24,7 +24,8 @@ if ($BatchFile) {
         $url = $_.Trim()
         if (-not [string]::IsNullOrWhiteSpace($url)) {
             Write-Host "Processing: $url"
-            $argsList = @("--url", "$url", "--outdir", "$outDir")
+            $argsList = @("--url", "$url", "--outdir", "$outDir", "--all-formats")
+            if (-not $BatchWholePage) { $argsList += "--main-content" }
 
             if (Test-Path -LiteralPath $venvExe) {
                 & $venvExe $argsList
@@ -357,6 +358,8 @@ $ConvertBtn.Add_Click({
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
+        # If Whole Page is unchecked, only convert the main content.
+        $optArg = if (-not $WholePageChk.IsChecked) { " --main-content" } else { "" }
 
         # Sanitize inputs for single-quoted string interpolation in PowerShell
         $safeUrl = $url -replace "'", "''"
@@ -366,11 +369,11 @@ $ConvertBtn.Add_Click({
 
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir'`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& '$safeVenvExe' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $psi.Arguments = "-NoExit -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir'`""
+            $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -Command `"& $pyCmd '$safePyScript' --url '$safeUrl' --outdir '$safeOutDir' --all-formats$optArg`""
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."


### PR DESCRIPTION
### Motivation
- The GUI relaunch and single-URL launch paths stopped forwarding `--all-formats` and the whole-page choice, causing the visible UI options to have no effect. 
- Batch-mode relaunch also dropped mapping of the `-BatchWholePage` switch to CLI arguments, so batch conversions ignored the whole-page/main-content choice. 
- The single-URL branch lacked `-ExecutionPolicy Bypass` leading to inconsistent launch behavior compared with the batch relaunch path.

### Description
- Reintroduced `--all-formats` into the batch-mode argument construction and added conditional `--main-content` when `$BatchWholePage` is not set (in `gui-url-convert.ps1`).
- Restored `$optArg` in the single-URL flow derived from `WholePageChk` and appended `--all-formats$optArg` to both venv and Python script launch commands.
- Added `-ExecutionPolicy Bypass` to single-URL `powershell.exe` invocations for consistency with the batch relaunch behavior.

### Testing
- Ran `git diff --check` to validate the working tree and found no whitespace or index errors (passed). 
- Searched the modified script for `--all-formats`, `--main-content`, `BatchWholePage`, and `ExecutionPolicy Bypass` using `rg` to verify the changes are present (passed). 
- Attempted to run `pytest` and PowerShell parse checks but these were not executed in this environment because `pytest` and `pwsh` are not installed (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd441cf408832093fcaf2bf21a08ee)