### PR TITLE
ci: document Gemini shell tool boundary

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -84,6 +84,11 @@ jobs:
           # The first two populate github.event.pull_request.number; the
           # last populates github.event.issue.number.
           github_pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # Keep tools.core to repo-scoped built-ins only. Do not add
+          # run_shell_command(cat|grep|head|tail): Gemini CLI treats those
+          # as shell-command prefixes, so PR-controlled prompts could add
+          # redirections, mutate the workspace, or read absolute paths
+          # outside the checkout.
           settings: |-
             {
               "model": {


### PR DESCRIPTION
### Motivation
- Prevent reintroduction of unsafe shell prefixes by documenting that `tools.core` should remain limited to repo-scoped built-ins because `run_shell_command(cat|grep|head|tail)` entries are treated as shell-command prefixes that allow redirection, workspace mutation, or absolute-path reads outside the checkout.

### Description
- Add a clear comment above the `settings` block in `.github/workflows/gemini-code-assist.yml` that explains the `tools.core` boundary and explicitly warns against adding `run_shell_command(cat|grep|head|tail)`, while preserving the existing built-in tool allowlist such as `read_file`, `read_many_files`, `glob`, and `grep_search`.

### Testing
- Parsed the workflow `settings` JSON with a Ruby/YAML check, ran `git diff --check`, and ran a ripgrep check to assert no `run_shell_command(cat|grep|head|tail)` entries exist, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0146d29dbc8320b35b49c0389438e4)