### PR TITLE
Align DNS pinning IDNA normalization with requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.5",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -80,21 +80,27 @@ def main(argv=None):
 
         def _normalize_hostname(hostname):
             """Return the canonical form used for DNS validation and pinning."""
-            normalized = hostname.rstrip('.').lower()
+            absolute = hostname.endswith('.')
+            hostname = hostname[:-1] if absolute else hostname
+            normalized = hostname.lower()
             try:
                 ipaddress.ip_address(normalized)
                 return normalized
             except ValueError:
                 pass
 
-            try:
-                return normalized.encode('ascii').decode('ascii')
-            except UnicodeEncodeError:
-                import idna  # pylint: disable=import-outside-toplevel
+            labels = []
+            for label in hostname.split('.'):
+                try:
+                    labels.append(label.encode('ascii').decode('ascii').lower())
+                except UnicodeEncodeError:
+                    import idna  # pylint: disable=import-outside-toplevel
 
-                return idna.encode(
-                    normalized, strict=True, std3_rules=True
-                ).decode('ascii')
+                    labels.append(idna.encode(label, uts46=True).decode('ascii'))
+            dns_hostname = '.'.join(labels)
+            if absolute:
+                dns_hostname += '.'
+            return dns_hostname
 
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""
@@ -149,8 +155,10 @@ def main(argv=None):
             def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
                 try:
                     requested_hostname = _normalize_hostname(host) if host else None
-                except UnicodeError:
-                    requested_hostname = host.rstrip('.').lower() if host else None
+                except UnicodeError as e:
+                    raise socket.gaierror(
+                        f"Invalid hostname for DNS pinning: {host}"
+                    ) from e
                 if requested_hostname == pinned_hostname:
                     resolved_port = requested_port if requested_port is not None else port
                     pinned = []

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -162,6 +162,112 @@ def test_idna_hostname_is_normalized_for_dns_pinning(mock_get, mock_getaddrinfo,
     )
 
 
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_idna_hostname_uses_uts46_mapping_for_dns_pinning(mock_get, mock_getaddrinfo, capsys):
+    """UTS46-mapped Unicode labels are pinned with requests-compatible DNS names."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>UTS46 Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_uts46_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("fullwidth.example", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_uts46_pinned_dns
+
+    cli.main(["--url", "http://ｆｕｌｌｗｉｄｔｈ.example/"])
+
+    outerr = capsys.readouterr()
+    assert "# UTS46 Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "fullwidth.example", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://ｆｕｌｌｗｉｄｔｈ.example/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_idna_hostname_normalizes_non_ascii_labels_only(mock_get, mock_getaddrinfo, capsys):
+    """ASCII labels requests leaves alone are not rejected while IDN labels are encoded."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Per Label Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_per_label_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo(
+            "_svc.xn--fa-hia.example", 80, type=socket.SOCK_STREAM
+        )
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_per_label_pinned_dns
+
+    cli.main(["--url", "http://_svc.faß.example/"])
+
+    outerr = capsys.readouterr()
+    assert "# Per Label Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "_svc.xn--fa-hia.example", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://_svc.faß.example/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_absolute_fqdn_trailing_dot_is_preserved_for_dns_pinning(
+    mock_get, mock_getaddrinfo, capsys
+):
+    """Absolute FQDNs keep their trailing dot for validation and pinned fetches."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Absolute Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_absolute_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("host.example.", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_absolute_pinned_dns
+
+    cli.main(["--url", "http://host.example./"])
+
+    outerr = capsys.readouterr()
+    assert "# Absolute Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "host.example.", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://host.example./", timeout=30, allow_redirects=False
+    )
+
+
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):


### PR DESCRIPTION
### Motivation

- Ensure DNS validation/pinning uses the same canonical host form as the HTTP client to prevent SSRF/DNS-rebinding between validation and connection. 
- Match Requests/urllib3 normalization for internationalized domain names (IDNs), including UTS46 mappings, so hosts Request would fetch are not rejected or pinned incorrectly. 
- Preserve absolute FQDN semantics (trailing dot) and fail closed on normalization errors to avoid falling back to unpinned lookups.

### Description

- Updated `_normalize_hostname` in `src/html2md/cli.py` to perform per-label normalization and encode only non-ASCII labels with `idna` using `uts46=True`, while preserving trailing `.` for absolute FQDNs. 
- Changed the DNS-pinning hook (`_pin_validated_dns`) to raise `socket.gaierror` on hostname normalization failure so pinned resolution fails closed instead of performing an unpinned lookup. 
- Declared `idna` as a direct runtime dependency in `pyproject.toml`. 
- Added regression tests in `tests/test_cli_security.py` to cover UTS46 fullwidth-label mapping, per-label IDNA normalization when ASCII labels (e.g. underscores) are present, and preservation of trailing dots for absolute FQDN pinning.

### Testing

- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` and all security tests passed (`16 passed`).
- Ran the full suite with `PYENV_VERSION=3.12.13 python -m pytest` and all tests passed (`32 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43fb9fe08320a098e2e194ba1f79)