### PR TITLE
Gate self-heal workflow_run checkouts to same-repo failures

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,7 +16,10 @@ jobs:
   self-heal:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+      (
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
### Motivation
- Prevent privileged `self-heal` runs from checking out and executing contributor-controlled code from forked `workflow_run` events that have write-scoped `GITHUB_TOKEN` permissions. 
- Preserve manual `workflow_dispatch` behavior while restricting automated `workflow_run` repairs to failures originating in the same repository.

### Description
- Update `.github/workflows/self-heal.yml` to require `github.event.workflow_run.head_repository.full_name == github.repository` in the `if` condition for `workflow_run` events so the job only runs for same-repo failures. 
- Leave the existing checkout `ref` logic and other setup steps intact so manual `workflow_dispatch` runs continue to function.

### Testing
- Ran `node --check scripts/healthcheck.mjs && node --check scripts/self-heal.mjs` and the syntax checks passed. 
- Validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/self-heal.yml"); puts "ok"'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4385cb2c8320ad550ae3a29a7cd4)