### PR TITLE
Preserve trailing dot in DNS validation and harden DNS-pinning normalization

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -80,7 +80,7 @@ def main(argv=None):
 
         def _normalize_hostname(hostname):
             """Return the canonical form used for DNS validation and pinning."""
-            normalized = hostname.rstrip('.').lower()
+            normalized = hostname.lower()
             try:
                 ipaddress.ip_address(normalized)
                 return normalized
@@ -149,8 +149,10 @@ def main(argv=None):
             def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
                 try:
                     requested_hostname = _normalize_hostname(host) if host else None
-                except UnicodeError:
-                    requested_hostname = host.rstrip('.').lower() if host else None
+                except UnicodeError as e:
+                    raise socket.gaierror(
+                        f"Invalid hostname for DNS pinning: {host}"
+                    ) from e
                 if requested_hostname == pinned_hostname:
                     resolved_port = requested_port if requested_port is not None else port
                     pinned = []

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -162,6 +162,44 @@ def test_idna_hostname_is_normalized_for_dns_pinning(mock_get, mock_getaddrinfo,
     )
 
 
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_absolute_fqdn_trailing_dot_is_preserved_for_dns_pinning(
+    mock_get, mock_getaddrinfo, capsys
+):
+    """Absolute FQDNs keep the trailing dot through validation and pinning."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Absolute FQDN Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_absolute_fqdn_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo(
+            "host.example.", 80, type=socket.SOCK_STREAM
+        )
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_absolute_fqdn_pinned_dns
+
+    cli.main(["--url", "http://Host.Example./"])
+
+    outerr = capsys.readouterr()
+    assert "# Absolute FQDN Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "host.example.", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://Host.Example./", timeout=30, allow_redirects=False
+    )
+
+
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):


### PR DESCRIPTION
### Motivation

- Keep absolute FQDN semantics (trailing dot) when resolving and pinning hostnames so validation uses the exact name the URL requested and cannot be affected by resolver search/ndots behavior.
- Close a security gap where a hostname normalization failure in the DNS-pinning hook fell back to a lossy comparison, allowing an unpinned `getaddrinfo` call that could reintroduce DNS rebinding.

### Description

- Stop stripping the trailing dot in `_normalize_hostname` by switching to `hostname.lower()` so absolute FQDN markers remain for DNS lookups. (`src/html2md/cli.py`)
- Make the DNS-pinning hook fail-closed by raising `socket.gaierror` on `UnicodeError` during hostname normalization instead of falling back to a stripped/lowercased form. (`src/html2md/cli.py`)
- Add `test_absolute_fqdn_trailing_dot_is_preserved_for_dns_pinning` to verify an absolute FQDN like `http://Host.Example./` is validated and pinned with the trailing dot preserved. (`tests/test_cli_security.py`)

### Testing

- Installed the package and dependencies with `python -m pip install -e .` and ran the security tests with `python -m pytest tests/test_cli_security.py`, which passed (`14 passed`).
- Ran the full test suite with `python -m pytest`, which passed (`30 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43e3a64c8320b50aca9aee0b4b7c)