### PR TITLE
Remove no-op whole-page GUI option

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -6,7 +6,7 @@ WPF GUI for html2md
 - Safe for double-click or PowerShell execution
 #>
 
-param([string]$BatchFile, [string]$BatchOutDir, [switch]$BatchWholePage)
+param([string]$BatchFile, [string]$BatchOutDir)
 
 if ($BatchFile) {
     if (-not (Test-Path -LiteralPath $BatchFile)) {
@@ -25,8 +25,6 @@ if ($BatchFile) {
         if (-not [string]::IsNullOrWhiteSpace($url)) {
             Write-Host "Processing: $url"
             $argsList = @("--url", "$url", "--outdir", "$outDir")
-            # The current html2md CLI does not accept --whole-page; keep the
-            # batch switch from adding unsupported arguments to each invocation.
 
             if (Test-Path -LiteralPath $venvExe) {
                 & $venvExe $argsList
@@ -113,10 +111,6 @@ $xaml = @"
             <Button Grid.Column="3" Name="OpenFolderBtn" Width="90" Height="28" Margin="10,0,0,0" ToolTip="Open output folder">_Open Folder</Button>
         </Grid>
 
-        <CheckBox Name="WholePageChk" Grid.Row="3" Content="Convert _Whole Page"
-                  VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,15,0,0"
-                  ToolTip="If checked, includes headers and footers. Default is main content only."/>
-
         <Button Name="ConvertBtn" Grid.Row="3" Content="_Convert (All Formats)"
                 Height="35" HorizontalAlignment="Right" Width="180" Margin="0,15,0,0"
                 IsEnabled="False"
@@ -154,7 +148,6 @@ $OpenFolderBtn = $window.FindName("OpenFolderBtn")
 $ConvertBtn = $window.FindName("ConvertBtn")
 $PasteBtn = $window.FindName("PasteBtn")
 $ClearBtn = $window.FindName("ClearBtn")
-$WholePageChk = $window.FindName("WholePageChk")
 $StatusText = $window.FindName("StatusText")
 $ProgressBar = $window.FindName("ProgressBar")
 $LogBox = $window.FindName("LogBox")
@@ -362,9 +355,6 @@ $ConvertBtn.Add_Click({
         # Relaunch this script in batch mode
         # Use single quotes for arguments to avoid variable expansion and allow containing spaces/special chars
         $psi.Arguments = "-NoExit -ExecutionPolicy Bypass -File '$safeCommandPath' -BatchFile '$safeTempFile' -BatchOutDir '$safeOutDir'"
-        if ($WholePageChk.IsChecked) {
-            $psi.Arguments += " -BatchWholePage"
-        }
     } else {
         # --- SINGLE URL MODE ---
         $url = $urlList[0]
@@ -378,17 +368,11 @@ $ConvertBtn.Add_Click({
         if (Test-Path -LiteralPath $venvExe) {
             $LogBox.AppendText("Found venv executable: $venvExe`r`n")
             $singleArgs = @("--url", "'$safeUrl'", "--outdir", "'$safeOutDir'")
-            if ($WholePageChk.IsChecked) {
-                $singleArgs += "--whole-page"
-            }
             $psi.Arguments = "-NoExit -Command `"& '$safeVenvExe' $($singleArgs -join ' ')`""
         }
         elseif (Test-Path -LiteralPath $pyScript) {
             $LogBox.AppendText("Found Python script: $pyScript`r`n")
             $singleArgs = @("--url", "'$safeUrl'", "--outdir", "'$safeOutDir'")
-            if ($WholePageChk.IsChecked) {
-                $singleArgs += "--whole-page"
-            }
             $psi.Arguments = "-NoExit -Command `"& $pyCmd '$safePyScript' $($singleArgs -join ' ')`""
         }
         else {


### PR DESCRIPTION
### Motivation
- The GUI exposed a “Convert Whole Page” option (and relaunch `-BatchWholePage` parameter) that the `html2md` CLI does not accept, creating a misleading UI and causing launched conversions to fail or silently ignore the option.

### Description
- Remove the unused `BatchWholePage` relaunch parameter from `gui-url-convert.ps1` and delete the `WholePageChk` checkbox XAML so the UI no longer presents an unsupported option.
- Stop propagating the unsupported `--whole-page` / `-BatchWholePage` flags from both the batch relaunch and single-URL launch paths so launched commands only use supported `--url` and `--outdir` arguments.
- Remove the `WholePageChk` `FindName` lookup and related conditional blocks that referenced the removed control.
- Keep the log placeholder and disabled/tooltip UX improvements intact while aligning the launcher behavior with the CLI.

### Testing
- Ran `git diff --check` and it succeeded.
- Installed test deps and ran `uv pip install pytest && uv run python -m pytest -q`, which executed the test suite and passed (all tests green).
- Attempted a PowerShell XAML parse check (`pwsh`), but it was skipped because `pwsh` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e65391f88320b225f9aa0c4415b5)