### PR TITLE
🧹 Add type hints to main function in log_export.py

### DIFF
--- a/src/html2md/log_export.py
+++ b/src/html2md/log_export.py
@@ -49,7 +49,7 @@ def _sanitize_value(value: object) -> object:
     return value
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> int:
     """Run the log export CLI."""
     ap = argparse.ArgumentParser(
         prog='html2md-log-export', description='Export html2md JSONL logs to CSV'


### PR DESCRIPTION
🎯 **What:** Added missing type hints `argv: list[str] | None = None) -> int` to the `main` CLI function in `src/html2md/log_export.py`.
💡 **Why:** Improves code maintainability, readability, and type safety as identified in the code health improvement task.
✅ **Verification:** Ran `pytest tests/test_log_export.py` to verify tests pass and no functionality was broken. Code review passed.
✨ **Result:** Enhanced type safety and code health.

---
*PR created automatically by Jules for task [13538993086144385099](https://jules.google.com/task/13538993086144385099) started by @badMade*