### PR TITLE
[AI-Assisted] Fix stale/spoofed Jules review dedupe bypass

### DIFF
--- a/.github/workflows/request-jules-review.yml
+++ b/.github/workflows/request-jules-review.yml
@@ -27,6 +27,7 @@ jobs:
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           python - <<'PY'
           from __future__ import annotations
@@ -41,7 +42,11 @@ jobs:
           repo = os.environ["GITHUB_REPOSITORY"]
           pr_number = os.environ["PR_NUMBER"]
           token = os.environ["GITHUB_TOKEN"]
-          review_body = "@jules please review this pull request."
+          pr_head_sha = os.environ["PR_HEAD_SHA"]
+          review_body = (
+              "@jules please review this pull request.\n\n"
+              f"<!-- jules-review-request:{pr_head_sha} -->"
+          )
 
           headers = {
               "Accept": "application/vnd.github+json",
@@ -59,7 +64,11 @@ jobs:
               )
               with urllib.request.urlopen(list_req) as resp:
                   comments = json.loads(resp.read().decode("utf-8"))
-              if any(c["body"].strip() == review_body for c in comments):
+              if any(
+                  c.get("user", {}).get("login") == "github-actions[bot]"
+                  and c.get("body", "").strip() == review_body
+                  for c in comments
+              ):
                   print("Review already requested — skipping duplicate comment.")
                   sys.exit(0)
               if len(comments) < 100:


### PR DESCRIPTION
### Motivation
- Prevent the workflow from skipping a fresh Jules review request on `synchronize` when an old or spoofed comment with a fixed body already exists.

### Description
- Update `.github/workflows/request-jules-review.yml` to add `PR_HEAD_SHA` from `github.event.pull_request.head.sha`, include a hidden marker `<!-- jules-review-request:<sha> -->` in the posted comment body, and tighten duplicate detection to only honor exact matches authored by `github-actions[bot]` so dedupe is scoped to the current commit and cannot be spoofed.

### Testing
- Ran `bash scripts/check_agents_consistency.sh` (passed); attempted `pytest -q` but it could not run in this environment due to missing `pytest`/pyenv mapping (also attempted `python3.12 -m pytest` which failed with `No module named pytest`); agent transcript: https://chatgpt.com/codex

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d30f1ea188320bc46caf9e5faac9d)