### PR TITLE
ci: configure Gemini CLI for PR reviews

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -33,5 +33,54 @@ jobs:
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY_AVAILABLE == 'true'
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.pull_request.body || github.event.issue.body }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+          ADDITIONAL_CONTEXT: ${{ github.event.comment.body || '' }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          settings: |-
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": [
+                  "run_shell_command(cat)",
+                  "run_shell_command(echo)",
+                  "run_shell_command(grep)",
+                  "run_shell_command(head)",
+                  "run_shell_command(tail)"
+                ]
+              }
+            }
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          prompt: /pr-code-review


### PR DESCRIPTION
### Motivation
- Ensure the Gemini CLI step receives PR-specific context and a PR-review prompt so it can perform code reviews rather than producing only a generic job summary. 
- Give the action the GitHub MCP server and review-writing tools so Gemini can read the PR diff and publish pending-review comments. 
- Provide explicit PR/issue metadata and a trusted-comment context for comment-triggered runs to make review runs deterministic.

### Description
- Added step-scoped environment variables to the `Gemini Code Assist` step (`GITHUB_TOKEN`, `ISSUE_TITLE`, `ISSUE_BODY`, `PULL_REQUEST_NUMBER`, `REPOSITORY`, and `ADDITIONAL_CONTEXT`) so the action has GitHub context available. 
- Continued passing the API key via the action `with` input as `gemini_api_key` and added `github_pr_number` so the action knows the PR number for both PR and trusted comment triggers. 
- Injected a `settings` JSON that configures an MCP GitHub server (`github-mcp-server`) with the `add_comment_to_pending_review`, `pull_request_read`, and `pull_request_review_write` tools and supplies the runner `GITHUB_TOKEN` to it. 
- Enabled the `code-review` extension and set the action `prompt` to `/pr-code-review` so the CLI runs a PR-review-specific workflow instead of the default assistant prompt.

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "YAML OK"'` and it succeeded. 
- Ran `git diff --check` to validate whitespace/patch issues and it succeeded. 
- Linted the workflow with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/gemini-code-assist.yml` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9e76eb08320a9f028e41edeceee)