### PR TITLE
Use Requests IDNA normalization for DNS pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "markdownify>=0.11.6",
   "beautifulsoup4>=4.10.0",
   "requests>=2.25.0",
+  "idna>=2.8",
   "reportlab>=3.6.0",
   "pillow>=9.0.0",
   "pyyaml>=6.0",

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -79,10 +79,20 @@ def main(argv=None):
                     ip_obj.is_reserved or ip_obj.is_multicast)
 
         def _normalize_dns_hostname(hostname):
-            """Return a canonical IDNA DNS hostname for matching pinned lookups."""
+            """Return Requests-compatible IDNA DNS hostname for pinned lookups."""
+            import idna  # pylint: disable=import-outside-toplevel
+
             if isinstance(hostname, bytes):
                 hostname = hostname.decode('ascii')
-            return hostname.rstrip('.').encode('idna').decode('ascii').lower()
+            try:
+                ipaddress.ip_address(hostname)
+                return hostname.lower()
+            except ValueError:
+                pass
+            try:
+                return idna.encode(hostname, uts46=True).decode('ascii').lower()
+            except idna.IDNAError as e:
+                raise UnicodeError from e
 
         def validate_url(target_url: str):
             """Validate a URL and return the DNS answers approved for fetching it."""

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -128,8 +128,8 @@ def test_validated_dns_answer_is_pinned_during_fetch(mock_get, mock_getaddrinfo,
 
 @patch("socket.getaddrinfo")
 @patch("requests.Session.get")
-def test_idna_hostname_uses_pinned_validated_dns(mock_get, mock_getaddrinfo, capsys):
-    """Unicode hostnames are normalized before validation and pinned lookup matching."""
+def test_idna_hostname_uses_requests_uts46_pinned_dns(mock_get, mock_getaddrinfo, capsys):
+    """IDNA hostnames use Requests' UTS#46 form for validation and pinning."""
     public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
     rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
     mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
@@ -141,22 +141,58 @@ def test_idna_hostname_uses_pinned_validated_dns(mock_get, mock_getaddrinfo, cap
     response.raise_for_status.return_value = None
 
     def get_with_idna_hostname(*_args, **_kwargs):
-        resolved = socket.getaddrinfo("xn--tst-qla.example", 80, type=socket.SOCK_STREAM)
+        resolved = socket.getaddrinfo("xn--fa-hia.example", 80, type=socket.SOCK_STREAM)
         assert resolved == public_answer
         return response
 
     mock_get.side_effect = get_with_idna_hostname
 
-    cli.main(["--url", "http://täst.example/"])
+    cli.main(["--url", "http://faß.example/"])
 
     outerr = capsys.readouterr()
     assert "# IDNA pinned" in outerr.out
     assert "169.254.169.254" not in outerr.err
     mock_getaddrinfo.assert_called_once_with(
-        "xn--tst-qla.example", 80, type=socket.SOCK_STREAM
+        "xn--fa-hia.example", 80, type=socket.SOCK_STREAM
     )
     mock_get.assert_called_once_with(
-        "http://täst.example/", timeout=30, allow_redirects=False
+        "http://faß.example/", timeout=30, allow_redirects=False
+    )
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_trailing_dot_hostname_is_preserved_for_validation_and_pin(
+    mock_get, mock_getaddrinfo, capsys
+):
+    """Absolute DNS names keep their trailing dot during validation and pinning."""
+    public_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    rebound_answer = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    mock_getaddrinfo.side_effect = [public_answer, rebound_answer]
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.text = "<h1>Trailing dot pinned</h1>"
+    response.raise_for_status.return_value = None
+
+    def get_with_absolute_hostname(*_args, **_kwargs):
+        resolved = socket.getaddrinfo("service.example.", 80, type=socket.SOCK_STREAM)
+        assert resolved == public_answer
+        return response
+
+    mock_get.side_effect = get_with_absolute_hostname
+
+    cli.main(["--url", "http://service.example./"])
+
+    outerr = capsys.readouterr()
+    assert "# Trailing dot pinned" in outerr.out
+    assert "169.254.169.254" not in outerr.err
+    mock_getaddrinfo.assert_called_once_with(
+        "service.example.", 80, type=socket.SOCK_STREAM
+    )
+    mock_get.assert_called_once_with(
+        "http://service.example./", timeout=30, allow_redirects=False
     )
 
 


### PR DESCRIPTION
### Motivation

- Prevent mismatches between the hostname form used for validation and the form `requests` actually uses when connecting, which could let IDN/UTS#46 differences bypass DNS pinning. 
- Preserve trailing-dot (absolute) hostnames so validation/pinning use the exact DNS name that the client will resolve.

### Description

- Replace the builtin `idna` codec path with Requests-compatible IDNA normalization by calling `idna.encode(..., uts46=True)` in a new `_normalize_dns_hostname()` helper and keep IP literals unchanged (so IP-based SSRF checks still work). 
- Stop stripping a trailing dot and rely on the UTS#46 encoder to preserve absolute FQDN semantics during validation and when comparing pinned lookups. 
- Add `idna` to project dependencies in `pyproject.toml`. 
- Update and add tests in `tests/test_cli_security.py` to cover UTS#46 (`faß.example`) normalization and trailing-dot pinning behavior; main logic changes are in `src/html2md/cli.py`.

### Testing

- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py`, which completed successfully (`14 passed`).
- Ran the full suite with `PYENV_VERSION=3.12.13 python -m pytest`, which completed successfully (`30 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd435fc71883209477d8bf625d7ca2)