### PR TITLE
Configure Gemini Code Assist review prompt and auth inputs

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -49,6 +49,8 @@ jobs:
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           google_api_key: ${{ env.GOOGLE_API_KEY }}
@@ -59,6 +61,33 @@ jobs:
           use_gemini_code_assist: ${{ env.GOOGLE_GENAI_USE_GCA }}
           use_vertex_ai: ${{ env.GOOGLE_GENAI_USE_VERTEXAI }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          settings: |-
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": []
+              }
+            }
           extensions: |
             [
               "https://github.com/gemini-cli-extensions/code-review"

--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -27,14 +27,40 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR'))
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GCP_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION }}
+      GCP_PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
+      GOOGLE_GENAI_USE_GCA: ${{ vars.GOOGLE_GENAI_USE_GCA }}
+      GOOGLE_GENAI_USE_VERTEXAI: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
       GEMINI_CLI_TRUST_WORKSPACE: "true"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        if: env.GEMINI_API_KEY != ''
+        if: >
+          env.GEMINI_API_KEY != '' ||
+          env.GOOGLE_API_KEY != '' ||
+          env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' ||
+          env.GOOGLE_GENAI_USE_GCA == 'true'
         continue-on-error: true
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          google_api_key: ${{ env.GOOGLE_API_KEY }}
+          gcp_location: ${{ env.GCP_LOCATION }}
+          gcp_project_id: ${{ env.GCP_PROJECT_ID }}
+          gcp_service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          gcp_workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          use_gemini_code_assist: ${{ env.GOOGLE_GENAI_USE_GCA }}
+          use_vertex_ai: ${{ env.GOOGLE_GENAI_USE_VERTEXAI }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: /pr-code-review


### PR DESCRIPTION
### Motivation
- Enable the Gemini Code Assist workflow to actually run PR-specific reviews by wiring authentication and a review prompt instead of only checking `GEMINI_API_KEY`.
- Support multiple authentication paths (Gemini API key, Google API key, Workload Identity, GCA/Vertex) so the action can authenticate in different environments.
- Ensure the action runs a PR review extension with an explicit PR number and GitHub token so reviews are posted as intended.

### Description
- Added environment inputs for `GOOGLE_API_KEY`, `GCP_LOCATION`, `GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GOOGLE_GENAI_USE_GCA`, and `GOOGLE_GENAI_USE_VERTEXAI` in `.github/workflows/gemini-code-assist.yml`.
- Broadened the step guard so the Gemini step runs when any supported auth path is present (`gemini_api_key`, `google_api_key`, `gcp_workload_identity_provider`, or `GOOGLE_GENAI_USE_GCA`).
- Kept the pinned action reference `google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489` and passed `GITHUB_TOKEN` plus explicit `github_pr_number`, the `code-review` extension, and the `/pr-code-review` prompt to drive PR-specific reviews.
- Preserved `continue-on-error: true` and the existing job gating that limits comment triggers to `MEMBER`/`OWNER`/`COLLABORATOR` and ensures runs only for same-repo PRs.

### Testing
- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "yaml ok"'`, which succeeded.
- Ran `git diff --check` to ensure no whitespace or syntax issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43c6740083209bfda39a93548d03)