### PR TITLE
Preserve absolute FQDNs in DNS pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.5",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -80,21 +80,29 @@ def main(argv=None):
 
         def _normalize_hostname(hostname):
             """Return the canonical form used for DNS validation and pinning."""
-            normalized = hostname.rstrip('.').lower()
+            normalized = hostname.lower()
             try:
                 ipaddress.ip_address(normalized)
                 return normalized
             except ValueError:
                 pass
 
-            try:
-                return normalized.encode('ascii').decode('ascii')
-            except UnicodeEncodeError:
-                import idna  # pylint: disable=import-outside-toplevel
+            labels = normalized.split('.')
+            canonical_labels = []
+            for label in labels:
+                if not label:
+                    canonical_labels.append(label)
+                    continue
+                try:
+                    canonical_labels.append(label.encode('ascii').decode('ascii'))
+                except UnicodeEncodeError:
+                    import idna  # pylint: disable=import-outside-toplevel
 
-                return idna.encode(
-                    normalized, strict=True, std3_rules=True
-                ).decode('ascii')
+                    canonical_labels.append(
+                        idna.encode(label, strict=True, uts46=True).decode('ascii')
+                    )
+
+            return '.'.join(canonical_labels)
 
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""
@@ -149,8 +157,10 @@ def main(argv=None):
             def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
                 try:
                     requested_hostname = _normalize_hostname(host) if host else None
-                except UnicodeError:
-                    requested_hostname = host.rstrip('.').lower() if host else None
+                except UnicodeError as e:
+                    raise socket.gaierror(
+                        f"Invalid hostname for DNS pinning: {host}"
+                    ) from e
                 if requested_hostname == pinned_hostname:
                     resolved_port = requested_port if requested_port is not None else port
                     pinned = []

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -128,6 +128,40 @@ def test_validated_dns_answer_is_pinned_during_fetch(mock_get, mock_getaddrinfo,
 
 @patch("socket.getaddrinfo")
 @patch("requests.Session.get")
+def test_trailing_dot_hostname_is_preserved_for_dns_pinning(mock_get, mock_getaddrinfo, capsys):
+    """Absolute FQDN hostnames keep their trailing dot through DNS pinning."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Absolute FQDN Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_absolute_fqdn_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("host.example.", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_absolute_fqdn_pinned_dns
+
+    cli.main(["--url", "http://host.example./"])
+
+    outerr = capsys.readouterr()
+    assert "# Absolute FQDN Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "host.example.", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://host.example./", timeout=30, allow_redirects=False
+    )
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
 def test_idna_hostname_is_normalized_for_dns_pinning(mock_get, mock_getaddrinfo, capsys):
     """Unicode hostnames are pinned with the same IDNA form used by requests."""
     public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]


### PR DESCRIPTION
### Motivation

- Keep trailing dots on absolute FQDNs so DNS validation looks up the exact name requested by the URL instead of a potentially different relative name.
- Ensure IDN hosts are normalized the same way the HTTP stack resolves them to prevent validation vs fetch mismatches that enable DNS rebinding.
- Fail closed when hostname normalization fails so the pinning hook cannot silently fall back to an unpinned lookup.
- Make IDNA handling reliable by declaring `idna` as a direct runtime dependency.

### Description

- Preserve trailing-dot semantics by no longer stripping the URL hostname before DNS lookups and instead applying normalization per label inside `_normalize_hostname` (file `src/html2md/cli.py`).
- Perform label-by-label IDNA encoding with UTS46 mapping for non-ASCII labels while leaving ASCII labels unchanged to match `requests`/urllib3 behavior (file `src/html2md/cli.py`).
- Change the DNS-pinning hook to raise `socket.gaierror` when hostname normalization fails so resolution cannot proceed unpinned (file `src/html2md/cli.py`).
- Declare `idna>=2.5` in `pyproject.toml` and add a regression test `test_trailing_dot_hostname_is_preserved_for_dns_pinning` verifying an absolute FQDN (e.g., `http://host.example./`) is validated and pinned with the trailing dot preserved (file `tests/test_cli_security.py`).

### Testing

- Installed the package in editable mode with `python -m pip install -e .` and dependencies installed successfully.
- Ran the focused security tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` and the suite passed with `14 passed`.
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` and all tests passed with `30 passed`.
- Ran `git diff --check` / local checks during the run and no check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43dd03948320bec46e56a2f34e2d)