### PR TITLE
Clarify supported Gemini Code Assist action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != ''
         continue-on-error: true
+        # Use the supported Gemini CLI action; google-gemini/code-assist-action does not resolve.
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
           gemini_api_key: ${{ env.GEMINI_API_KEY }}
+          prompt: |
+            You are Gemini Code Assist reviewing this repository's pull request context.
+            Identify actionable correctness, security, and maintainability issues, and keep feedback concise.


### PR DESCRIPTION
### Motivation
- Ensure the Gemini workflow invokes a resolvable, supported action instead of a non-existent slug so Code Assist runs rather than failing at action resolution.
- Make the restored action invocation explicitly review-oriented by providing a concise PR-review prompt.

### Description
- Update `.github/workflows/gemini-code-assist.yml` to clarify that the workflow uses `google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489` (the supported Gemini CLI action) rather than the unavailable `google-gemini/code-assist-action` slug.
- Add a `prompt:` input to the Gemini CLI step so the action receives a short, review-focused instruction set for PR reviews.
- Include an in-file comment explaining the reason for using the supported action.

### Testing
- Loaded the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "yaml ok"'`, which succeeded.
- Ran `git diff --check` to verify no whitespace or diff issues, which reported no problems.
- Verified the pinned action tag exists with `git ls-remote --exit-code https://github.com/google-github-actions/run-gemini-cli.git refs/tags/v0.1.22`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43a38498832098f96f564767751b)