### PR TITLE
Declare idna dependency for IDN URL handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ pip install pytest build
 - `markdownify>=0.11.6` — HTML to Markdown conversion
 - `beautifulsoup4>=4.10.0` — HTML parsing
 - `requests>=2.25.0` — HTTP fetching
+- `idna>=2.5,<4` — IDNA hostname normalization for URL validation
 - `reportlab>=3.6.0` — PDF generation
 - `pillow>=9.0.0` — Image processing
 - `pyyaml>=6.0` — YAML config parsing

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The full runtime conversion workflow described in earlier packaging notes is **n
 
 - **Language:** Python 3.8+
 - **Build:** setuptools + wheel via `pyproject.toml` (PEP 517/518)
-- **Core dependencies:** [`markdownify`](https://pypi.org/project/markdownify/), [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/), [`requests`](https://pypi.org/project/requests/), [`reportlab`](https://pypi.org/project/reportlab/), [`pillow`](https://pypi.org/project/Pillow/), [`pyyaml`](https://pypi.org/project/PyYAML/)
+- **Core dependencies:** [`markdownify`](https://pypi.org/project/markdownify/), [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/), [`requests`](https://pypi.org/project/requests/), [`idna`](https://pypi.org/project/idna/), [`reportlab`](https://pypi.org/project/reportlab/), [`pillow`](https://pypi.org/project/Pillow/), [`pyyaml`](https://pypi.org/project/PyYAML/)
 - **Testing:** pytest
 - **CI:** GitHub Actions (Windows-latest)
 - **Platform extras:** PowerShell setup scripts + WPF GUI for Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.5,<4",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",


### PR DESCRIPTION
### Motivation

- Ensure the runtime `idna` package is explicitly declared so IDNA hostname normalization used by the CLI does not depend on `requests`' transitive dependencies and cannot fail at runtime for IDN URLs.

### Description

- Add `idna>=2.5,<4` to the `dependencies` in `pyproject.toml` and update `README.md` and `CLAUDE.md` to list `idna` in the runtime/core dependency set.

### Testing

- Installed the package in editable mode with `python -m pip install -e . pytest` and the install completed successfully.
- Ran the IDN/security test file with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` and it passed (`13 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` and it passed (`29 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43ef1fc083208768155fa5e33e36)