### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [HIGH] Fix credential leakage in CLI output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-06-13 - Prevent Credential Leakage in CLI Output
+**Vulnerability:** The CLI prints processed URLs and raw exception messages to `stdout`/`stderr` without sanitization. If a user provides a URL containing Basic Authentication credentials (e.g., `http://admin:secret@example.com`), the password is leaked in the console output and logs. Network error messages from `requests` often include the request URL, causing secondary leakage.
+**Learning:** Any user-provided URL or raw exception message from an HTTP client may contain embedded credentials and must be considered sensitive data that should not be exposed in logs or console output.
+**Prevention:** Implement a global string sanitization function (`_sanitize_text`) using regex to redact passwords from URLs (e.g., `http://admin:***@...`) before any output is logged or printed. Apply this to both informational messages and exception strings.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import re
 from pathlib import Path
 from urllib.parse import urlparse, unquote
+
+
+def _sanitize_text(text: str) -> str:
+    """Sanitize text by redacting credentials from URLs."""
+    return re.sub(r'(https?://[^:\s@/]+):([^:\s@/]+)@', r'\1:***@', str(text))
 
 def main(argv=None):
     """Run the CLI."""
@@ -81,7 +87,7 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            print(f"Processing URL: {_sanitize_text(target_url)}")
 
             try:
                 print("Fetching content...")
@@ -147,13 +153,13 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                print(f"Network error: {_sanitize_text(str(e))}", file=sys.stderr)
                 return 1
             except OSError as e:
-                print(f"File error: {e}", file=sys.stderr)
+                print(f"File error: {_sanitize_text(str(e))}", file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                print(f"Conversion failed: {_sanitize_text(str(e))}", file=sys.stderr)
                 return 1
 
             return 0

--- a/tests/test_cli_credential_leak.py
+++ b/tests/test_cli_credential_leak.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+import pytest
+from html2md import cli
+import io
+
+@patch("requests.Session.get")
+def test_cli_redacts_credentials_in_output(mock_get, capsys, tmp_path):
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://admin:secret123@example.com/foo", "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+
+    assert "admin:***@" in outerr.out
+    assert "secret123" not in outerr.out
+
+@patch("requests.Session.get")
+def test_cli_redacts_credentials_in_errors(mock_get, tmp_path, capsys):
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    import requests
+    mock_get.side_effect = requests.RequestException("404 Client Error for url: http://admin:secret123@example.com/foo")
+
+    cli.main(["--url", "http://admin:secret123@example.com/foo", "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+    output = outerr.err
+    assert "admin:***@" in output
+    assert "secret123" not in output


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix credential leakage in CLI output

🚨 Severity: HIGH
💡 Vulnerability: The CLI printed raw URLs and exception messages to `stdout`/`stderr`. This caused URLs containing Basic Authentication credentials (e.g., `http://admin:secret@example.com`) to leak the password in the console output.
🎯 Impact: Passwords could be recorded in terminal histories, CI logs, or application logs, leading to credential exposure.
🔧 Fix: Added a global regex sanitization function (`_sanitize_text`) to redact passwords from printed URLs and exception strings.
✅ Verification: Ran unit tests targeting the new sanitization function for CLI output and error messages.

---
*PR created automatically by Jules for task [9990060674541851549](https://jules.google.com/task/9990060674541851549) started by @badMade*