### PR TITLE
Restrict self-heal workflow to trusted same-repo workflow_run events

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,7 +16,8 @@ jobs:
   self-heal:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure')
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
### Motivation
- Prevent the self-heal job from checking out and executing contributor-controlled code when the failed `workflow_run` originates from a forked repository, which could lead to privilege escalation via the write-scoped `GITHUB_TOKEN`.
- Preserve the interactive `workflow_dispatch` path and the intended behavior for trusted same-repo repairs.

### Description
- Add a guard in `.github/workflows/self-heal.yml` so the `workflow_run`-driven job only runs for failed runs where `github.event.workflow_run.head_repository.full_name == github.repository`.
- Keep the existing checkout of the failing `head_sha` for trusted same-repo runs and leave `workflow_dispatch` behavior unchanged.

### Testing
- Ran `node --check scripts/healthcheck.mjs && node --check scripts/self-heal.mjs` and both files passed syntax checks.
- Validated the workflow file with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/self-heal.yml` which succeeded.
- `npx --yes actionlint .github/workflows/self-heal.yml` failed due to npm executable resolution so the Go `actionlint` was used instead for validation.
- Ran `git diff --check` to ensure no whitespace/diff errors and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd04c264008320a2fa20f5d9211738)