### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure default host binding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2024-05-28 - Bound Flask app to localhost by default
+**Vulnerability:** The Flask application in `app.py` previously bound to `0.0.0.0` by default when no `HOST` environment variable was provided, potentially exposing the application across all network interfaces instead of restricting it to local loopback.
+**Learning:** Default configurations should always favor local containment and explicit override patterns for public interfaces to prevent unintended external exposure.
+**Prevention:** Hardcode default network bindings to `127.0.0.1` and rely on environment variable configuration for broader exposure when strictly required in deployed environments.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -30,7 +30,8 @@ def get_host_port():
         )
         port_value = DEFAULT_PORT
 
-    hostname = os.environ.get('HOST', '0.0.0.0')
+    # Default to 127.0.0.1 (localhost) to prevent unintended external exposure
+    hostname = os.environ.get('HOST', '127.0.0.1')
     return hostname, port_value
 
 


### PR DESCRIPTION
## 🛡️ Sentinel: [MEDIUM] Fix insecure default host binding

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The default network binding for the Flask application in `app.py` was set to `0.0.0.0`. This means that if run without specific environment variables, the application binds to all available network interfaces.
🎯 **Impact**: Binding to all interfaces can inadvertently expose the service to other users on the local network or internet if firewalls are not strictly configured, creating a risk for unauthorized access.
🔧 **Fix**: Changed the default host value from `0.0.0.0` to `127.0.0.1` (localhost). A comment was also added to document this security decision.
✅ **Verification**: Code analysis (via Bandit) confirmed that `B104:hardcoded_bind_all_interfaces` is no longer flagged in the source code. Tests execute successfully.

---
*PR created automatically by Jules for task [5388192415608683352](https://jules.google.com/task/5388192415608683352) started by @badMade*