### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leakage in URL logging and error messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-18 - Prevented Credential Leaks in URL Logging
+**Vulnerability:** The CLI tool directly logged input URLs to stdout and embedded them in error messages. If a user provided a URL with basic authentication credentials (e.g., `http://admin:secret@example.com/`), the password would be printed to the console or log file, exposing the secret.
+**Learning:** Raw user inputs, particularly URLs, can contain embedded secrets. These must be sanitized before logging or including in exception messages.
+**Prevention:** Always parse and sanitize URLs to mask credentials (e.g., replacing passwords with `***`) before logging them or injecting them into error messages.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -7,6 +7,14 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
+def mask_url_password(url: str) -> str:
+    """Mask the password in a URL if it exists to prevent leaking credentials."""
+    parsed = urlparse(url)
+    if parsed.password:
+        safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+        return parsed._replace(netloc=safe_netloc).geturl()
+    return url
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -81,7 +89,8 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_target_url = mask_url_password(target_url)
+            print(f"Processing URL: {safe_target_url}")
 
             try:
                 print("Fetching content...")
@@ -147,13 +156,22 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                msg = str(e).replace(target_url, safe_target_url)
+                if parsed.password:
+                    msg = msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Network error: {msg}", file=sys.stderr)
                 return 1
             except OSError as e:
-                print(f"File error: {e}", file=sys.stderr)
+                msg = str(e).replace(target_url, safe_target_url)
+                if parsed.password:
+                    msg = msg.replace(f":{parsed.password}@", ":***@")
+                print(f"File error: {msg}", file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                msg = str(e).replace(target_url, safe_target_url)
+                if parsed.password:
+                    msg = msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Conversion failed: {msg}", file=sys.stderr)
                 return 1
 
             return 0


### PR DESCRIPTION
The CLI tool previously logged input URLs to stdout and embedded them in error messages directly. If a user provided a URL with basic authentication credentials (e.g., `http://admin:secret@example.com/`), the password would be leaked to the console or log files. This PR adds a utility function to mask passwords in URLs and updates the logging and exception handling logic to use the sanitized URLs, preventing credential leaks.

---
*PR created automatically by Jules for task [12257904135513286980](https://jules.google.com/task/12257904135513286980) started by @badMade*