### PR TITLE
Check raw symlink names in sensitive-file hook

### DIFF
--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -37,20 +37,21 @@ PATH_KEYS = ("file_path", "path", "notebook_path")
 
 
 def is_sensitive(path: str) -> bool:
-    """Return whether ``path`` matches a sensitive filename pattern."""
+    """Return whether ``path`` or its resolved target matches a sensitive pattern."""
     if not path:
         return False
 
-    normalized_path = os.path.realpath(path)
-    basename = os.path.basename(normalized_path)
+    paths_to_check = (os.path.normpath(path), os.path.realpath(path))
 
-    for pattern in SENSITIVE_BASENAME_PATTERNS:
-        if fnmatch.fnmatch(basename, pattern):
-            return True
-        if fnmatch.fnmatch(normalized_path, pattern):
-            return True
-        if fnmatch.fnmatch(normalized_path, os.path.join("*", pattern)):
-            return True
+    for candidate_path in paths_to_check:
+        basename = os.path.basename(candidate_path)
+        for pattern in SENSITIVE_BASENAME_PATTERNS:
+            if fnmatch.fnmatch(basename, pattern):
+                return True
+            if fnmatch.fnmatch(candidate_path, pattern):
+                return True
+            if fnmatch.fnmatch(candidate_path, os.path.join("*", pattern)):
+                return True
 
     return False
 

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -56,6 +56,28 @@ def test_is_sensitive_matches_secret_basenames():
     assert not hook.is_sensitive("docs/env-example.md")
 
 
+def test_is_sensitive_checks_raw_symlink_filename(tmp_path):
+    """A sensitive symlink name is blocked even when its target basename is safe."""
+    hook = load_hook_module()
+    safe_target = tmp_path / "safe-target.txt"
+    sensitive_link = tmp_path / ".env"
+    safe_target.write_text("not secret", encoding="utf-8")
+    sensitive_link.symlink_to(safe_target)
+
+    assert hook.is_sensitive(str(sensitive_link))
+
+
+def test_is_sensitive_checks_resolved_symlink_target(tmp_path):
+    """A safe-looking symlink name is blocked when it resolves to a sensitive file."""
+    hook = load_hook_module()
+    sensitive_target = tmp_path / "id_ed25519"
+    safe_link = tmp_path / "safe-target.txt"
+    sensitive_target.write_text("secret", encoding="utf-8")
+    safe_link.symlink_to(sensitive_target)
+
+    assert hook.is_sensitive(str(safe_link))
+
+
 def test_candidate_paths_extracts_supported_keys_only():
     """Only supported Claude Code path keys are considered targets."""
     hook = load_hook_module()


### PR DESCRIPTION
### Motivation
- Prevent a symlink-based bypass where a sensitive filename (e.g. `.env` or `.ssh/id_ed25519`) is discarded by `realpath()` and an Edit/Write tool can modify the symlink target; the hook must consider both the original path and the resolved target.

### Description
- Update `is_sensitive` in `.claude/hooks/protect-sensitive-files.py` to evaluate both the raw path (`os.path.normpath(path)`) and the resolved path (`os.path.realpath(path)`) and match basename/patterns against both candidates. 
- Add regression tests in `tests/test_protect_sensitive_files_hook.py` that cover a sensitive symlink name pointing to a safe target and a safe symlink name resolving to a sensitive target. 
- Commit the changes and include the updated tests.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_protect_sensitive_files_hook.py`, which passed. 
- After installing the project editable with `PYENV_VERSION=3.12.13 python -m pip install -e .`, ran `PYENV_VERSION=3.12.13 pytest -q` and the full test suite passed. 
- Executed `git diff --check` to validate there are no whitespace/diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca08e2908320abf32230f23cc8f5)