### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Flask application

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2025-03-12 - Missing Security Headers in Flask App
+**Vulnerability:** The Flask application `src/html2md/app.py` was serving responses without essential security headers (e.g., `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security`, `Content-Security-Policy`). This could expose the application to clickjacking, MIME-type sniffing, and other injection attacks if expanded.
+**Learning:** Even internal or simple health endpoints should apply standard security headers, as they can act as vectors for subtle vulnerabilities or might be exposed unintentionally.
+**Prevention:** Apply an `@app.after_request` hook that injects these headers uniformly across all responses.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,16 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    response.headers['Content-Security-Policy'] = "default-src 'none'"
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,37 @@
+"""Tests for the Flask application."""
+
+import pytest
+
+try:
+    from html2md.app import app
+except ImportError:
+    app = None
+
+
+@pytest.mark.skipif(app is None, reason="Flask is not installed")
+def test_health_endpoint():
+    """Test the /health endpoint returns correct JSON and security headers."""
+    client = app.test_client()
+    response = client.get('/health')
+
+    # Check status code
+    assert response.status_code == 200
+
+    # Check JSON body
+    data = response.get_json()
+    assert data is not None
+    assert data.get('status') == 'ok'
+    assert data.get('service') == 'html2md'
+    assert 'version' in data
+
+@pytest.mark.skipif(app is None, reason="Flask is not installed")
+def test_security_headers():
+    """Test that security headers are applied to responses."""
+    client = app.test_client()
+    response = client.get('/health')
+
+    # Check security headers
+    assert response.headers.get('X-Content-Type-Options') == 'nosniff'
+    assert response.headers.get('X-Frame-Options') == 'DENY'
+    assert response.headers.get('Strict-Transport-Security') == 'max-age=31536000; includeSubDomains'
+    assert response.headers.get('Content-Security-Policy') == "default-src 'none'"


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Flask application `src/html2md/app.py` was serving responses without essential security headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`). This could expose the application to clickjacking, MIME-type sniffing, and other injection attacks if expanded.
🎯 **Impact:** Exposes endpoints to browser-based vulnerabilities like MIME sniffing or clickjacking.
🔧 **Fix:** Added an `@app.after_request` hook that injects these standard security headers uniformly across all responses. Included tests to verify the headers.
✅ **Verification:** Verified by running `pytest tests/test_app.py` successfully and observing the headers directly on local GET requests to `/health`.

---
*PR created automatically by Jules for task [14768256684880744731](https://jules.google.com/task/14768256684880744731) started by @badMade*