### PR TITLE
Preserve trailing-dot DNS pinning semantics

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -82,7 +82,7 @@ def main(argv=None):
             """Return a canonical IDNA DNS hostname for matching pinned lookups."""
             if isinstance(hostname, bytes):
                 hostname = hostname.decode('ascii')
-            return hostname.rstrip('.').encode('idna').decode('ascii').lower()
+            return hostname.encode('idna').decode('ascii').lower()
 
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -160,6 +160,42 @@ def test_idna_hostname_uses_pinned_validated_dns(mock_get, mock_getaddrinfo, cap
     )
 
 
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_trailing_dot_hostname_uses_absolute_dns_name(mock_get, mock_getaddrinfo, capsys):
+    """Trailing-dot hostnames are validated and pinned as absolute DNS names."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Absolute pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_absolute_hostname(*_args, **_kwargs):
+        resolved = socket.getaddrinfo(
+            "service.example.", 80, type=socket.SOCK_STREAM
+        )
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_absolute_hostname
+
+    cli.main(["--url", "http://service.example./"])
+
+    outerr = capsys.readouterr()
+    assert "# Absolute pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "service.example.", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://service.example./", timeout=30, allow_redirects=False
+    )
+
+
 @patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 0))])
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, _mock_getaddrinfo, capsys, tmp_path):


### PR DESCRIPTION
### Motivation

- Stripping a trailing dot from hostnames changes absolute FQDN semantics and can make validation/pinning approve a different effective name than the URL requested, which undermines the DNS-pinning protection.

### Description

- Remove the `rstrip('.')` call in `_normalize_dns_hostname` so trailing dots are preserved before performing `encode('idna')` and subsequent validation/pinning.
- Add `test_trailing_dot_hostname_uses_absolute_dns_name` to `tests/test_cli_security.py` to assert a dotted hostname (e.g. `http://service.example./`) is validated and the validated DNS answer is reused during the pinned fetch.
- Changes touch `src/html2md/cli.py` and `tests/test_cli_security.py` to ensure validation and the pinned `getaddrinfo` comparator use the same dotted/IDNA hostname form.

### Testing

- Installed the package in editable mode with `PYENV_VERSION=3.12.13 python -m pip install -e .` which completed successfully.
- Ran the focused tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py` which passed (`14 passed`).
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest` which passed (`30 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd436f5b708320985a5828c1f1b9f5)