### PR TITLE
Postpone annotations in AI-assisted PR guard test for Python 3.8 compatibility

### DIFF
--- a/tests/test_ai_assisted_pr_guard.py
+++ b/tests/test_ai_assisted_pr_guard.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import textwrap


### PR DESCRIPTION
### Motivation
- The test module is imported during pytest collection and used a runtime-generic annotation `subprocess.CompletedProcess[str]` which raises on Python 3.8, so annotations must be postponed to keep the test suite usable on the declared `>=3.8` floor.

### Description
- Add `from __future__ import annotations` to `tests/test_ai_assisted_pr_guard.py` so type annotations are not evaluated at import time.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/test_ai_assisted_pr_guard.py -q` and the test file executed successfully.
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca221950832084ae17ebd6625575)