### PR TITLE
Normalize DNS-pinned IDNA hosts per label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.5,<4",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -80,21 +80,32 @@ def main(argv=None):
 
         def _normalize_hostname(hostname):
             """Return the canonical form used for DNS validation and pinning."""
-            normalized = hostname.rstrip('.').lower()
+            normalized = hostname.lower()
             try:
                 ipaddress.ip_address(normalized)
                 return normalized
             except ValueError:
                 pass
 
-            try:
-                return normalized.encode('ascii').decode('ascii')
-            except UnicodeEncodeError:
-                import idna  # pylint: disable=import-outside-toplevel
+            labels = normalized.split('.')
+            normalized_labels = []
+            for label in labels:
+                try:
+                    normalized_labels.append(
+                        label.encode('ascii').decode('ascii')
+                    )
+                except UnicodeEncodeError:
+                    import idna  # pylint: disable=import-outside-toplevel
 
-                return idna.encode(
-                    normalized, strict=True, std3_rules=True
-                ).decode('ascii')
+                    normalized_labels.append(
+                        idna.encode(
+                            label,
+                            strict=True,
+                            std3_rules=True,
+                            uts46=True,
+                        ).decode('ascii')
+                    )
+            return '.'.join(normalized_labels)
 
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""
@@ -149,8 +160,10 @@ def main(argv=None):
             def pinned_getaddrinfo(host, requested_port, family=0, type=0, proto=0, flags=0):
                 try:
                     requested_hostname = _normalize_hostname(host) if host else None
-                except UnicodeError:
-                    requested_hostname = host.rstrip('.').lower() if host else None
+                except UnicodeError as e:
+                    raise socket.gaierror(
+                        f"Invalid hostname for DNS pinning: {host}"
+                    ) from e
                 if requested_hostname == pinned_hostname:
                     resolved_port = requested_port if requested_port is not None else port
                     pinned = []

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -162,6 +162,84 @@ def test_idna_hostname_is_normalized_for_dns_pinning(mock_get, mock_getaddrinfo,
     )
 
 
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_absolute_fqdn_trailing_dot_is_preserved_for_dns_pinning(
+    mock_get, mock_getaddrinfo, capsys
+):
+    """Absolute FQDNs are validated and pinned with their trailing root dot."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))
+    ]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Absolute Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_absolute_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("host.example.", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_absolute_pinned_dns
+
+    cli.main(["--url", "http://host.example./"])
+
+    outerr = capsys.readouterr()
+    assert "# Absolute Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "host.example.", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://host.example./", timeout=30, allow_redirects=False
+    )
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_idna_hostname_normalizes_non_ascii_labels_only(
+    mock_get, mock_getaddrinfo, capsys
+):
+    """ASCII-only labels stay unchanged while Unicode labels are IDNA encoded."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))
+    ]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Label Pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_label_pinned_dns(*_args, **_kwargs):
+        resolved = socket.getaddrinfo(
+            "_svc.xn--fa-hia.example", 80, type=socket.SOCK_STREAM
+        )
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_label_pinned_dns
+
+    cli.main(["--url", "http://_svc.faß.example/"])
+
+    outerr = capsys.readouterr()
+    assert "# Label Pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "_svc.xn--fa-hia.example", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://_svc.faß.example/", timeout=30, allow_redirects=False
+    )
+
+
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):


### PR DESCRIPTION
### Motivation

- Prevent DNS-pinning/SSRF mismatches where validation used a different hostname form than the HTTP stack, allowing rebinding between validation and connection. 
- Match the HTTP client behavior by IDNA-encoding only non-ASCII DNS labels so hosts like `http://_svc.faß.example/` keep ASCII-only labels (e.g., `_svc`) unchanged. 
- Preserve the requested host semantics for absolute FQDNs (trailing dot) and ensure failures in normalization do not fall back to an unpinned DNS lookup.

### Description

- Implement per-label hostname canonicalization in `_normalize_hostname` that splits on `.` and IDNA-encodes only non-ASCII labels using `idna.encode(..., uts46=True)` while keeping ASCII labels unchanged and preserving trailing root dots via `hostname.lower()` (file `src/html2md/cli.py`).
- Make the DNS-pinning hook fail closed by raising `socket.gaierror` if normalization fails during a request-time lookup instead of falling back to a plain string normalization and performing an unpinned lookup (file `src/html2md/cli.py`).
- Add `idna` as an explicit runtime dependency in `pyproject.toml` to avoid relying on transitive packaging of the module (file `pyproject.toml`).
- Add regression tests for absolute FQDN trailing-dot preservation and for per-label IDNA normalization of mixed ASCII/Unicode hosts (files `tests/test_cli_security.py`).

### Testing

- Ran the security tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` and they passed (`15 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` and it passed (`31 passed`).
- Ran `git diff --check` and CI-style checks locally with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43d213ec8320bcfd3dba9ed72422)