### PR TITLE
Add PR target input to manual Gemini workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -1,7 +1,14 @@
 name: Gemini Code Assist
 
+run-name: Gemini Code Assist for PR #${{ inputs.pr_number }}
+
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -11,10 +18,12 @@ permissions:
 jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
       - name: Gemini Code Assist
         uses: google-gemini/code-assist-action@v1
+        with:
+          pr_number: ${{ inputs.pr_number }}


### PR DESCRIPTION
### Motivation

- Manually triggered `workflow_dispatch` runs do not include a pull request payload, so the Gemini Code Assist workflow needs an explicit PR target to operate on. 
- The existing job-level guard was preventing manual runs from executing, so the workflow must accept a manual PR input and use it to checkout the PR head. 

### Description

- Add a `run-name` that references `inputs.pr_number` and define a required `workflow_dispatch` input `pr_number` of type `number` in `.github/workflows/gemini-code-assist.yml`. 
- Remove the redundant job-level `if: ${{ github.event_name == 'workflow_dispatch' }}` guard. 
- Checkout the PR head by setting `ref: refs/pull/${{ inputs.pr_number }}/head` in the `actions/checkout` step. 
- Pass the PR number into the Gemini action via `with: pr_number: ${{ inputs.pr_number }}` so the action has an explicit target. 

### Testing

- Parsed the updated workflow with `python3` and `yaml.safe_load()` to ensure valid YAML (success). 
- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/gemini-code-assist.yml` to lint the workflow (success). 
- Ran `git diff --check` to ensure no whitespace or diff errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca4858148320b60dc3ce1e18abed)