### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [MEDIUM] Add basic security headers to Flask app

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2026-05-15 - Added Security Headers to Flask App
+**Vulnerability:** The Flask app in `src/html2md/app.py` was missing essential security headers (CSP, HSTS, X-Frame-Options, X-XSS-Protection, X-Content-Type-Options).
+**Learning:** By default, Flask does not include standard security headers. These must be added explicitly to mitigate XSS and content-sniffing vulnerabilities.
+**Prevention:** Added an `@app.after_request` hook to append security headers on all responses.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,29 +11,44 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
-@app.route('/health')
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'none'; frame-ancestors 'none';"
+    )
+    response.headers["Strict-Transport-Security"] = (
+        "max-age=31536000; includeSubDomains"
+    )
+    return response
+
+
+@app.route("/health")
 def health():
     """Return health status of the application."""
-    return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
+    return jsonify({"status": "ok", "service": "html2md", "version": __version__})
 
 
 def get_host_port():
     """Get host and port from environment variables."""
     default_port = 10000
-    port_str = os.environ.get('PORT')
+    port_str = os.environ.get("PORT")
     try:
         port_value = int(port_str) if port_str is not None else DEFAULT_PORT
     except ValueError:
         print(
-            f'Warning: Invalid PORT environment variable value '
-            f'{port_str!r}; falling back to default {default_port}.'
+            f"Warning: Invalid PORT environment variable value "
+            f"{port_str!r}; falling back to default {default_port}."
         )
         port_value = DEFAULT_PORT
 
-    hostname = os.environ.get('HOST', '0.0.0.0')
+    hostname = os.environ.get("HOST", "0.0.0.0")
     return hostname, port_value
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     host, port = get_host_port()
     app.run(host=host, port=port)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+"""Tests for the Flask application."""
+
+import pytest
+
+try:
+    import flask
+    from html2md.app import app
+except ImportError:
+    flask = None
+    app = None
+
+pytestmark = pytest.mark.skipif(flask is None, reason="Flask is not installed")
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the app."""
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_health_endpoint(client):
+    """Test that the health endpoint returns correctly."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.is_json
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["service"] == "html2md"
+    assert "version" in data
+
+
+def test_security_headers(client):
+    """Test that security headers are added to responses."""
+    response = client.get("/health")
+    headers = response.headers
+
+    assert headers.get("X-Content-Type-Options") == "nosniff"
+    assert headers.get("X-Frame-Options") == "DENY"
+    assert headers.get("X-XSS-Protection") == "1; mode=block"
+    assert (
+        headers.get("Content-Security-Policy")
+        == "default-src 'none'; frame-ancestors 'none';"
+    )
+    assert (
+        headers.get("Strict-Transport-Security")
+        == "max-age=31536000; includeSubDomains"
+    )


### PR DESCRIPTION
## Summary
Added an `@app.after_request` hook in `src/html2md/app.py` to ensure standard security headers are attached to all HTTP responses. This includes `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Content-Security-Policy` and `Strict-Transport-Security`.

🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers.
🎯 Impact: Without security headers, the Flask app may be more susceptible to Clickjacking, XSS, and MIME-sniffing attacks.
🔧 Fix: Added `@app.after_request` to set standard security headers on all responses.
✅ Verification: Created `tests/test_app.py` and ran full pytest suite (`PYTHONPATH=src python3 -m pytest tests/`).

## AI Usage
AI-generated the `@app.after_request` hook, tests, and the sentinel journal entry.

## Assumptions & Validation
Assumed the API is stateless and doesn't rely on rendering complex frontend scripts directly, so a restrictive CSP (`default-src 'none'`) is appropriate. Verified by testing the `/health` endpoint output.

## Design Rationale
Leveraged Flask's native `@app.after_request` decorator to ensure all routes inherit the headers cleanly without repeating code.

## Testing
Unit tests in `tests/test_app.py` cover the `/health` endpoint structure and verify each security header is present.

## Risk & Rollback
Low risk; the headers are standard web security configurations. Rollback plan is to simply remove the `@app.after_request` function.

## Tech Debt (If any)
None.

---
*PR created automatically by Jules for task [7554847921163764869](https://jules.google.com/task/7554847921163764869) started by @badMade*