### PR TITLE
Pin IDNA-normalized hostnames in SSRF DNS guard

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -29,16 +29,30 @@ def _resolve_global_addrinfo(hostname: str, port: int):
     return addrinfo
 
 
+def _normalized_hostname_variants(hostname: str) -> set[str]:
+    """Return hostnames that may be used for DNS after URL preparation."""
+    normalized_hostname = hostname.rstrip('.').lower()
+    variants = {normalized_hostname}
+
+    try:
+        idna_hostname = normalized_hostname.encode('idna').decode('ascii')
+    except UnicodeError:
+        return variants
+
+    variants.add(idna_hostname.rstrip('.').lower())
+    return variants
+
+
 @contextmanager
 def _bound_getaddrinfo(hostname: str, addrinfo):
     """Pin requests' DNS lookup for hostname to previously vetted answers."""
     original_getaddrinfo = socket.getaddrinfo
-    normalized_hostname = hostname.rstrip('.').lower()
+    pinned_hostnames = _normalized_hostname_variants(hostname)
 
     def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         if (
             isinstance(host, str)
-            and host.rstrip('.').lower() == normalized_hostname
+            and host.rstrip('.').lower() in pinned_hostnames
         ):
             return addrinfo
         return original_getaddrinfo(host, port, family, type, proto, flags)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -224,3 +224,18 @@ def test_bound_getaddrinfo_pins_vetted_answer_during_fetch():
         with cli._bound_getaddrinfo("example.com", vetted):
             assert socket.getaddrinfo("example.com", 443) == vetted
             assert socket.getaddrinfo("other.example", 443) == rebinding_answer
+
+
+def test_bound_getaddrinfo_pins_idna_normalized_hostname_during_fetch():
+    """IDNA hostnames prepared by requests must reuse vetted DNS answers."""
+    vetted = addrinfo("93.184.216.34")
+    rebinding_answer = addrinfo("127.0.0.1")
+
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):
+        return rebinding_answer
+
+    with patch("html2md.cli.socket.getaddrinfo", side_effect=rebinding_getaddrinfo):
+        with cli._bound_getaddrinfo("bücher.example", vetted):
+            assert socket.getaddrinfo("bücher.example", 443) == vetted
+            assert socket.getaddrinfo("xn--bcher-kva.example", 443) == vetted
+            assert socket.getaddrinfo("other.example", 443) == rebinding_answer


### PR DESCRIPTION
### Motivation
- The DNS pinning guard compared only the original parsed hostname, which lets an attacker use an IDNA/punycode form prepared by `requests` to rebind and bypass SSRF protections.

### Description
- Add `_normalized_hostname_variants(hostname: str)` to produce the normalized Unicode hostname and its ASCII IDNA (punycode) form when available.
- Update `_bound_getaddrinfo()` to build a `pinned_hostnames` set and match `host.rstrip('.').lower()` against all pinned variants rather than a single normalized name.
- Add `test_bound_getaddrinfo_pins_idna_normalized_hostname_during_fetch` to assert both the Unicode and punycode hostnames reuse the vetted DNS answers and prevent rebinding.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/test_cli_security.py` and the security tests passed.
- Ran the full test suite with `PYENV_VERSION=3.12.13 pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0153ae5f4c83208ccb638d1c046c9d)