### PR TITLE
Fix auto-merge ready PR handling

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
   issues: write
   checks: read
   statuses: read
@@ -71,7 +72,7 @@ jobs:
             core.info(`Target PRs: ${JSON.stringify(numbers)}`);
             core.setOutput('numbers', JSON.stringify(numbers));
 
-      - name: Evaluate criteria & enable auto-merge
+      - name: Evaluate criteria & merge
         if: steps.prs.outputs.numbers != '[]'
         uses: actions/github-script@v7
         env:
@@ -198,6 +199,16 @@ jobs:
                 }`, { id: prNodeId, method: MERGE_METHOD });
             }
 
+            async function mergePullRequest(pr) {
+              const method = MERGE_METHOD.toLowerCase();
+              await github.rest.pulls.merge({
+                owner, repo,
+                pull_number: pr.number,
+                merge_method: method,
+                commit_title: `${pr.title} (#${pr.number})`,
+              });
+            }
+
             await ensureLabel();
 
             for (const num of numbers) {
@@ -205,6 +216,10 @@ jobs:
 
               if (pr.state !== 'open' || pr.draft || pr.merged) {
                 core.info(`PR #${num}: skip (state=${pr.state}, draft=${pr.draft}, merged=${pr.merged}).`);
+                continue;
+              }
+              if (pr.mergeable === null) {
+                core.info(`PR #${num}: mergeability is still being computed.`);
                 continue;
               }
               if (pr.mergeable === false || pr.mergeable_state === 'dirty') {
@@ -236,10 +251,17 @@ jobs:
                 core.info(`PR #${num}: auto-merge already enabled.`);
                 continue;
               }
+
               try {
-                await enableAutoMerge(pr.node_id);
-                core.info(`PR #${num}: auto-merge enabled (${MERGE_METHOD}).`);
-              } catch (e) {
-                core.warning(`PR #${num}: failed to enable auto-merge — ${e.message}`);
+                await mergePullRequest(pr);
+                core.info(`PR #${num}: merged directly (${MERGE_METHOD}).`);
+              } catch (mergeError) {
+                core.warning(`PR #${num}: direct merge failed — ${mergeError.message}`);
+                try {
+                  await enableAutoMerge(pr.node_id);
+                  core.info(`PR #${num}: auto-merge enabled (${MERGE_METHOD}).`);
+                } catch (autoMergeError) {
+                  core.warning(`PR #${num}: failed to enable auto-merge — ${autoMergeError.message}`);
+                }
               }
             }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -204,6 +204,7 @@ jobs:
               await github.rest.pulls.merge({
                 owner, repo,
                 pull_number: pr.number,
+                sha: pr.head.sha,
                 merge_method: method,
                 commit_title: `${pr.title} (#${pr.number})`,
               });


### PR DESCRIPTION
### Motivation
- Ensure the workflow token can actually perform merges or enable auto-merge by granting the scopes required to write repository contents. 
- Prevent premature labeling or auto-merge attempts while GitHub is still computing PR mergeability or when no CI signal exists. 

### Description
- Add `contents: write` to the workflow `permissions` so the action can merge or call the GraphQL mutation. 
- Rename the step to `Evaluate criteria & merge` to reflect that the workflow may merge directly when criteria are satisfied. 
- Add a `mergePullRequest` helper that attempts a direct squash-merge via the REST API and falls back to `enablePullRequestAutoMerge` if the direct merge fails. 
- Skip PRs where `mergeable === null` so the job does not act while GitHub is still computing mergeability. 

### Testing
- Parsed the workflow YAML with `python3` using `yaml.safe_load` and parsing succeeded. 
- Installed the package with `python -m pip install -e .` which completed successfully. 
- Ran the test suite with `LC_ALL=C PYENV_VERSION=3.12.13 pytest` and received `20 passed` (all tests passed). 
- `actionlint` was not available in the environment, so linting was not executed (environment warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9b7cbd88320882bf318f175efba)