### PR TITLE
🧹 [Code Health] Move inline imports to module level

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -7,16 +7,26 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
+try:
+    import requests  # type: ignore
+    from markdownify import markdownify as md
+
+    _MISSING_DEP_ERROR = None
+except ImportError as e:
+    requests = None  # type: ignore
+    md = None  # type: ignore
+    _MISSING_DEP_ERROR = e
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
-        prog='html2md',
-        description='Convert HTML URL to Markdown.'
+        prog="html2md", description="Convert HTML URL to Markdown."
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    ap.add_argument("--help-only", action="store_true", help=argparse.SUPPRESS)
+    ap.add_argument("--url", help="Input URL to convert")
+    ap.add_argument("--batch", help="File containing URLs to process (one per line)")
+    ap.add_argument("--outdir", help="Output directory to save the file")
 
     args = ap.parse_args(argv)
 
@@ -25,35 +35,37 @@ def main(argv=None):
         return 0
 
     if args.url or args.batch:
-        try:
-            import requests  # type: ignore  # pylint: disable=import-outside-toplevel
-            from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
-        except ImportError as e:
-            print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+        if _MISSING_DEP_ERROR is not None:
+            print(
+                f"Error: Missing dependency {_MISSING_DEP_ERROR.name}."
+                "Please run: pip install requests markdownify",
+                file=sys.stderr,
+            )
             return 1
 
         session = requests.Session()
-        session.headers.update({
-            'User-Agent': (
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/120.0.0.0 Safari/537.36'
-            ),
-            'Accept': (
-                'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                'image/avif,image/webp,image/apng,*/*;q=0.8'
-            ),
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://www.google.com/',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'cross-site',
-            'Sec-Fetch-User': '?1',
-        })
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,image/apng,*/*;q=0.8"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Referer": "https://www.google.com/",
+                "Connection": "keep-alive",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "cross-site",
+                "Sec-Fetch-User": "?1",
+            }
+        )
 
         outdir_path = None
         real_outdir = None
@@ -61,24 +73,33 @@ def main(argv=None):
             outdir_path = Path(args.outdir)
             try:
                 if outdir_path.exists() and not outdir_path.is_dir():
-                    print(f"Error: --outdir must be a directory: {args.outdir}", file=sys.stderr)
+                    print(
+                        f"Error: --outdir must be a directory: {args.outdir}",
+                        file=sys.stderr,
+                    )
                     return 1
                 outdir_path.mkdir(parents=True, exist_ok=True)
                 real_outdir = outdir_path.resolve()
             except OSError as e:
-                print(f"Error creating output directory '{args.outdir}': {e}", file=sys.stderr)
+                print(
+                    f"Error creating output directory '{args.outdir}': {e}",
+                    file=sys.stderr,
+                )
                 return 1
 
         def process_url(target_url: str) -> int:
             """Process a single URL. Returns 0 on success, 1 on error."""
             # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
+            if "/?" in target_url:
+                target_url = target_url.replace("/?", "?")
 
             parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
+            if parsed.scheme not in ("http", "https"):
+                print(
+                    f"Error: Unsupported URL scheme '{parsed.scheme}'. "
+                    "Only http and https are allowed.",
+                    file=sys.stderr,
+                )
                 return 1
 
             print(f"Processing URL: {target_url}")
@@ -92,8 +113,11 @@ def main(argv=None):
 
                     max_size = 10 * 1024 * 1024
                     try:
-                        if int(response.headers.get('Content-Length', 0)) > max_size:
-                            print(f"Error: Content-Length exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)
+                        if int(response.headers.get("Content-Length", 0)) > max_size:
+                            print(
+                                f"Error: Content-Length exceeds maximum allowed size ({max_size} bytes).",
+                                file=sys.stderr,
+                            )
                             return 1
                     except ValueError:
                         # Invalid or non-numeric Content-Length: treat as unknown size.
@@ -105,14 +129,19 @@ def main(argv=None):
                     for chunk in response.iter_content(chunk_size=8192):
                         total += len(chunk)
                         if total > max_size:
-                            print(f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)
+                            print(
+                                f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).",
+                                file=sys.stderr,
+                            )
                             return 1
                         chunks.append(chunk)
                     content_bytes = b"".join(chunks)
                 finally:
                     response.close()
 
-                encoding = response.encoding if isinstance(response.encoding, str) else "utf-8"
+                encoding = (
+                    response.encoding if isinstance(response.encoding, str) else "utf-8"
+                )
                 html_content = content_bytes.decode(encoding, errors="replace")
 
                 print("Converting to Markdown...")
@@ -121,12 +150,12 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
+                    url_path = target_url.split("?")[0].rstrip("/")
                     if url_path:
                         base = os.path.basename(unquote(url_path))
                         # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
-                        base = base.strip('. ')
+                        base = base.replace("/", "_").replace("\\", "_")
+                        base = base.strip(". ")
                         if base:
                             filename = f"{base}.md"
 
@@ -137,10 +166,12 @@ def main(argv=None):
                         if real_outdir:
                             real_out_path.relative_to(real_outdir)
                     except ValueError:
-                        print("Error: Output path escapes output directory.",
-                              file=sys.stderr)
+                        print(
+                            "Error: Output path escapes output directory.",
+                            file=sys.stderr,
+                        )
                         return 1
-                    with out_path.open('w', encoding='utf-8') as f:
+                    with out_path.open("w", encoding="utf-8") as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
@@ -169,7 +200,7 @@ def main(argv=None):
             if not os.path.exists(args.batch):
                 print(f"Error: Batch file not found: {args.batch}", file=sys.stderr)
                 return 1
-            with open(args.batch, 'r', encoding='utf-8') as f:
+            with open(args.batch, "r", encoding="utf-8") as f:
                 for line in f:
                     u = line.strip()
                     if u:

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -1,4 +1,5 @@
 """Tests for html2md CLI error-handling paths."""
+
 import unittest
 from unittest.mock import patch, MagicMock
 import sys
@@ -7,7 +8,7 @@ import os
 import requests  # type: ignore[import-untyped]
 
 # Ensure src is in path before importing the local package.
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
 import html2md.cli  # pylint: disable=wrong-import-position  # type: ignore[import-untyped]
 
@@ -32,10 +33,12 @@ class TestCliError(unittest.TestCase):
         # Capture stderr
         captured_stderr = io.StringIO()
 
-        with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
-            with patch('sys.stderr', captured_stderr):
+        with patch("html2md.cli.requests", mock_requests), patch(
+            "html2md.cli.md", mock_markdownify.markdownify
+        ):
+            with patch("sys.stderr", captured_stderr):
                 try:
-                    html2md.cli.main(['--url', 'http://example.com'])
+                    html2md.cli.main(["--url", "http://example.com"])
                 except (SystemExit, RuntimeError, ValueError) as e:
                     self.fail(f"main raised exception {e}")
 
@@ -61,10 +64,12 @@ class TestCliError(unittest.TestCase):
 
         captured_stderr = io.StringIO()
 
-        with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
-            with patch('sys.stderr', captured_stderr):
+        with patch("html2md.cli.requests", mock_requests), patch(
+            "html2md.cli.md", mock_markdownify.markdownify
+        ):
+            with patch("sys.stderr", captured_stderr):
                 try:
-                    html2md.cli.main(['--url', 'http://example.com'])
+                    html2md.cli.main(["--url", "http://example.com"])
                 except (SystemExit, RuntimeError, ValueError) as e:
                     self.fail(f"main raised exception {e}")
 
@@ -73,5 +78,6 @@ class TestCliError(unittest.TestCase):
         self.assertIn("Conversion failed", output)
         self.assertIn("Parse error", output)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -1,9 +1,10 @@
 """Tests for html2md CLI exception-handling paths."""
+
 import unittest
 from unittest.mock import patch, MagicMock
 import io
-import requests  # type: ignore[import-untyped]
 from pathlib import Path
+import requests  # type: ignore[import-untyped]
 from html2md.cli import main
 
 
@@ -13,12 +14,12 @@ class TestCliExceptions(unittest.TestCase):
     def test_network_error(self):
         """Test that network errors are caught and printed."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
+        with patch("sys.stderr", captured_stderr):
+            with patch("html2md.cli.requests.Session.get") as mock_get:
                 mock_get.side_effect = requests.RequestException("Network unreachable")
 
                 try:
-                    main(['--url', 'http://example.com'])
+                    main(["--url", "http://example.com"])
                 except (SystemExit, RuntimeError, ValueError) as e:
                     self.fail(f"main raised exception {e}")
 
@@ -29,21 +30,24 @@ class TestCliExceptions(unittest.TestCase):
     def test_file_error(self):
         """Test that file I/O errors are caught and printed."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
+        with patch("sys.stderr", captured_stderr):
+            with patch("html2md.cli.requests.Session.get") as mock_get:
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
                 mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
+                with patch("html2md.cli.md", return_value="# Hello"):
                     with (
-                        patch('pathlib.Path.exists', return_value=False),
-                        patch('pathlib.Path.mkdir'),
-                        patch('pathlib.Path.open', side_effect=OSError("Permission denied")),
+                        patch("pathlib.Path.exists", return_value=False),
+                        patch("pathlib.Path.mkdir"),
+                        patch(
+                            "pathlib.Path.open",
+                            side_effect=OSError("Permission denied"),
+                        ),
                     ):
                         try:
-                            main(['--url', 'http://example.com', '--outdir', 'dummy'])
+                            main(["--url", "http://example.com", "--outdir", "dummy"])
                         except (SystemExit, RuntimeError, ValueError) as e:
                             self.fail(f"main raised exception {e}")
 
@@ -54,12 +58,14 @@ class TestCliExceptions(unittest.TestCase):
     def test_outdir_is_file_returns_error(self):
         """Test that --outdir pointing at an existing file returns a non-zero exit code."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
+        with patch("sys.stderr", captured_stderr):
             with (
-                patch('pathlib.Path.exists', return_value=True),
-                patch('pathlib.Path.is_dir', return_value=False),
+                patch("pathlib.Path.exists", return_value=True),
+                patch("pathlib.Path.is_dir", return_value=False),
             ):
-                result = main(['--url', 'http://example.com', '--outdir', '/tmp/file.txt'])
+                result = main(
+                    ["--url", "http://example.com", "--outdir", "/tmp/file.txt"]
+                )
 
         assert result != 0
         assert "--outdir must be a directory" in captured_stderr.getvalue()
@@ -67,28 +73,38 @@ class TestCliExceptions(unittest.TestCase):
     def test_outdir_containment_uses_path_aware_check(self):
         """Test that output containment check rejects prefix-matching escapes."""
         captured_stderr = io.StringIO()
-        with patch('sys.stderr', captured_stderr):
-            with patch('requests.Session.get') as mock_get:
+        with patch("sys.stderr", captured_stderr):
+            with patch("html2md.cli.requests.Session.get") as mock_get:
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
                 mock_get.return_value = mock_resp
 
-                with patch('markdownify.markdownify', return_value="# Hello"):
+                with patch("html2md.cli.md", return_value="# Hello"):
                     with (
-                        patch('pathlib.Path.exists', return_value=True),
-                        patch('pathlib.Path.is_dir', return_value=True),
-                        patch('pathlib.Path.mkdir'),
+                        patch("pathlib.Path.exists", return_value=True),
+                        patch("pathlib.Path.is_dir", return_value=True),
+                        patch("pathlib.Path.mkdir"),
                     ):
-                        with patch('pathlib.Path.open') as mock_open:
-                            def fake_resolve(path):
-                                if str(path).endswith('.md'):
-                                    return Path('/tmp/outside/a.md')
-                                return Path('/tmp/out')
+                        with patch("pathlib.Path.open") as mock_open:
 
-                            with patch('pathlib.Path.resolve', fake_resolve):
-                                main(['--url', 'http://example.com/a', '--outdir', '/tmp/out'])
+                            def fake_resolve(path):
+                                if str(path).endswith(".md"):
+                                    return Path("/tmp/outside/a.md")
+                                return Path("/tmp/out")
+
+                            with patch("pathlib.Path.resolve", fake_resolve):
+                                main(
+                                    [
+                                        "--url",
+                                        "http://example.com/a",
+                                        "--outdir",
+                                        "/tmp/out",
+                                    ]
+                                )
 
                             output = captured_stderr.getvalue()
-                            self.assertIn("Output path escapes output directory", output)
+                            self.assertIn(
+                                "Output path escapes output directory", output
+                            )
                             mock_open.assert_not_called()


### PR DESCRIPTION
🎯 **What:** Moved `requests` and `markdownify` imports to the top level of `src/html2md/cli.py` while ensuring `--help-only` works if dependencies are missing. Also formatted code with black.
💡 **Why:** Having top-level imports improves code readability and maintainability. Storing missing dependencies in `_MISSING_DEP_ERROR` prevents breaking the CLI arguments.
✅ **Verification:** Handled mock patch updates in `test_cli_error.py` and `test_cli_exceptions.py` to match the new module-level structure. Ran pytest and all tests passed.
✨ **Result:** Clean, top-level imports without breaking the exception behavior.

---
*PR created automatically by Jules for task [5770220435167783285](https://jules.google.com/task/5770220435167783285) started by @badMade*