### PR TITLE
Use Gemini CLI default model

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -65,4 +65,3 @@ jobs:
         uses: google-github-actions/run-gemini-cli@v0
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
-          gemini_model: gemini-2.0-flash


### PR DESCRIPTION
### Motivation
- Avoid invoking a hard-coded Gemini model ID that can be shut down or become unsupported by letting the `run-gemini-cli` action select its default supported model.

### Description
- Removed the explicit `gemini_model` input from `./github/workflows/gemini-code-assist.yml` so `google-github-actions/run-gemini-cli` will use its default model instead of the previously hard-coded value.

### Testing
- Ran `git diff --check` and searched the workflow with `rg -n "gemini_model|gemini_api_key|run-gemini-cli" .github/workflows/gemini-code-assist.yml`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9775e108320b038e28b42f50d53)