### PR TITLE
ci: resolve Gemini PR checkout ref in preflight

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -45,6 +45,8 @@ jobs:
        contains(github.event.comment.body, '@gemini-code-assist'))
     outputs:
       enabled: ${{ steps.gate.outputs.enabled }}
+      pull_request_number: ${{ steps.gate.outputs.pull_request_number }}
+      checkout_ref: ${{ steps.gate.outputs.checkout_ref }}
     steps:
       - name: Gate on fork status and Gemini API key
         id: gate
@@ -68,6 +70,15 @@ jobs:
               head_repo=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.repo.full_name)
               ;;
           esac
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Gemini Code Assist: could not determine the pull request number for this event."
+            exit 0
+          fi
+
+          echo "pull_request_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=refs/pull/$PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
 
           if [ -n "$head_repo" ] && [ "$head_repo" != "$REPO" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -98,8 +109,9 @@ jobs:
           # pull_request_review_comment runs default to the workflow ref
           # (the base branch's tip), which would make local read tools
           # like read_file/glob inspect base-branch code instead of the
-          # PR under review.
-          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+          # PR under review. The preflight job resolves this from
+          # github.event.issue.number for issue_comment triggers.
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Strip PR-supplied Gemini config
@@ -145,15 +157,14 @@ jobs:
           # Consumed by the code-review extension's /pr-code-review prompt
           # template via $REPOSITORY and $PULL_REQUEST_NUMBER expansions.
           REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PULL_REQUEST_NUMBER: ${{ needs.preflight.outputs.pull_request_number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_cli_version: "0.41.2"
-          # Resolves the PR number across all three supported triggers:
-          # pull_request, pull_request_review_comment, and issue_comment.
-          # The first two populate github.event.pull_request.number; the
-          # last populates github.event.issue.number.
-          github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # Use the PR number resolved by preflight across all supported
+          # triggers, including top-level PR comments where GitHub exposes
+          # it as github.event.issue.number instead of pull_request.number.
+          github_pr_number: ${{ needs.preflight.outputs.pull_request_number }}
           settings: |-
             {
               "model": {


### PR DESCRIPTION
### Motivation

- Ensure comment-triggered runs (`issue_comment` and `pull_request_review_comment`) check out the actual PR merge commit instead of the repository default branch so local read tools inspect the PR under review.  
- Make PR context (PR number and checkout ref) available to downstream steps so the Gemini action receives consistent target-PR information for comment-triggered runs.  
- Fail fast and emit a clear notice when the event payload does not expose a resolvable PR number.

### Description

- Expose `pull_request_number` and `checkout_ref` as `preflight` job outputs and populate them from the resolved `PR_NUMBER`.  
- Add a preflight guard that notices and exits when `PR_NUMBER` cannot be determined.  
- Use the preflight-provided `checkout_ref` in `actions/checkout` so `ref: ${{ needs.preflight.outputs.checkout_ref }}` checks out `refs/pull/<number>/merge`.  
- Pass the preflight-resolved PR number into the Gemini step via `PULL_REQUEST_NUMBER` and `github_pr_number` so comment-triggered runs have consistent PR context.

### Testing

- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gemini-code-assist.yml"); puts "valid yaml"'` and it succeeded.  
- Ran the repository-level Python checks that assert the presence of `checkout_ref`, the `echo` to `GITHUB_OUTPUT`, and the `needs.preflight` substitutions and they all passed.  
- Ran `git diff --check` and there were no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0147e5cf1c8320b38f98a829670403)