### PR TITLE
Restore same-repo guard for Gemini PR runs

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,8 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -17,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       ((github.event_name == 'pull_request_review_comment' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
         (github.event.comment.author_association == 'MEMBER' ||
@@ -35,7 +39,7 @@ jobs:
         with:
           script: |
             let pr;
-            if (context.eventName === "pull_request_review_comment") {
+            if (context.eventName === "pull_request" || context.eventName === "pull_request_review_comment") {
               pr = context.payload.pull_request;
             } else if (context.eventName === "issue_comment" && context.payload.issue?.pull_request) {
               const response = await github.rest.pulls.get({
@@ -47,7 +51,7 @@ jobs:
             }
 
             if (!pr) {
-              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request_review_comment or issue_comment on a pull request.");
+              core.setFailed("Could not resolve pull request from event payload. This workflow requires pull_request, pull_request_review_comment, or issue_comment on a pull request.");
               return;
             }
 


### PR DESCRIPTION
### Motivation
- The workflow previously removed the `pull_request` automatic trigger which disabled automatic Gemini Code Assist runs on opened/updated PRs.  
- Running the Gemini job for forked PRs can execute the action without repository secrets, which leads to failing or unauthenticated runs instead of skipping; a same-repo guard is needed.  
- The PR head resolution step needed to accept `pull_request` events so the workflow can obtain the correct head SHA for automatic PR runs.

### Description
- Re-added the `pull_request` event with `types: [opened, synchronize, reopened]` to `on:` so same-repo PRs trigger automatic runs.  
- Restored a job-level same-repo guard in the job `if:` by checking `github.event.pull_request.head.repo.full_name == github.repository` so fork PRs are not executed with missing secrets.  
- Updated the `actions/github-script` `script` to handle `pull_request` events (in addition to `pull_request_review_comment` and `issue_comment`) and adjusted the error message accordingly.  
- Continued to emit `head_sha` and `is_same_repo` outputs used by the `actions/checkout` and Gemini step so the workflow checks out the intended ref only for same-repo runs.

### Testing
- Loaded the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'` which succeeded and printed `YAML OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc96fcff08320b42506cac8121028)