### PR TITLE
Handle IDNA hostname resolution failures

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -76,7 +76,7 @@ def _validate_url_for_fetch(target_url: str):
     port = parsed.port or (443 if parsed.scheme == 'https' else 80)
     try:
         addrinfo = _resolve_global_addrinfo(hostname, port)
-    except (socket.gaierror, ValueError):
+    except (socket.gaierror, UnicodeError, ValueError):
         return parsed, None, "Error: Could not resolve hostname to a valid IP."
 
     if addrinfo is None:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -149,6 +149,57 @@ def test_process_url_reports_dns_resolution_failure(mock_get, capsys, tmp_path):
 
 
 @patch("requests.Session.get")
+def test_process_url_reports_idna_resolution_failure(mock_get, capsys, tmp_path):
+    """Hostname IDNA encoding failures use the URL validation error path."""
+    overlong_label = "a" * 64
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        side_effect=UnicodeError("encoding with 'idna' codec failed"),
+    ):
+        cli.main([
+            "--url",
+            f"https://{overlong_label}.example",
+            "--outdir",
+            str(tmp_path),
+        ])
+
+    outerr = capsys.readouterr()
+    assert "Error: Could not resolve hostname to a valid IP." in outerr.err
+    mock_get.assert_not_called()
+
+
+def test_batch_continues_after_idna_resolution_failure(capsys, tmp_path):
+    """Malformed hostnames do not abort later batch entries."""
+    batch_file = tmp_path / "urls.txt"
+    batch_file.write_text(
+        "https://bad-host.example\nhttps://example.com/page.html\n",
+        encoding="utf-8",
+    )
+    response = MagicMock()
+    response.is_redirect = False
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+
+    with patch(
+        "html2md.cli.socket.getaddrinfo",
+        side_effect=[
+            UnicodeError("encoding with 'idna' codec failed"),
+            addrinfo("93.184.216.34"),
+            addrinfo("93.184.216.34"),
+        ],
+    ), patch("requests.Session.get", return_value=response) as mock_get:
+        cli.main(["--batch", str(batch_file), "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: Could not resolve hostname to a valid IP." in outerr.err
+    assert "Success!" in outerr.out
+    mock_get.assert_called_once_with(
+        "https://example.com/page.html", timeout=30, allow_redirects=False
+    )
+
+
+@patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""
     outdir = tmp_path / "output"


### PR DESCRIPTION
### Motivation
- Prevent the CLI from aborting on hostname IDNA/Unicode encoding errors raised during DNS lookups, which previously surfaced as uncaught exceptions. 
- Ensure `--batch` processing continues when one line contains a malformed/overlong hostname instead of terminating the entire run.

### Description
- Treat `UnicodeError` from hostname resolution as a URL validation failure by adding it to the exception tuple in `_validate_url_for_fetch` so it returns the existing "Could not resolve hostname" error path. 
- Add `test_process_url_reports_idna_resolution_failure` to assert IDNA encoding failures produce the validation error and do not trigger a network call. 
- Add `test_batch_continues_after_idna_resolution_failure` to verify batch mode reports the IDNA failure and still processes subsequent valid entries.
- Modified files: `src/html2md/cli.py` and `tests/test_cli_security.py`.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_cli_security.py -q` and the security-focused tests passed. 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01464e0cc88320bdad01fc9b344b44)