### PR TITLE
Align Jules review workflow mention

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -38,7 +38,7 @@ jobs:
           request = urllib.request.Request(
               url=f"{api_url}/repos/{repo}/issues/{pr_number}/comments",
               data=json.dumps(
-                  {"body": "@google-labs-jules please review this pull request."}
+                  {"body": "@jules please review this pull request."}
               ).encode("utf-8"),
               headers={
                   "Accept": "application/vnd.github+json",
@@ -51,7 +51,7 @@ jobs:
           try:
               with urllib.request.urlopen(request) as response:
                   print(
-                      "Requested review from @google-labs-jules via comment on "
+                      "Requested review from @jules via comment on "
                       f"PR #{pr_number} (status {response.status})"
                   )
           except urllib.error.HTTPError as error:


### PR DESCRIPTION
### Motivation
- Ensure the workflow posts the review-request comment to the same handle configured in `CODEOWNERS` so the intended reviewer actually receives the automated notification.

### Description
- Replace `"@google-labs-jules please review this pull request."` and the corresponding success log message with `"@jules please review this pull request."` inside `.github/workflows/request-jules-review.yml` inline Python.

### Testing
- Ran `git diff --check` and compiled the workflow inline Python with `python3` while asserting the new handle is present, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e6709fc08320aa6bd6342d983a54)