### PR TITLE
Add PR selector for manual Gemini workflow

### DIFF
--- a/.github/workflows/gemini-code-assist.yml
+++ b/.github/workflows/gemini-code-assist.yml
@@ -2,6 +2,11 @@ name: Gemini Code Assist
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -12,8 +17,43 @@ jobs:
   gemini-code-assist:
     runs-on: ubuntu-latest
     steps:
+      - name: Build pull request context
+        id: pr-context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = Number(context.payload.inputs.pr_number);
+            const { owner, repo } = context.repo;
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const eventPayload = {
+              action: 'opened',
+              number: prNumber,
+              pull_request: pullRequest,
+              repository: context.payload.repository,
+              sender: context.payload.sender,
+            };
+
+            await fs.promises.writeFile(
+              'gemini-pull-request-event.json',
+              JSON.stringify(eventPayload, null, 2),
+            );
+
+            core.setOutput('head_sha', pullRequest.head.sha);
+            core.setOutput('head_ref', pullRequest.head.ref);
+            core.setOutput('event_path', `${process.env.GITHUB_WORKSPACE}/gemini-pull-request-event.json`);
       - uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
       - name: Gemini Code Assist
         uses: google-gemini/code-assist-action@v1
+        env:
+          GITHUB_EVENT_NAME: pull_request
+          GITHUB_EVENT_PATH: ${{ steps.pr-context.outputs.event_path }}


### PR DESCRIPTION
### Motivation
- Manual `workflow_dispatch` runs lost pull-request context after the triggers were replaced, preventing Gemini from targeting PRs when invoked manually.
- Provide a deterministic way to select and synthesize PR context so manual runs behave like PR-sourced runs for Gemini Code Assist.

### Description
- Add a required `pr_number` input to the `workflow_dispatch` entry in `.github/workflows/gemini-code-assist.yml`.
- Add a `actions/github-script@v7` step that resolves the selected pull request via the GitHub API and writes a synthetic pull-request event payload to `gemini-pull-request-event.json` while exporting `head_sha`, `head_ref`, and `event_path` outputs.
- Update the checkout to use the selected PR head ref `refs/pull/${{ inputs.pr_number }}/head` and pass `GITHUB_EVENT_NAME: pull_request` and `GITHUB_EVENT_PATH` to the Gemini action so it receives PR context.

### Testing
- Ran `python3` assertions that verified the workflow contains the required `pr_number` input, the PR API lookup, the PR checkout ref, and the `GITHUB_EVENT_*` environment usage and they all passed.
- Parsed the workflow YAML with Ruby (`YAML.load_file`) to ensure the file remained valid and parsing succeeded.
- Committed the updated file with `git commit` which succeeded, producing the change recorded in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca27d82c83209cb7ff76e3b05a10)