### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+.venv/

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,16 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add essential security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    response.headers['Content-Security-Policy'] = "default-src 'none'"
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -1,0 +1,18 @@
+"""Security tests for Flask app."""
+import pytest
+from html2md.app import app
+
+@pytest.fixture
+def client():
+    app.testing = True
+    with app.test_client() as client:
+        yield client
+
+def test_security_headers(client):
+    """Test that security headers are present in responses."""
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.headers.get('X-Content-Type-Options') == 'nosniff'
+    assert response.headers.get('X-Frame-Options') == 'DENY'
+    assert response.headers.get('Strict-Transport-Security') == 'max-age=31536000; includeSubDomains'
+    assert "default-src 'none'" in response.headers.get('Content-Security-Policy', '')

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -1,6 +1,7 @@
 """Security tests for Flask app."""
 import pytest
 
+# Skip this test if Flask is not installed (e.g., in core CI environments)
 flask = pytest.importorskip("flask")
 from html2md.app import app
 

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -1,5 +1,7 @@
 """Security tests for Flask app."""
 import pytest
+
+flask = pytest.importorskip("flask")
 from html2md.app import app
 
 @pytest.fixture


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers on Flask endpoints could leave the application open to various risks if exposed over the web (MIME-sniffing, clickjacking, etc).
🎯 Impact: Defense in depth to prevent clickjacking, enforce HTTPS, and restrict resource loading.
🔧 Fix: Added an `@app.after_request` hook to automatically add essential security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`, and `Content-Security-Policy: default-src 'none'`) to all responses.
✅ Verification: Created `tests/test_app_security.py` and ran `pytest tests/test_app_security.py` to verify the headers are present. Run `pytest tests/` to verify no regressions were introduced.

---
*PR created automatically by Jules for task [10680581637880943217](https://jules.google.com/task/10680581637880943217) started by @badMade*