### PR TITLE
Ensure Flask app tests run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
+          pip install -e ".[deploy]"
           pip install pytest
       - name: Test
         run: pytest -q

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,5 @@
 """Tests for the Flask application module."""
 
-import os
 import pytest
 
 # Skip all tests in this module if flask is not installed


### PR DESCRIPTION
### Motivation
- Ensure the new `get_host_port()` tests are exercised by CI because `flask` is provided only in the optional `deploy` extra. 
- Remove an unused `os` import from the test module to keep the test code clean.

### Description
- Change CI install step to install extras by replacing `pip install -e .` with `pip install -e ".[deploy]"` in `.github/workflows/ci.yml` so `flask` is available before `pytest` runs. 
- Remove the unused `os` import from `tests/test_app.py` so the file only imports `pytest` prior to `pytest.importorskip("flask")`.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pip install -e ".[deploy]" pytest`, which installed `flask` and dependencies successfully. (Succeeded)
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_app.py`, which passed. (Succeeded)
- Ran `LC_ALL=C PYENV_VERSION=3.12.13 pytest -q`, which passed after a plain `pytest -q` run failed due to a locale/gettext interaction in `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` when `builtins.open` was mocked; re-running with `LC_ALL=C` resolved the environment-specific failure. (Noted)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc99f36f88320887446ebde56fb9c)