### PR TITLE
[AI-Assisted] Replace $isTempFile heuristic with explicit -DeleteBatchFile switch

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -60,7 +60,7 @@ if ($BatchFile -or $Url) {
         }
     } finally {
         if ($DeleteBatchFile) {
-            Remove-Item -LiteralPath $BatchFile -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $BatchFile -Force -ErrorAction SilentlyContinue
         }
     }
     exit

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -59,7 +59,7 @@ if ($BatchFile -or $Url) {
             }
         }
     } finally {
-        if ($DeleteBatchFile) {
+        if ($DeleteBatchFile -and $BatchFile -and (Test-Path -LiteralPath $BatchFile)) {
             Remove-Item -LiteralPath $BatchFile -Force -ErrorAction SilentlyContinue
         }
     }

--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -6,18 +6,14 @@ WPF GUI for html2md
 - Safe for double-click or PowerShell execution
 #>
 
-param([string]$BatchFile, [string]$BatchOutDir, [switch]$BatchWholePage, [string]$Url, [string]$OutDir, [switch]$WholePage)
+param([string]$BatchFile, [string]$BatchOutDir, [switch]$BatchWholePage, [string]$Url, [string]$OutDir, [switch]$WholePage, [switch]$DeleteBatchFile)
 
 if ($BatchFile -or $Url) {
     if ($BatchFile -and -not (Test-Path -LiteralPath $BatchFile)) {
         Write-Error "Batch file not found: $BatchFile"
         exit 1
     }
-    
-    # Check if this is a temp file created by the GUI (temp files are in %TEMP%)
-    # Check if this is a temp file created by the GUI (temp files are in %TEMP% and follow our naming pattern)
-    $isTempFile = $BatchFile -and ($BatchFile -like "$env:TEMP\html2md_batch_*")
-    
+
     $scriptDir = Split-Path -Parent $PSCommandPath
     if (-not $scriptDir) { $scriptDir = (Get-Location).Path }
 
@@ -63,14 +59,8 @@ if ($BatchFile -or $Url) {
             }
         }
     } finally {
-        # Clean up temp file if it was created by the GUI
-        if ($isTempFile -and (Test-Path -LiteralPath $BatchFile)) {
-            try {
-                Remove-Item -LiteralPath $BatchFile -Force -ErrorAction SilentlyContinue
-                Write-Host "Cleaned up temporary batch file: $BatchFile"
-            } catch {
-                Write-Warning "Could not delete temporary file: $BatchFile"
-            }
+        if ($DeleteBatchFile) {
+            Remove-Item -LiteralPath $BatchFile -ErrorAction SilentlyContinue
         }
     }
     exit
@@ -396,6 +386,7 @@ $ConvertBtn.Add_Click({
         if ($WholePageChk.IsChecked) {
             $psi.Arguments += " -BatchWholePage"
         }
+        $psi.Arguments += " -DeleteBatchFile"
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]

--- a/tests/test_gui_launcher_security.py
+++ b/tests/test_gui_launcher_security.py
@@ -22,3 +22,20 @@ def test_gui_script_avoids_command_relaunch() -> None:
     for line in active_arguments:
         assert "-Command" not in line
         assert "-File" in line
+
+
+def test_batch_mode_passes_delete_batch_file_switch() -> None:
+    gui_script = (ROOT / "gui-url-convert.ps1").read_text(encoding="utf-8")
+
+    # Batch mode must append -DeleteBatchFile so the subprocess cleans up
+    # the GUI-created temp file.
+    assert '$psi.Arguments += " -DeleteBatchFile"' in gui_script
+
+
+def test_delete_batch_file_guarded_by_batch_file_param() -> None:
+    gui_script = (ROOT / "gui-url-convert.ps1").read_text(encoding="utf-8")
+
+    # The finally cleanup must check $BatchFile is non-empty before calling
+    # Remove-Item, so passing -DeleteBatchFile with only -Url does not cause
+    # a parameter-binding error.
+    assert "$DeleteBatchFile -and $BatchFile" in gui_script


### PR DESCRIPTION
## Summary

- Removes the `$isTempFile = $BatchFile -like "$env:TEMP\*"` heuristic, which could silently delete a user-supplied `-BatchFile` that happened to live under `%TEMP%`.
- Adds a `-DeleteBatchFile` switch to the script's `param` block. The GUI batch launcher appends `-DeleteBatchFile` only for the temp file it creates, so user-supplied paths are never deleted implicitly.
- Adds `-Force` to `Remove-Item` in the `finally` block so read-only temp files are cleaned up rather than silently skipped.

## Test plan

- [ ] Batch-convert multiple URLs via the GUI — temp file in `%TEMP%` is deleted after the subprocess exits.
- [ ] Run the script directly with a user-supplied `-BatchFile` (no `-DeleteBatchFile`) — the file is left untouched after processing.
- [ ] Verify a read-only temp file (e.g. `attrib +R`) is still deleted when `-DeleteBatchFile` is passed.

https://claude.ai/code/session_01HwWbZfEMDVD2TQgT8ky8rQ