### PR TITLE
Restore Gemini Code Assist review action

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Gemini Code Assist
-        uses: actions/checkout@v4
+        uses: google-gemini/code-assist-action@v1


### PR DESCRIPTION
### Motivation
- Fix the `gemini-code-assist` workflow where the Gemini review step was incorrectly invoking `actions/checkout@v4`, which prevented the `google-gemini/code-assist-action@v1` review action from running.

### Description
- Replace the second `actions/checkout@v4` step with `google-gemini/code-assist-action@v1` in `.github/workflows/gemini-code-assist.yml` so the Gemini Code Assist action is executed.

### Testing
- Parsed the workflow YAML with `python3 - <<'PY' ... PY` and asserted that `jobs.gemini-code-assist.steps[1].uses == 'google-gemini/code-assist-action@v1'`, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca6157488320b29ab0db00bdebc3)