### PR TITLE
Pass GitHub auth to Gemini Code Assist

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -27,6 +27,8 @@ jobs:
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       GEMINI_CLI_TRUST_WORKSPACE: true
+      GITHUB_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Resolve PR head SHA
         id: pr_head
@@ -66,3 +68,27 @@ jobs:
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
           gemini_model: gemini-2.0-flash
+          settings: |-
+            {
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              }
+            }


### PR DESCRIPTION
### Motivation

- Ensure the Gemini CLI can authenticate to GitHub so it can read PRs and post review comments during Code Assist runs.
- Configure the Gemini MCP server so the action has the necessary GitHub tooling access for automated PR reviews.

### Description

- Export `GITHUB_TOKEN` and `GH_TOKEN` in the workflow job `env` so the Gemini action has a workflow token available at runtime. 
- Add a `settings` block to the `google-github-actions/run-gemini-cli` invocation that configures an MCP `github` server using `ghcr.io/github/github-mcp-server:v0.27.0` and injects the workflow token via `GITHUB_PERSONAL_ACCESS_TOKEN` for the MCP server `env`.
- Enable the MCP tools `add_comment_to_pending_review`, `pull_request_read`, and `pull_request_review_write` so Gemini can inspect PRs and submit review comments.

### Testing

- Parsed the updated workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gemini-code-assist.yml'); puts 'YAML OK'"`, which succeeded.
- Ran `git diff --check` to validate no whitespace/patch issues, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc98f4a5c83209b2c1d64c90d733d)