### PR TITLE
Grant contents write to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
   issues: write
   checks: read
   statuses: read


### PR DESCRIPTION
### Motivation
- Ensure the auto-merge workflow can run the `enablePullRequestAutoMerge` GraphQL mutation and perform label operations without 403 errors by granting the token the repository contents scope while keeping least-privilege for other operations.

### Description
- Added `contents: write` to the `permissions` block in `.github/workflows/auto-merge.yml` and retained `pull-requests: write`, `issues: write`, `checks: read`, and `statuses: read`.

### Testing
- Parsed `.github/workflows/auto-merge.yml` with `python3` and `yaml.safe_load` to validate the YAML structure, and confirmed `actionlint` is not installed in the environment so no linter run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9bdaa188320b45c8ac5d250b68e)