### PR TITLE
Skip Gemini Code Assist when API key is missing

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -56,10 +56,14 @@ jobs:
             core.setOutput("is_same_repo", String(sameRepo));
 
       - uses: actions/checkout@v6
-        if: github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true'
+        if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.pr_head.outputs.head_sha }}
+      - name: Skip Gemini Code Assist without API key
+        if: env.GEMINI_API_KEY == ''
+        run: echo 'GEMINI_API_KEY is not configured; skipping Gemini Code Assist.'
+
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != '' && (github.event_name == 'workflow_dispatch' || steps.pr_head.outputs.is_same_repo == 'true')
         uses: google-github-actions/run-gemini-cli@v0


### PR DESCRIPTION
### Motivation
- Prevent the workflow from invoking `run-gemini-cli` with an empty `GEMINI_API_KEY` so comment/dispatch runs do not fail or run unauthenticated in environments without the secret.

### Description
- Modify `.github/workflows/gemini-code-assist.yml` to require a non-empty `GEMINI_API_KEY` for the checkout/run path and add a `Skip Gemini Code Assist without API key` step that logs `GEMINI_API_KEY is not configured; skipping Gemini Code Assist.` when the secret is empty.

### Testing
- Validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML ok"'` and ran `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc97d291c83209c3498e1d84a531b)