### PR TITLE
Avoid Node for sensitive-file hook launcher

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -49,11 +49,12 @@ def is_sensitive(path: str) -> bool:
 
 def _candidate_paths(tool_input: Dict[str, Any]) -> List[str]:
     """Collect path-like fields from a Claude Code tool input payload."""
-    return [
-        value
-        for key in PATH_KEYS
-        if isinstance((value := tool_input.get(key)), str) and value
-    ]
+    paths = []
+    for key in PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            paths.append(value)
+    return paths
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/.claude/hooks/run_protect_sensitive_files.sh
+++ b/.claude/hooks/run_protect_sensitive_files.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Run the sensitive-file protection hook without requiring Node.
+#
+# Claude Code only blocks PreToolUse hooks when the command exits with status 2.
+# This launcher preserves stdin for fallback Python launchers and fails closed with
+# status 2 whenever the policy cannot be evaluated.
+
+HOOK_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 2
+HOOK_SCRIPT=$HOOK_DIR/protect_sensitive_files.py
+PAYLOAD_FILE=$(mktemp "${TMPDIR:-/tmp}/protect-sensitive-files.XXXXXX") || exit 2
+
+cleanup() {
+    rm -f "$PAYLOAD_FILE"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! cat > "$PAYLOAD_FILE"; then
+    echo "protect-sensitive-files: failed to read stdin; failing closed" >&2
+    exit 2
+fi
+
+run_launcher() {
+    "$@" "$HOOK_SCRIPT" < "$PAYLOAD_FILE"
+    status=$?
+
+    case "$status" in
+        0|2)
+            exit "$status"
+            ;;
+        126|127)
+            return 1
+            ;;
+        *)
+            echo "protect-sensitive-files: hook failed with status $status; failing closed" >&2
+            exit 2
+            ;;
+    esac
+}
+
+run_launcher python3
+run_launcher py -3
+run_launcher python
+
+echo "protect-sensitive-files: no working Python 3 launcher found; failing closed" >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py\" || py -3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py\" || python \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py\" || exit 2"
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/run_protect_sensitive_files.sh\""
           }
         ]
       }

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 
-HOOK_SCRIPT = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "protect_sensitive_files.py"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_SCRIPT = REPO_ROOT / ".claude" / "hooks" / "protect_sensitive_files.py"
+HOOK_LAUNCHER = REPO_ROOT / ".claude" / "hooks" / "run_protect_sensitive_files.sh"
+SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
 
 
-def run_hook(payload: Union[Dict[str, object], str]) -> subprocess.CompletedProcess[str]:
+def run_hook(payload: Union[Dict[str, object], str]) -> subprocess.CompletedProcess:
     """Run the hook with a JSON payload or raw stdin text."""
     stdin = payload if isinstance(payload, str) else json.dumps(payload)
     return subprocess.run(
@@ -21,6 +25,24 @@ def run_hook(payload: Union[Dict[str, object], str]) -> subprocess.CompletedProc
         text=True,
         capture_output=True,
         check=False,
+    )
+
+
+def run_launcher(
+    payload: Union[Dict[str, object], str], path: Optional[str] = None
+) -> subprocess.CompletedProcess:
+    """Run the hook launcher with a JSON payload or raw stdin text."""
+    stdin = payload if isinstance(payload, str) else json.dumps(payload)
+    env = os.environ.copy()
+    if path is not None:
+        env["PATH"] = path
+    return subprocess.run(
+        [str(HOOK_LAUNCHER)],
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
     )
 
 
@@ -72,41 +94,49 @@ def test_malformed_payload_does_not_block() -> None:
     assert "bad JSON payload" in result.stderr
 
 
-def test_hook_settings_uses_python_directly_and_fails_closed() -> None:
-    """Claude Code should run Python directly and block if launch fails."""
-    settings_path = Path(__file__).resolve().parents[1] / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-
-    assert command == (
-        'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py" '
-        '|| py -3 "$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py" '
-        '|| python "$CLAUDE_PROJECT_DIR/.claude/hooks/protect_sensitive_files.py" '
-        '|| exit 2'
-    )
-    assert "node" not in command
-    assert "run_protect_sensitive_files.js" not in command
-    assert command.endswith("|| exit 2")
-
-
-def test_hook_settings_fails_closed_when_no_python_launcher_works(tmp_path: Path) -> None:
-    """The configured shell fallback must return 2 if no Python command works."""
-    settings_path = Path(__file__).resolve().parents[1] / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-    env = {
-        "CLAUDE_PROJECT_DIR": str(Path(__file__).resolve().parents[1]),
-        "PATH": str(tmp_path),
-    }
-
-    result = subprocess.run(
-        command,
-        input=json.dumps(tool_payload("Write", ".env")),
-        text=True,
-        capture_output=True,
-        check=False,
-        env=env,
-        shell=True,
-    )
+def test_hook_launcher_preserves_blocking_exit() -> None:
+    """The launcher must not fall through after the hook returns the blocking status."""
+    result = run_launcher(tool_payload("Write", ".env"))
 
     assert result.returncode == 2
+    assert "BLOCKED" in result.stderr
+
+
+def test_hook_settings_uses_shell_launcher_without_node_or_direct_python() -> None:
+    """Claude Code should run the shell launcher instead of Node or a direct Python shim."""
+    settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+    command = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+    assert command == '"$CLAUDE_PROJECT_DIR/.claude/hooks/run_protect_sensitive_files.sh"'
+    assert "node" not in command
+    assert "run_protect_sensitive_files.js" not in command
+    assert "python" not in command
+
+
+def test_hook_launcher_fails_closed_when_no_python_launcher_works(tmp_path: Path) -> None:
+    """The shell fallback must return 2 if no Python command works."""
+    for utility in ("cat", "dirname", "mktemp", "rm"):
+        utility_path = Path(f"/usr/bin/{utility}")
+        if not utility_path.exists():
+            utility_path = Path(f"/bin/{utility}")
+        (tmp_path / utility).symlink_to(utility_path)
+
+    result = run_launcher(tool_payload("Write", ".env"), path=str(tmp_path))
+
+    assert result.returncode == 2
+    assert "no working Python 3 launcher found" in result.stderr
+
+
+def test_hook_launcher_tries_python3_before_other_launchers() -> None:
+    """The shell launcher should prefer python3 before py or python."""
+    launcher = HOOK_LAUNCHER.read_text(encoding="utf-8")
+
+    launcher_lines = [
+        line for line in launcher.splitlines() if line.startswith("run_launcher ")
+    ]
+
+    assert launcher_lines == [
+        "run_launcher python3",
+        "run_launcher py -3",
+        "run_launcher python",
+    ]


### PR DESCRIPTION
### Motivation
- Prevent the blocking `PreToolUse` hook from depending on `node` or a pyenv-sensitive `python` shim so the sensitive-file policy reliably runs across installs and platforms. 
- Ensure the launcher preserves stdin and preserves the hook’s blocking semantics (exit code `2`) instead of silently failing open. 
- Broaden Python compatibility in the hook script by removing PEP-604 / walrus usage that can break older supported interpreters.

### Description
- Replace the inline `python3 || py -3 || python || exit 2` command in `.claude/settings.json` with a project-root POSIX shell launcher: `"$CLAUDE_PROJECT_DIR/.claude/hooks/run_protect_sensitive_files.sh"`. 
- Add `.claude/hooks/run_protect_sensitive_files.sh` which preserves stdin, tries `python3`, then `py -3`, then `python`, propagates exit code `2` for blocked edits, and exits `2` when no launcher can evaluate the policy. 
- Update `.claude/hooks/protect_sensitive_files.py` to remove the walrus/list-comprehension form and use an explicit loop in `_candidate_paths` for broader syntax compatibility. 
- Update `tests/test_protect_sensitive_files_hook.py` to exercise the new shell launcher, assert settings point to the shell launcher (no `node` or direct `python`), verify the launcher preserves blocking exits, verify fail-closed behavior when no Python launcher is available, and check launcher ordering; also add explicit `encoding='utf-8'` reads and tidy typing annotations in tests.

### Testing
- Installed project and test deps with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest` and the install completed successfully. 
- Ran the modified hook test with `PYENV_VERSION=3.12.13 python -m pytest tests/test_protect_sensitive_files_hook.py -q` and it passed. 
- Linted the shell launcher with `sh -n .claude/hooks/run_protect_sensitive_files.sh` which succeeded. 
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` after installing dependencies and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0147de572c8320b1fcf40ba4703570)