### PR TITLE
Export Gemini PR review context before action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -28,14 +28,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Export PR review context
+        run: |
+          {
+            echo "REPOSITORY=${{ github.repository }}"
+            echo "PULL_REQUEST_NUMBER=${{ github.event.pull_request.number || github.event.issue.number }}"
+            echo "PR_URL=${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
+            echo "ADDITIONAL_CONTEXT=Review ${{ github.repository }} pull request #${{ github.event.pull_request.number || github.event.issue.number }} (${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }})."
+          } >> "$GITHUB_ENV"
       - name: Gemini Code Assist
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
### Motivation
- The installed `/pr-code-review` prompt expects `REPOSITORY` and `PULL_REQUEST_NUMBER` (and optional `ADDITIONAL_CONTEXT`) in the runner environment, but `run-gemini-cli` exposes only `GH_PR_NUMBER`, leaving the code-review extension without explicit PR context.
- Exporting the PR context into the runner environment ensures the code-review extension can identify the pull request and use the GitHub MCP tools to fetch diffs and post review comments.

### Description
- Added an `Export PR review context` step in `.github/workflows/gemini-code-assist.yml` that writes `REPOSITORY`, `PULL_REQUEST_NUMBER`, `PR_URL`, and `ADDITIONAL_CONTEXT` to `$GITHUB_ENV` before invoking `run-gemini-cli`.
- Removed the previous practice of passing those PR-specific values as action `env` entries to rely on the exported runner environment instead, while keeping token inputs (`GITHUB_TOKEN`, `GEMINI_API_KEY`) available to the Gemini action.
- Left the `settings` JSON (MCP server configuration and included tools) and the `/pr-code-review` prompt in place so the CLI receives the explicit repository/PR context it needs.

### Testing
- Ran `git diff --check` which passed successfully.
- Parsed the workflow YAML and validated the `settings` JSON with `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/gemini-code-assist.yml'); require 'json'; JSON.parse(data['jobs']['gemini-code-assist']['steps'][2]['with']['settings']); puts 'YAML and settings JSON OK'"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca112fa48320919f504a85fd8c03)