### PR TITLE
Pass PR review prompt and code-review extension to Gemini CLI

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -66,3 +66,8 @@ jobs:
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           gemini_model: gemini-2.0-flash
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: /pr-code-review


### PR DESCRIPTION
### Motivation
- The Gemini Code Assist workflow invoked `run-gemini-cli` without the code-review extension or the `/pr-code-review` prompt, so automatic runs received only the action's generic assistant prompt and produced no PR review output. 
- Provide the code-review extension and explicit review prompt so Gemini can perform PR reviews and publish review feedback as intended.

### Description
- Updated `.github/workflows/gemini-code-assist.yml` to include the code-review extension URL under the `extensions` input for `google-github-actions/run-gemini-cli@v0`.
- Added `prompt: /pr-code-review` to the same step so the CLI invocation uses the PR review prompt rather than the default assistant prompt.

### Testing
- Verified the modified workflow YAML parses with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'YAML OK'"`, which returned `YAML OK`.
- Committed the change as `Add Gemini PR review prompt` and validated the diff shows the added `extensions` and `prompt` inputs in `.github/workflows/gemini-code-assist.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9852ed88320bbf38f479f0bca3c)