### PR TITLE
🔒 fix: prevent sensitive data exposure by masking password in url logging

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -7,16 +7,16 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
-        prog='html2md',
-        description='Convert HTML URL to Markdown.'
+        prog="html2md", description="Convert HTML URL to Markdown."
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    ap.add_argument("--help-only", action="store_true", help=argparse.SUPPRESS)
+    ap.add_argument("--url", help="Input URL to convert")
+    ap.add_argument("--batch", help="File containing URLs to process (one per line)")
+    ap.add_argument("--outdir", help="Output directory to save the file")
 
     args = ap.parse_args(argv)
 
@@ -27,33 +27,40 @@ def main(argv=None):
     if args.url or args.batch:
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
-            from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from markdownify import (
+                markdownify as md,
+            )  # pylint: disable=import-outside-toplevel
         except ImportError as e:
-            print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+            print(
+                f"Error: Missing dependency {e.name}."
+                "Please run: pip install requests markdownify",
+                file=sys.stderr,
+            )
             return 1
 
         session = requests.Session()
-        session.headers.update({
-            'User-Agent': (
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/120.0.0.0 Safari/537.36'
-            ),
-            'Accept': (
-                'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                'image/avif,image/webp,image/apng,*/*;q=0.8'
-            ),
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://www.google.com/',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'cross-site',
-            'Sec-Fetch-User': '?1',
-        })
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,image/apng,*/*;q=0.8"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Referer": "https://www.google.com/",
+                "Connection": "keep-alive",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "cross-site",
+                "Sec-Fetch-User": "?1",
+            }
+        )
 
         outdir_path = None
         real_outdir = None
@@ -61,27 +68,41 @@ def main(argv=None):
             outdir_path = Path(args.outdir)
             try:
                 if outdir_path.exists() and not outdir_path.is_dir():
-                    print(f"Error: --outdir must be a directory: {args.outdir}", file=sys.stderr)
+                    print(
+                        f"Error: --outdir must be a directory: {args.outdir}",
+                        file=sys.stderr,
+                    )
                     return 1
                 outdir_path.mkdir(parents=True, exist_ok=True)
                 real_outdir = outdir_path.resolve()
             except OSError as e:
-                print(f"Error creating output directory '{args.outdir}': {e}", file=sys.stderr)
+                print(
+                    f"Error creating output directory '{args.outdir}': {e}",
+                    file=sys.stderr,
+                )
                 return 1
 
         def process_url(target_url: str) -> int:
             """Process a single URL. Returns 0 on success, 1 on error."""
             # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
+            if "/?" in target_url:
+                target_url = target_url.replace("/?", "?")
 
             parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
+            if parsed.scheme not in ("http", "https"):
+                print(
+                    f"Error: Unsupported URL scheme '{parsed.scheme}'. "
+                    "Only http and https are allowed.",
+                    file=sys.stderr,
+                )
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = parsed.geturl()
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+                safe_url = parsed._replace(netloc=safe_netloc).geturl()
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -92,8 +113,11 @@ def main(argv=None):
 
                     max_size = 10 * 1024 * 1024
                     try:
-                        if int(response.headers.get('Content-Length', 0)) > max_size:
-                            print(f"Error: Content-Length exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)
+                        if int(response.headers.get("Content-Length", 0)) > max_size:
+                            print(
+                                f"Error: Content-Length exceeds maximum allowed size ({max_size} bytes).",
+                                file=sys.stderr,
+                            )
                             return 1
                     except ValueError:
                         # Invalid or non-numeric Content-Length: treat as unknown size.
@@ -105,14 +129,19 @@ def main(argv=None):
                     for chunk in response.iter_content(chunk_size=8192):
                         total += len(chunk)
                         if total > max_size:
-                            print(f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)
+                            print(
+                                f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).",
+                                file=sys.stderr,
+                            )
                             return 1
                         chunks.append(chunk)
                     content_bytes = b"".join(chunks)
                 finally:
                     response.close()
 
-                encoding = response.encoding if isinstance(response.encoding, str) else "utf-8"
+                encoding = (
+                    response.encoding if isinstance(response.encoding, str) else "utf-8"
+                )
                 html_content = content_bytes.decode(encoding, errors="replace")
 
                 print("Converting to Markdown...")
@@ -121,12 +150,12 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
+                    url_path = target_url.split("?")[0].rstrip("/")
                     if url_path:
                         base = os.path.basename(unquote(url_path))
                         # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
-                        base = base.strip('. ')
+                        base = base.replace("/", "_").replace("\\", "_")
+                        base = base.strip(". ")
                         if base:
                             filename = f"{base}.md"
 
@@ -137,10 +166,12 @@ def main(argv=None):
                         if real_outdir:
                             real_out_path.relative_to(real_outdir)
                     except ValueError:
-                        print("Error: Output path escapes output directory.",
-                              file=sys.stderr)
+                        print(
+                            "Error: Output path escapes output directory.",
+                            file=sys.stderr,
+                        )
                         return 1
-                    with out_path.open('w', encoding='utf-8') as f:
+                    with out_path.open("w", encoding="utf-8") as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
@@ -169,7 +200,7 @@ def main(argv=None):
             if not os.path.exists(args.batch):
                 print(f"Error: Batch file not found: {args.batch}", file=sys.stderr)
                 return 1
-            with open(args.batch, 'r', encoding='utf-8') as f:
+            with open(args.batch, "r", encoding="utf-8") as f:
                 for line in f:
                     u = line.strip()
                     if u:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -48,7 +48,9 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
-    assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
+    assert list(
+        outdir.rglob("*.md")
+    ), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
 
@@ -79,3 +81,27 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_url_password_is_masked_in_stdout(mock_get, capsys, tmp_path):
+    """Ensure that passwords in URLs are masked when printed to stdout."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    url = "https://user:secretpassword@example.com/api"
+    cli.main(["--url", url, "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+
+    # The password should be masked
+    assert "Processing URL: https://user:***@example.com/api" in outerr.out
+
+    # The actual unmasked password should not appear anywhere in stdout or stderr
+    assert "secretpassword" not in outerr.out
+    assert "secretpassword" not in outerr.err


### PR DESCRIPTION
🎯 **What:** The CLI logged full URLs, including unmasked passwords if they were embedded directly in the input URL scheme (e.g., `https://user:secret@example.com/`). This resulted in sensitive credentials being exposed in the `stdout` logs.
⚠️ **Risk:** If these logs were collected, retained, or reviewed by third parties, unauthorized personnel might gain access to credentials that grant unauthorized access to external domains or systems.
🛡️ **Solution:** Used `urllib.parse` to parse the URL and detect if a `password` attribute is present. If it is, the script now reconstructs the network location (`netloc`) substituting the actual password with `***`, and generates a safe URL for printing. The actual URL sent to the `requests` library for processing remains unaffected. I also added a test in `tests/test_cli_security.py` to ensure this masking behavior works as intended and passwords are not visible in `stdout` or `stderr`.

---
*PR created automatically by Jules for task [16774054062311638638](https://jules.google.com/task/16774054062311638638) started by @badMade*