### PR TITLE
Pass comment requests through Gemini workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,8 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -16,7 +18,8 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       ((github.event_name == 'pull_request_review_comment' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
         (github.event.comment.author_association == 'MEMBER' ||
@@ -35,7 +38,9 @@ jobs:
         with:
           script: |
             let pr;
-            if (context.eventName === "pull_request_review_comment") {
+            if (context.eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            } else if (context.eventName === "pull_request_review_comment") {
               pr = context.payload.pull_request;
             } else if (context.eventName === "issue_comment" && context.payload.issue?.pull_request) {
               const response = await github.rest.pulls.get({
@@ -47,22 +52,30 @@ jobs:
             }
 
             if (!pr) {
-              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request_review_comment or issue_comment on a pull request.");
+              core.setFailed("Could not resolve pull request from event payload. This workflow requires a pull_request event, pull_request_review_comment, or issue_comment on a pull request.");
               return;
             }
 
             const sameRepo = pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("is_same_repo", String(sameRepo));
+            core.setOutput("number", String(pr.number));
 
       - uses: actions/checkout@v6
         if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
+
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           gemini_model: gemini-2.0-flash
+          github_pr_number: ${{ github.event_name == 'workflow_dispatch' && '' || steps.pr_head.outputs.number }}
+          prompt: |
+            ${{ github.event_name == 'pull_request' && '/pr-code-review' || github.event_name == 'workflow_dispatch' && 'Run Gemini Code Assist for this repository.' || format('A trusted collaborator requested Gemini Code Assist on pull request #{0} with this comment: {1}', steps.pr_head.outputs.number, github.event.comment.body) }}


### PR DESCRIPTION
### Motivation
- Restore automatic same-repository PR reviews and ensure comment-triggered runs forward the maintainer's request to Gemini rather than the action's generic default prompt.
- Resolve PR metadata for all relevant events so the workflow checks out the correct ref and can target the proper PR number.

### Description
- Re-added the `pull_request` trigger (`opened`, `synchronize`, `reopened`) and extended the job `if` to allow same-repo PR runs while keeping the fork guard to avoid exposing secrets to forked PRs.
- Enhanced the `Resolve PR head SHA` step to handle `pull_request` events as well as comment events and emit `head_sha`, `is_same_repo`, and `number` outputs for downstream steps.
- Made the checkout explicit by using the resolved PR head SHA and only checking out when the head is same-repo, and passed `GITHUB_TOKEN`/`GH_TOKEN` into the Gemini action environment.
- Passed `github_pr_number` and an explicit `prompt` to `google-github-actions/run-gemini-cli@v0`, using `/pr-code-review` for PR opens and embedding the triggering comment body for comment-triggered runs so Gemini receives the requested task.

### Testing
- Ran `git diff --check` with no issues reported.
- Validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'yaml ok'"`, which printed `yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc95951f083208c341f6d0bbc9e3e)