### PR TITLE
Return blocking status for unreadable hook payloads

### DIFF
--- a/.claude/hooks/protect-sensitive-files.py
+++ b/.claude/hooks/protect-sensitive-files.py
@@ -85,7 +85,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"protect-sensitive-files: failed to read stdin: {exc}",
             file=sys.stderr,
         )
-        return 1
+        return 2
 
     if not payload_raw.strip():
         return 0
@@ -97,7 +97,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"protect-sensitive-files: bad JSON payload: {exc}",
             file=sys.stderr,
         )
-        return 1
+        return 2
 
     tool_name = payload.get("tool_name") or ""
     if tool_name not in PROTECTED_TOOLS:

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -148,7 +148,7 @@ def test_hook_fails_closed_on_bad_json():
     """Malformed non-empty payloads are rejected because safety cannot be verified."""
     result = run_hook_raw("{not valid json")
 
-    assert result.returncode == 1
+    assert result.returncode == 2
     assert "bad JSON payload" in result.stderr
 
 
@@ -157,6 +157,6 @@ def test_hook_fails_closed_when_stdin_read_fails(capsys):
     hook = load_hook_module()
 
     with patch.object(hook.sys.stdin, "read", side_effect=OSError("boom")):
-        assert hook.main() == 1
+        assert hook.main() == 2
 
     assert "failed to read stdin" in capsys.readouterr().err


### PR DESCRIPTION
### Motivation
- Ensure the `PreToolUse` sensitive-file hook fails closed so protected tool invocations are blocked when the hook cannot read stdin or cannot parse the JSON payload.

### Description
- Change `.claude/hooks/protect-sensitive-files.py` to return exit code `2` when `stdin.read()` raises or `json.loads()` fails, and update the tests to assert the blocking exit status.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_protect_sensitive_files_hook.py`, which passed.
- Ran `PYENV_VERSION=3.12.13 pytest -q` (full test suite), which passed in the test environment after installing editable dependencies.
- Verified manually with `printf '{not valid json' | PYENV_VERSION=3.12.13 python .claude/hooks/protect-sensitive-files.py; test $? -eq 2`, which returned the expected blocking status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca0b3a48832085ff0cbcadb4f596)