### PR TITLE
Apply SSRF guard to CLI fetch, block non-global addresses, and pin DNS answers

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 import argparse
+from collections.abc import Iterator
+from contextlib import contextmanager
 import ipaddress
 import os
 import socket
@@ -9,31 +11,106 @@ import sys
 from urllib.parse import urlparse, unquote, urljoin
 
 
-def _check_ssrf(hostname: str) -> None:
+_AddrInfo = tuple[int, int, int, str, tuple]
+
+
+def _check_ssrf(hostname: str) -> list[_AddrInfo]:
     """Resolve *hostname* and block any non-globally-routable address.
 
     Uses ``socket.getaddrinfo`` so that every returned address (IPv4 and IPv6)
     is validated, preventing SSRF via dual-stack hosts or unexpected AAAA records.
+    The validated address info is returned so the HTTP request can be pinned to
+    the same DNS answers that were checked.
 
     Raises ``ValueError`` if the hostname cannot be resolved or any resolved
-    address is private, loopback, link-local, or multicast.
+    address is not globally routable.
     """
     try:
-        results = socket.getaddrinfo(hostname, None)
+        results = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
     except OSError as exc:
         raise ValueError(f"Could not resolve hostname '{hostname}'") from exc
     if not results:
         raise ValueError(f"No addresses found for hostname '{hostname}'")
-    for _family, _type, _proto, _canon, sockaddr in results:
-        ip_str = sockaddr[0].split('%')[0]  # strip IPv6 scope-id (e.g. fe80::1%eth0)
+
+    validated_results: list[_AddrInfo] = []
+    for family, socktype, proto, canon, sockaddr in results:
+        ip_str = str(sockaddr[0]).split('%')[0]  # strip IPv6 scope-id (e.g. fe80::1%eth0)
         try:
             ip_obj = ipaddress.ip_address(ip_str)
-        except ValueError:
-            continue
+        except ValueError as exc:
+            raise ValueError(
+                f"Could not parse resolved address '{ip_str}' for hostname '{hostname}'"
+            ) from exc
         if not ip_obj.is_global or ip_obj.is_multicast:
             raise ValueError(
                 f"SSRF blocked: '{hostname}' resolves to non-public address {ip_obj}"
             )
+        validated_results.append((family, socktype, proto, canon, sockaddr))
+
+    if not validated_results:
+        raise ValueError(f"No usable addresses found for hostname '{hostname}'")
+    return validated_results
+
+
+def _normalize_hostname(hostname: object) -> str:
+    """Normalize hostnames for comparing requests' resolver input."""
+    if isinstance(hostname, bytes):
+        hostname = hostname.decode('idna')
+    return str(hostname).rstrip('.').lower()
+
+
+def _with_requested_port(sockaddr: tuple, port: object) -> tuple:
+    """Return *sockaddr* with the port requested by ``getaddrinfo``."""
+    requested_port = 0 if port is None else port
+    if len(sockaddr) == 2:
+        return (sockaddr[0], requested_port)
+    return (sockaddr[0], requested_port, *sockaddr[2:])
+
+
+@contextmanager
+def _pin_resolved_addrinfo(hostname: str, addrinfo: list[_AddrInfo]) -> Iterator[None]:
+    """Temporarily pin ``getaddrinfo`` for *hostname* to validated answers.
+
+    ``requests``/urllib3 performs its own DNS lookup after SSRF validation.
+    During the guarded request, return the already-validated address records for
+    the same hostname so DNS rebinding or round-robin changes cannot swap in an
+    unchecked private/link-local address between validation and connect.
+    """
+    original_getaddrinfo = socket.getaddrinfo
+    pinned_hostname = _normalize_hostname(hostname)
+
+    def pinned_getaddrinfo(
+        host: object,
+        port: object,
+        family: int = 0,
+        type: int = 0,  # pylint: disable=redefined-builtin
+        proto: int = 0,
+        flags: int = 0,
+    ) -> list[_AddrInfo]:
+        if _normalize_hostname(host) == pinned_hostname:
+            matches = [
+                (
+                    result_family,
+                    result_type,
+                    result_proto,
+                    canon,
+                    _with_requested_port(sockaddr, port),
+                )
+                for result_family, result_type, result_proto, canon, sockaddr in addrinfo
+                if family in (0, result_family)
+                and type in (0, result_type)
+                and proto in (0, result_proto)
+            ]
+            if matches:
+                return matches
+        return original_getaddrinfo(host, port, family, type, proto, flags)
+
+    socket.getaddrinfo = pinned_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -117,13 +194,14 @@ def main(argv=None):
                         )
                         return
                     try:
-                        _check_ssrf(hop_host)
+                        validated_addrinfo = _check_ssrf(hop_host)
                     except ValueError as ssrf_err:
                         print(f"Error: {ssrf_err}", file=sys.stderr)
                         return
-                    response = session.get(
-                        current_url, timeout=30, stream=True, allow_redirects=False
-                    )
+                    with _pin_resolved_addrinfo(hop_host, validated_addrinfo):
+                        response = session.get(
+                            current_url, timeout=30, stream=True, allow_redirects=False
+                        )
                     if response.status_code in (301, 302, 303, 307, 308):
                         location = response.headers.get('Location', '')
                         if not location:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -41,6 +41,7 @@ _EXAMPLE_COM_ADDRINFO = _make_addrinfo("93.184.216.34")
     "10.0.0.1",         # private class A
     "192.168.1.1",      # private class C
     "172.16.0.1",       # private class B
+    "100.64.0.1",       # carrier-grade NAT (not private, but non-global)
     "224.0.0.1",        # multicast
 ])
 def test_check_ssrf_blocks_non_public(blocked_ip):
@@ -104,6 +105,42 @@ def test_process_url_blocks_ssrf(ssrf_url, blocked_ip, capsys):
     outerr = capsys.readouterr()
     assert "SSRF blocked" in outerr.err
 
+
+def test_process_url_pins_validated_dns_answers_during_fetch(capsys):
+    """The CLI must fetch using the same DNS answers validated by the SSRF guard."""
+    public_ip = "93.184.216.34"
+    private_ip = "10.0.0.1"
+    original_resolutions = []
+
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):
+        original_resolutions.append((host, port, args, kwargs))
+        if len(original_resolutions) == 1:
+            return _make_addrinfo(public_ip)
+        return _make_addrinfo(private_ip)
+
+    response = MagicMock()
+    response.text = "<h1>safe</h1>"
+    response.raise_for_status.return_value = None
+    response.status_code = 200
+    response.headers = {}
+    response.iter_content.return_value = iter([b"<h1>safe</h1>"])
+
+    def fake_get(url, **kwargs):
+        pinned = socket.getaddrinfo("rebind.example", 80, type=socket.SOCK_STREAM)
+        assert pinned[0][4] == (public_ip, 80)
+        assert all(result[4][0] == public_ip for result in pinned)
+        assert url == "http://rebind.example/"
+        assert kwargs["allow_redirects"] is False
+        return response
+
+    with patch("socket.getaddrinfo", side_effect=rebinding_getaddrinfo):
+        with patch("requests.Session.get", side_effect=fake_get) as mock_get:
+            cli.main(["--url", "http://rebind.example/"])
+            mock_get.assert_called_once()
+
+    outerr = capsys.readouterr()
+    assert "SSRF blocked" not in outerr.err
+    assert len(original_resolutions) == 1
 
 # ---------------------------------------------------------------------------
 # Existing scheme / path-traversal tests (preserved, now with SSRF mock)


### PR DESCRIPTION
### Motivation
- The prior mitigation was added as a diff artifact but the CLI still performed raw `session.get(target_url, ...)` without validating resolved addresses, leaving an SSRF window via loopback/internal addresses or redirects. 
- Simple checks for `is_private` or selective exclusions can miss non-global ranges like carrier-grade NAT (`100.64.0.0/10`) and DNS rebinding can cause the client to connect to a different address than the one validated.

### Description
- Change `_check_ssrf` to resolve with `socket.getaddrinfo(..., type=socket.SOCK_STREAM)`, validate every returned address using `ipaddress.ip_address(...)`, reject any address that is not `is_global` or is multicast, and return the validated `addrinfo` records for use by the fetcher. 
- Add `_pin_resolved_addrinfo` context manager that temporarily pins `socket.getaddrinfo` for the validated hostname so `requests`/urllib3 uses the same DNS answers during the guarded `session.get`, preventing DNS rebinding/round-robin bypasses. 
- Use the validated addrinfo + pinning on every redirect hop and perform guarded fetches with `allow_redirects=False` and manual redirect handling to ensure validation runs for each hop. 
- Extend tests in `tests/test_cli_security.py` to include a CGNAT address (`100.64.0.1`) in the blocked matrix and add an integration test that simulates DNS rebinding to confirm the client uses pinned, validated answers during the fetch.

### Testing
- Verified the modified module compiles with `python -m py_compile src/html2md/cli.py` and reported no syntax errors. 
- Ran targeted tests with `PYTHONPATH=src python -m pytest tests/test_cli_security.py -q` and observed they passed. 
- Ran the full test suite with `PYTHONPATH=src python -m pytest tests/ -q` and observed all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01537f0afc832084654c80e73f6038)