### PR TITLE
Harden sensitive hook Windows path matching

### DIFF
--- a/.claude/hooks/protect_sensitive_files.py
+++ b/.claude/hooks/protect_sensitive_files.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import fnmatch
 import json
 import os
+import posixpath
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -41,7 +42,7 @@ def is_sensitive(path: str) -> bool:
         return False
 
     normalized_path = path.replace("\\", "/").lower()
-    normalized_base = os.path.basename(normalized_path).lower()
+    normalized_base = posixpath.basename(normalized_path).lower()
 
     for pattern in SENSITIVE_BASENAME_PATTERNS:
         normalized_pattern = pattern.lower()

--- a/tests/test_protect_sensitive_files_hook.py
+++ b/tests/test_protect_sensitive_files_hook.py
@@ -56,10 +56,17 @@ def test_blocks_all_dotenv_variants() -> None:
 
 def test_blocks_windows_separator_paths() -> None:
     """Backslash-separated paths are normalized before matching."""
-    result = run_hook(hook_payload("Write", r"C:\repo\credentials.json"))
+    paths = (
+        r"C:\repo\credentials.json",
+        r"config\.env.production",
+        r"C:\repo\id_rsa",
+    )
 
-    assert result.returncode == 2
-    assert "credentials.json" in result.stderr
+    for path in paths:
+        result = run_hook(hook_payload("Write", path))
+
+        assert result.returncode == 2
+        assert path in result.stderr
 
 
 def test_blocks_sensitive_multiedit_paths() -> None:


### PR DESCRIPTION
### Motivation
- Prevent Windows-style backslash paths from bypassing the sensitive-file PreToolUse hook on non-Windows runners by ensuring basenames are extracted consistently after normalizing separators. 
- Add regression coverage for the reviewer examples (`config\.env.production`, `C:\repo\id_rsa`) so the hook behavior is validated against common Windows payload forms.

### Description
- Normalize backslashes to forward slashes and use `posixpath.basename()` when deriving the candidate basename inside `is_sensitive()` so Windows-style paths split correctly on POSIX hosts. 
- Expand the `tests/test_protect_sensitive_files_hook.py` regression to iterate over multiple backslash-separated examples including `C:\repo\credentials.json`, `config\\.env.production`, and `C:\repo\id_rsa`. 
- No behavioral changes to the sensitive pattern list or to other hook logic were introduced in this patch.

### Testing
- Ran the focused hook tests with `PYENV_VERSION=3.12.13 python -m pytest tests/test_protect_sensitive_files_hook.py -q` and they passed. 
- Installed package and test deps with `PYENV_VERSION=3.12.13 python -m pip install -e . pytest requests` and the installation completed successfully. 
- Ran the full test suite with `PYENV_VERSION=3.12.13 python -m pytest -q` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca327fb48320af46aa78b4dfbe1d)