### PR TITLE
Document trusted gating for Gemini comment triggers

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
+    # Run automatically only for same-repository PRs. Comment-triggered
+    # invocations require a trusted repository relationship before the job
+    # receives issues:write and pull-requests:write permissions.
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository) ||


### PR DESCRIPTION
### Motivation
- Document that the Gemini Code Assist job should only run automatically for same-repository PRs and that comment-triggered invocations must come from a trusted `author_association` before the job receives `issues: write` / `pull-requests: write` permissions.

### Description
- Add a short explanatory comment above the job `if:` in `.github/workflows/gemini-code-assist.yml` clarifying the same-repo auto-run behavior and the trusted-commenter requirement.

### Testing
- Validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "yaml ok"'` and checked formatting with `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43b05e408320b3076bcb82312204)