### PR TITLE
🛡️ Sentinel: [MEDIUM] Add absolute timeout to prevent Slow-Read DoS during streaming

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2025-05-22 - [Slow-Read DoS during Streaming]
+**Vulnerability:** A Slow-Read DoS vulnerability was identified when using streaming downloads (`requests.get(..., stream=True)` and `response.iter_content`). Although `timeout=30` was set on the request, this only applies to the *socket* timeout (time between bytes) and not the *absolute* time. An attacker could send data very slowly, at a rate just above the socket timeout, keeping the connection open indefinitely and exhausting server/client resources.
+**Learning:** `requests.Session.get` socket timeout does not prevent Slowloris attacks during `iter_content`. When downloading files, particularly un-sized ones or ones from untrusted servers, an absolute timeout is necessary to ensure the application does not hang forever.
+**Prevention:** Track the `start_time = time.time()` before the chunk reading loop, and inside the loop check if `time.time() - start_time > MAX_ALLOWED_TIME`. If it exceeds the time, terminate the connection and error out.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
@@ -102,7 +103,11 @@ def main(argv=None):
 
                     chunks = []
                     total = 0
+                    start_time = time.time()
                     for chunk in response.iter_content(chunk_size=8192):
+                        if time.time() - start_time > 60:
+                            print("Error: Download took too long (exceeded 60 seconds).", file=sys.stderr)
+                            return 1
                         total += len(chunk)
                         if total > max_size:
                             print(f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,31 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+@patch("requests.Session.get")
+@patch("time.time")
+def test_slowloris_timeout_prevention(mock_time, mock_get, capsys, tmp_path):
+    """Ensure that absolute timeout prevents Slow-Read DoS during iter_content."""
+    # Setup mock response
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.headers = {'Content-Length': '100'}
+
+    # iter_content will yield 3 chunks
+    response.iter_content.return_value = [b"chunk1", b"chunk2", b"chunk3"]
+    mock_get.return_value = response
+
+    # Mock time.time() to simulate time passing slowly.
+    # 1st call: start_time (0)
+    # 2nd call: check chunk 1 (10 seconds)
+    # 3rd call: check chunk 2 (70 seconds) -> should trigger timeout!
+    mock_time.side_effect = [0, 10, 70]
+
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    ret = cli.main(["--url", "http://example.com", "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+    assert ret == 1
+    assert "Error: Download took too long (exceeded 60 seconds)." in outerr.err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Slow-Read Denial of Service (DoS) during streaming downloads. While `requests` had `timeout=30`, this only applies to the socket timeout (time between bytes). An attacker could slowly trickle data, bypassing the socket timeout but keeping the connection open indefinitely.
🎯 **Impact:** An attacker could exhaust connection pools or system resources by initiating many downloads that never complete, leading to a Denial of Service.
🔧 **Fix:** Introduced an absolute timeout check inside the `response.iter_content` streaming loop. If the total download time exceeds 60 seconds, the download is aborted and an error is returned.
✅ **Verification:** A test case `test_slowloris_timeout_prevention` was added in `tests/test_cli_security.py` that mocks `time.time` to simulate a slow response and verifies that the download is correctly aborted after 60 seconds. Tests pass successfully.

---
*PR created automatically by Jules for task [5739643282761465705](https://jules.google.com/task/5739643282761465705) started by @badMade*