### PR TITLE
Document published Gemini Code Assist action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Use the published Gemini CLI action. The google-gemini/code-assist-action@v1
+      # repository is not a resolvable GitHub Action and fails during action resolution.
       - name: Gemini Code Assist
         if: env.GEMINI_API_KEY != ''
         continue-on-error: true


### PR DESCRIPTION
### Motivation
- The `google-gemini/code-assist-action@v1` target is not a resolvable GitHub Action and caused workflow resolution failures, so clarify and point the workflow at the published `google-github-actions/run-gemini-cli` action.

### Description
- Add an inline comment to `.github/workflows/gemini-code-assist.yml` explaining that the workflow intentionally uses `google-github-actions/run-gemini-cli@f77273f4` because `google-gemini/code-assist-action@v1` is not published.

### Testing
- Verified syntax and changes with `git diff --check`, parsed the workflow via `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml")'`, and confirmed the action references using `rg`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014818c8bc8320957fa72c5462b63a)