### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [MEDIUM] Add security headers to Flask app

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -17,6 +17,17 @@ def health():
     return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['X-XSS-Protection'] = '1; mode=block'
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    response.headers['Content-Security-Policy'] = "default-src 'self'"
+    return response
+
+
 def get_host_port():
     """Get host and port from environment variables."""
     default_port = 10000

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,29 @@
+import pytest
+
+try:
+    import flask
+except ImportError:
+    pytest.skip("flask is not installed", allow_module_level=True)
+
+from html2md.app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_health_endpoint(client):
+    response = client.get('/health')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['status'] == 'ok'
+    assert data['service'] == 'html2md'
+
+def test_security_headers(client):
+    response = client.get('/health')
+    assert response.headers.get('X-Content-Type-Options') == 'nosniff'
+    assert response.headers.get('X-Frame-Options') == 'DENY'
+    assert response.headers.get('X-XSS-Protection') == '1; mode=block'
+    assert response.headers.get('Strict-Transport-Security') == 'max-age=31536000; includeSubDomains'
+    assert "default-src 'self'" in response.headers.get('Content-Security-Policy', '')


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP, etc.) in the Flask application, exposing the app to potential cross-site attacks and MIME sniffing if deployed.
🎯 Impact: Attackers could potentially leverage the lack of security headers in chain attacks, MIME sniffing, or clickjacking on exposed endpoints.
🔧 Fix: Added an `@app.after_request` hook in `app.py` to inject standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`, `Content-Security-Policy`) to all responses.
✅ Verification: Covered by a new test in `tests/test_app.py` which validates the headers are correctly applied. Run `PYTHONPATH=src pytest tests/test_app.py` to confirm.

---
*PR created automatically by Jules for task [12268570286718012852](https://jules.google.com/task/12268570286718012852) started by @badMade*