### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in URL fetching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-18 - Prevent Server-Side Request Forgery (SSRF) in URL fetching
+**Vulnerability:** The CLI fetched URLs directly without checking if the resolved IP addresses point to internal, private, or loopback network addresses, which allows Server-Side Request Forgery (SSRF).
+**Learning:** In URL fetching utilities, user-provided URLs can resolve to sensitive internal addresses (e.g., localhost, AWS metadata, etc), and following redirects blindly could also lead to similar vulnerabilities.
+**Prevention:** Use `socket.getaddrinfo` to resolve hostnames before making HTTP requests and use `ipaddress` module to block any internal or unroutable IPs. Additionally, disable automatic redirects and manually validate the URL at each redirect step.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -69,6 +69,25 @@ def main(argv=None):
                 print(f"Error creating output directory '{args.outdir}': {e}", file=sys.stderr)
                 return 1
 
+        def _is_safe_url(url: str) -> bool:
+            import socket
+            import ipaddress
+            u = urlparse(url)
+            if not u.hostname:
+                return False
+            try:
+                # Use getaddrinfo to get all IPs (IPv4 and IPv6) and fail closed on resolution errors
+                addr_info = socket.getaddrinfo(u.hostname, None)
+                for item in addr_info:
+                    ip_str = item[4][0]
+                    ip = ipaddress.ip_address(ip_str)
+                    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+                        return False
+            except (socket.gaierror, ValueError):
+                # Fail closed: if we can't resolve it or parse the IP, we assume it's unsafe.
+                return False
+            return True
+
         def process_url(target_url: str) -> int:
             """Process a single URL. Returns 0 on success, 1 on error."""
             # Fix common URL typo: trailing slash before query parameters
@@ -81,12 +100,36 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
+            if not _is_safe_url(target_url):
+                print("Error: URL resolves to a forbidden internal IP address.", file=sys.stderr)
+                return 1
+
             print(f"Processing URL: {target_url}")
 
             try:
                 print("Fetching content...")
                 # Security: Stream response and enforce 10MB limit to prevent DoS (OOM)
-                response = session.get(target_url, timeout=30, stream=True)
+                # Security: Manually handle redirects to prevent SSRF via redirect
+                current_url = target_url
+                for _ in range(10): # Max 10 redirects
+                    response = session.get(current_url, timeout=30, stream=True, allow_redirects=False)
+                    if response.is_redirect is True:
+                        next_url = response.headers.get("Location")
+                        if not next_url:
+                            break
+                        # Resolve relative URLs
+                        from urllib.parse import urljoin
+                        next_url = urljoin(str(current_url), str(next_url))
+                        if not _is_safe_url(next_url):
+                            print("Error: Redirect resolves to a forbidden internal IP address.", file=sys.stderr)
+                            return 1
+                        current_url = next_url
+                        response.close()
+                    else:
+                        break
+                else:
+                    print("Error: Too many redirects.", file=sys.stderr)
+                    return 1
                 try:
                     response.raise_for_status()
 

--- a/tests/test_cli_error.py
+++ b/tests/test_cli_error.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 import sys
 import io
 import os
+import socket
 import requests  # type: ignore[import-untyped]
 
 # Ensure src is in path before importing the local package.
@@ -15,7 +16,8 @@ import html2md.cli  # pylint: disable=wrong-import-position  # type: ignore[impo
 class TestCliError(unittest.TestCase):
     """Unit tests for CLI network and conversion error handling."""
 
-    def test_cli_conversion_request_failure(self):
+    @patch('socket.getaddrinfo', return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))])
+    def test_cli_conversion_request_failure(self, mock_getaddrinfo):
         """Test that requests.get failure is caught and printed."""
 
         # Configure requests mock to fail
@@ -42,7 +44,8 @@ class TestCliError(unittest.TestCase):
         output = captured_stderr.getvalue()
         self.assertIn("Network error", output)
 
-    def test_cli_conversion_markdownify_failure(self):
+    @patch('socket.getaddrinfo', return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))])
+    def test_cli_conversion_markdownify_failure(self, mock_getaddrinfo):
         """Test that markdownify failure is caught and printed."""
 
         mock_requests = MagicMock()
@@ -53,6 +56,7 @@ class TestCliError(unittest.TestCase):
         mock_requests.Session.return_value = mock_session
         mock_response = MagicMock()
         mock_response.text = "<html></html>"
+        mock_response.is_redirect = False
         mock_session.get.return_value = mock_response
 
         mock_markdownify = MagicMock()

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import io
+import socket
 import requests  # type: ignore[import-untyped]
 from pathlib import Path
 from html2md.cli import main
@@ -10,7 +11,8 @@ from html2md.cli import main
 class TestCliExceptions(unittest.TestCase):
     """Unit tests for CLI network, file, and path-containment error handling."""
 
-    def test_network_error(self):
+    @patch('socket.getaddrinfo', return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))])
+    def test_network_error(self, mock_getaddrinfo):
         """Test that network errors are caught and printed."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
@@ -26,7 +28,8 @@ class TestCliExceptions(unittest.TestCase):
                 self.assertIn("Network error", output)
                 self.assertIn("Network unreachable", output)
 
-    def test_file_error(self):
+    @patch('socket.getaddrinfo', return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))])
+    def test_file_error(self, mock_getaddrinfo):
         """Test that file I/O errors are caught and printed."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
@@ -34,6 +37,7 @@ class TestCliExceptions(unittest.TestCase):
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
+                mock_resp.is_redirect = False
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):
@@ -64,7 +68,8 @@ class TestCliExceptions(unittest.TestCase):
         assert result != 0
         assert "--outdir must be a directory" in captured_stderr.getvalue()
 
-    def test_outdir_containment_uses_path_aware_check(self):
+    @patch('socket.getaddrinfo', return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))])
+    def test_outdir_containment_uses_path_aware_check(self, mock_getaddrinfo):
         """Test that output containment check rejects prefix-matching escapes."""
         captured_stderr = io.StringIO()
         with patch('sys.stderr', captured_stderr):
@@ -72,6 +77,7 @@ class TestCliExceptions(unittest.TestCase):
                 mock_resp = MagicMock()
                 mock_resp.text = "<h1>Hello</h1>"
                 mock_resp.status_code = 200
+                mock_resp.is_redirect = False
                 mock_get.return_value = mock_resp
 
                 with patch('markdownify.markdownify', return_value="# Hello"):

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,41 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+@patch('socket.getaddrinfo')
+def test_ssrf_forbidden_ip(mock_getaddrinfo, capsys):
+    """Test that URLs resolving to forbidden internal IPs are rejected."""
+    import socket
+    # Mock resolution to localhost
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80))
+    ]
+
+    ret = cli.main(["--url", "http://example.com/internal-data"])
+    outerr = capsys.readouterr()
+
+    assert ret == 1
+    assert "Error: URL resolves to a forbidden internal IP address." in outerr.err
+
+@patch('socket.getaddrinfo')
+@patch("requests.Session.get")
+def test_ssrf_forbidden_ip_redirect(mock_get, mock_getaddrinfo, capsys):
+    """Test that redirects resolving to forbidden internal IPs are rejected."""
+    import socket
+
+    # First resolve to a safe IP, then to an internal one on redirect
+    mock_getaddrinfo.side_effect = [
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))], # safe
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('169.254.169.254', 80))] # AWS metadata
+    ]
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = True
+    mock_response.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+    mock_get.return_value = mock_response
+
+    ret = cli.main(["--url", "http://example.com"])
+    outerr = capsys.readouterr()
+
+    assert ret == 1
+    assert "Error: Redirect resolves to a forbidden internal IP address." in outerr.err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The CLI fetched URLs directly without checking if the resolved IP addresses point to internal, private, or loopback network addresses, which allows Server-Side Request Forgery (SSRF).
🎯 Impact: Attackers could coerce the CLI into reaching internal application APIs or accessing AWS metadata services, resulting in unauthorized data exposure or internal network probing.
🔧 Fix: Used `socket.getaddrinfo` to resolve hostnames before making HTTP requests, and the `ipaddress` module to reject any internal or unroutable IPs. Additionally, disabled automatic redirects and manually validate the URL at each redirect step. Added automated tests, updated mocks.
✅ Verification: `tests/test_cli_security.py` now includes specific checks that internal IPs throw errors appropriately. All other existing checks passing.

---
*PR created automatically by Jules for task [15625639173999619167](https://jules.google.com/task/15625639173999619167) started by @badMade*