### PR TITLE
GUI: Add empty/disabled states, enable disabled tooltips, and fix conversion launcher/CLI args

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -327,6 +327,7 @@ $ConvertBtn.Add_Click({
         if ($short) { $scriptDir = $short }
     } catch {}
 
+    $bat = Join-Path $scriptDir "run-html2md.bat"
     $venvExe = Join-Path $scriptDir ".venv\Scripts\html2md.exe"
     $pyScript = Join-Path $scriptDir "html2md.py"
 
@@ -344,7 +345,6 @@ $ConvertBtn.Add_Click({
     }
 
     $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = "powershell.exe"
     $psi.WorkingDirectory = $scriptDir
     $psi.UseShellExecute = $true
 
@@ -359,8 +359,11 @@ $ConvertBtn.Add_Click({
         $safeTempFile = $tempFile -replace "'", "''"
         $safeOutDir = $outdir -replace "'", "''"
 
-        # Relaunch this script in batch mode
-        # Use single quotes for arguments to avoid variable expansion and allow containing spaces/special chars
+        # Relaunch this script in batch mode.
+        # Use PowerShell only for the script re-entry point; single-URL conversions
+        # continue to use the batch launcher below so this UI-only change does not
+        # alter the normal converter process.
+        $psi.FileName = "powershell.exe"
         $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File '$safeCommandPath' -BatchFile '$safeTempFile' -BatchOutDir '$safeOutDir'"
         if ($WholePageChk.IsChecked) {
             $psi.Arguments += " -BatchWholePage"
@@ -369,27 +372,26 @@ $ConvertBtn.Add_Click({
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
 
-        # Sanitize inputs for single-quoted string interpolation in PowerShell
-        $safeUrl = $url -replace "'", "''"
-        $safeOutDir = $outdir -replace "'", "''"
-        $safeVenvExe = $venvExe -replace "'", "''"
-        $safePyScript = $pyScript -replace "'", "''"
+        # Sanitize inputs for double-quoted cmd.exe arguments. URL validation and
+        # the output directory metacharacter check above reject embedded quotes.
+        $safeUrl = $url -replace '"', '\"'
+        $safeOutDir = $outdir -replace '"', '\"'
+        $safeBat = $bat -replace '"', '\"'
+        $safeVenvExe = $venvExe -replace '"', '\"'
+        $safePyScript = $pyScript -replace '"', '\"'
 
-        if (Test-Path -LiteralPath $venvExe) {
+        $psi.FileName = "cmd.exe"
+        if (Test-Path -LiteralPath $bat) {
+            $LogBox.AppendText("Found batch launcher: $bat`r`n")
+            $psi.Arguments = "/c `"`"$safeBat`" --url `"$safeUrl`" --outdir `"$safeOutDir`"`""
+        }
+        elseif (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
-            $singleArgs = @("--url", "'$safeUrl'", "--outdir", "'$safeOutDir'")
-            if ($WholePageChk.IsChecked) {
-                $singleArgs += "--whole-page"
-            }
-            $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' $($singleArgs -join ' ')`""
+            $psi.Arguments = "/c `"`"$safeVenvExe`" --url `"$safeUrl`" --outdir `"$safeOutDir`"`""
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
-            $singleArgs = @("--url", "'$safeUrl'", "--outdir", "'$safeOutDir'")
-            if ($WholePageChk.IsChecked) {
-                $singleArgs += "--whole-page"
-            }
-            $psi.Arguments = "-NoExit -Command `"& $pyCmd '$safePyScript' $($singleArgs -join ' ')`""
+            $psi.Arguments = "/c `"`"$pyCmd`" `"$safePyScript`" --url `"$safeUrl`" --outdir `"$safeOutDir`"`""
         }
         else {
             $StatusText.Text = "Error: html2md executable not found."


### PR DESCRIPTION
### Motivation
- Improve initial/empty-state UX by ensuring non-actionable controls are disabled with explanatory text and the log area shows a placeholder instead of being blank. 
- Ensure the GUI does not change runtime conversion behavior unintentionally by restoring the normal conversion launcher and preventing unsupported CLI flags from being forwarded. 
- Address reviewer feedback about disabled control tooltips, whitespace-only Clear behavior, duplicated/unsupported flags, and brittle process-launch argument construction. 

### Description
- Updated `gui-url-convert.ps1` to add an initial log placeholder (`Text="Ready. Conversion logs will appear here..."`) and make the `ClearBtn`/`ConvertBtn` tooltips visible on disabled controls by setting `ToolTipService.ShowOnDisabled="True"`. 
- Changed the `UrlBox` `TextChanged` handler to decouple Convert vs Clear enablement so `Clear` remains available for whitespace-only content while `Convert` still requires non-whitespace input. 
- Reworked URL validation to build a sanitized `urlList` from `AbsoluteUri` values and added defensive checks for dangerous characters in the output directory. 
- Restored the use of the `run-html2md.bat` batch launcher / `cmd.exe` path for single-URL conversions (with robust quoting) and scoped `powershell.exe` usage to the multi-URL re-entry (`-BatchFile`) path to avoid changing the converter’s behavior; removed forwarding of the unsupported `--whole-page` flag to the CLI. 
- Improved argument quoting/escaping and removed code that appended duplicate `--whole-page` flags in batch mode. 

### Testing
- Ran `git diff --check` to verify no whitespace/diff issues and the check passed. 
- Executed repository content assertions using a short Python script to verify presence/absence of key strings (e.g., `run-html2md.bat`, `cmd.exe`, no `--whole-page` in single-URL branch), and all assertions succeeded. 
- Installed test tooling and ran the test suite via `uv pip install pytest && uv run python -m pytest -q`, and the tests completed successfully. 
- PowerShell syntax/parsing check with `pwsh` was skipped in this environment because `pwsh` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e38e26088320b37668f87ca0d15b)