### PR TITLE
🎨 Palette: Screen reader announcements for status bar in GUI

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -156,7 +156,7 @@ $xaml = @"
                  TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
 
         <StatusBar Grid.Row="6" Margin="0,10,0,0">
-            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555"/>
+            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555" AutomationProperties.LiveSetting="Polite"/>
         </StatusBar>
     </Grid>
 </Window>


### PR DESCRIPTION
💡 What: Added `AutomationProperties.LiveSetting="Polite"` to the `StatusText` TextBlock.
🎯 Why: Status updates in elements like `TextBlock` do not inherently announce their text updates to screen readers. This addition acts as a live region so screen readers can unobtrusively pick up state changes, improving accessibility.
♿ Accessibility: Improved screen reader support for critical status changes within the WPF GUI.

---
*PR created automatically by Jules for task [7324301003426447914](https://jules.google.com/task/7324301003426447914) started by @badMade*