### PR TITLE
Mirror Windows CI for self-heal pytest validation

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -17,8 +17,11 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'failure')
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,15 +72,21 @@ jobs:
 
       - name: Run healthcheck (pre-repair)
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-pre.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-pre.txt
 
       - name: Attempt self-heal repairs
-        run: node scripts/self-heal.mjs | tee selfheal-repair.txt
+        run: |
+          set -o pipefail
+          node scripts/self-heal.mjs | tee selfheal-repair.txt
 
       - name: Run healthcheck (post-repair)
         id: post
         continue-on-error: true
-        run: node scripts/healthcheck.mjs | tee selfheal-post.txt
+        run: |
+          set -o pipefail
+          node scripts/healthcheck.mjs | tee selfheal-post.txt
 
       - name: Collect logs
         if: always()

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -31,7 +31,7 @@ try {
   tryRun("Build", hasScript("build") ? "pnpm run build" : null);
 
   // Native Python project checks.
-  tryRun("Python tests", existsSync("pyproject.toml") && existsSync("tests") ? "python3 -m pytest" : null);
+  tryRun("Python tests", existsSync("pyproject.toml") && existsSync("tests") ? "python -m pytest -q" : null);
 
   process.exit(0);
 } catch (e) {


### PR DESCRIPTION
### Motivation
- Run the self-heal healthcheck on the same OS as the repository `ci` job so Python test validation uses the same platform behavior as the main CI runner.
- Ensure the healthcheck invokes the interpreter configured by `actions/setup-python` rather than hard-coding `python3` so the check is portable across runners.
- Prevent `tee` from masking failure exit codes so pre- and post-repair checks accurately reflect test outcomes.

### Description
- Updated `.github/workflows/self-heal.yml` to run the job on `windows-latest`, add `defaults.run.shell: bash` to preserve bash semantics on Windows, and add `set -o pipefail` to piped steps that run the healthcheck and repair scripts. 
- Changed the healthcheck to use `python -m pytest -q` instead of `python3 -m pytest` in `scripts/healthcheck.mjs` so it uses the interpreter from `actions/setup-python`. 
- Edited only ` .github/workflows/self-heal.yml` and `scripts/healthcheck.mjs` to implement these changes.

### Testing
- Ran lint/sanity checks with `node --check scripts/healthcheck.mjs` and `node --check scripts/self-heal.mjs`, which succeeded. 
- Executed the healthcheck under `PYENV_VERSION=3.11.15` after installing project test dependencies (`python -m pip install -e . pytest`) to exercise the Python path, which ran the test suite but failed on an existing test: `tests/test_cli_exceptions.py::TestCliExceptions::test_outdir_containment_uses_path_aware_check` (the failure reproduces the pre-existing test issue). 
- Ran `git diff --check` to verify no whitespace or diff issues remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd438b0f4c8320a0798ebe06460a35)