### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS risk in Markdown generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-08 - Prevent XSS in Markdown Output
+**Vulnerability:** The CLI converted HTML to Markdown without stripping potentially dangerous tags (like `<script>`, `<style>`, `<iframe>`, `<object>`, and `<embed>`). While Markdown itself doesn't execute these tags, rendering the resulting Markdown output in an insecure web viewer could lead to Stored XSS if malicious scripts are preserved as plain HTML within the Markdown.
+**Learning:** HTML-to-Markdown conversion can silently pass XSS payloads into the Markdown artifact unless explicitly sanitized. Default conversions often preserve unknown tags or their contents.
+**Prevention:** Explicitly sanitize HTML by decomposing potentially dangerous tags (e.g. using BeautifulSoup) prior to passing the HTML into the markdown converter.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -28,9 +28,10 @@ def main(argv=None):
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
             from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from bs4 import BeautifulSoup  # pylint: disable=import-outside-toplevel
         except ImportError as e:
             print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+                  "Please run: pip install requests markdownify beautifulsoup4", file=sys.stderr)
             return 1
 
         session = requests.Session()
@@ -115,8 +116,15 @@ def main(argv=None):
                 encoding = response.encoding if isinstance(response.encoding, str) else "utf-8"
                 html_content = content_bytes.decode(encoding, errors="replace")
 
+                # Security: Sanitize HTML to prevent XSS payloads in Markdown output
+                print("Sanitizing HTML...")
+                soup = BeautifulSoup(html_content, "html.parser")
+                for tag in soup(["script", "style", "iframe", "object", "embed"]):
+                    tag.decompose()
+                sanitized_html = str(soup)
+
                 print("Converting to Markdown...")
-                md_content = md(html_content, heading_style="ATX")
+                md_content = md(sanitized_html, heading_style="ATX")
 
                 if args.outdir:
                     # Create a safe filename based on the URL


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Stored XSS risk in Markdown generation

🚨 Severity: HIGH
💡 Vulnerability: The CLI converted HTML to Markdown without stripping potentially dangerous tags (like `<script>`, `<style>`, `<iframe>`, `<object>`, and `<embed>`). While Markdown itself doesn't execute these tags, rendering the resulting Markdown output in an insecure web viewer could lead to Stored XSS.
🎯 Impact: An attacker could host a page with malicious `<script>` tags, trick a user into converting it, and if the user renders the resulting Markdown file in a vulnerable viewer, the payload executes.
🔧 Fix: Explicitly parse and sanitize the HTML using BeautifulSoup to decompose dangerous tags prior to Markdown conversion.
✅ Verification: Ran the existing test suite and confirmed successful generation of Markdown without script tags.

---
*PR created automatically by Jules for task [11119162521084126236](https://jules.google.com/task/11119162521084126236) started by @badMade*