### PR TITLE
Restore Gemini Code Assist workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,0 +1,31 @@
+name: Gemini Code Assist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gemini-code-assist:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@gemini-code-assist')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@gemini-code-assist'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gemini Code Assist
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Reintroduce the deleted workflow so Gemini Code Assist continues running on PR `opened`, `synchronize`, and `reopened` events and still responds to on-demand `@gemini-code-assist` review/issue comments.
- The deletion would have silently removed an unrelated review automation while only the Jules workflow change was intended.

### Description
- Adds back `.github/workflows/gemini-code-assist.yml` with `on: pull_request`, `pull_request_review_comment`, and `issue_comment` triggers. 
- Grants `contents: read`, `pull-requests: write`, and `issues: write` permissions for the workflow. 
- Restores the `gemini-code-assist` job which checks out the repo with `actions/checkout@v4` and runs `google-gemini/code-assist-action@v1` guarded by a conditional that checks for PR events and `@gemini-code-assist` mentions. 

### Testing
- Ran `git diff --check` against the change and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9ac70f08320aee1eaed48e65ce0)