### PR TITLE
🎨 Palette: Enhance status text accessibility and clear button state

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -116,14 +116,15 @@ $xaml = @"
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Label Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
+            <Label Name="UrlBoxLabel" Content="_Paste URL(s):" Target="{Binding ElementName=UrlBox}" FontSize="14" VerticalAlignment="Bottom"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,0,2">
                 <Button Name="PasteBtn" Content="Pas_te" Height="22" Width="60" Margin="0,0,5,0" ToolTip="Paste from Clipboard"/>
-                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list"/>
+                <Button Name="ClearBtn" Content="Clea_r" Height="22" Width="60" ToolTip="Clear URL list" IsEnabled="False"/>
             </StackPanel>
         </Grid>
 
         <TextBox Name="UrlBox" Grid.Row="1" FontSize="14" Margin="0,5,0,10" AcceptsReturn="True"
+                 AutomationProperties.LabeledBy="{Binding ElementName=UrlBoxLabel}"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Height="80"
                  ToolTip="Enter one or more URLs (one per line)"/>
 
@@ -156,7 +157,7 @@ $xaml = @"
                  TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
 
         <StatusBar Grid.Row="6" Margin="0,10,0,0">
-            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555"/>
+            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555" AutomationProperties.LiveSetting="Polite"/>
         </StatusBar>
     </Grid>
 </Window>
@@ -285,9 +286,11 @@ $UrlBox.Add_TextChanged({
     if ([string]::IsNullOrWhiteSpace($UrlBox.Text)) {
         $ConvertBtn.IsEnabled = $false
         $ConvertBtn.ToolTip = "Please enter at least one URL to enable conversion"
+        $ClearBtn.IsEnabled = $false
     } else {
         $ConvertBtn.IsEnabled = $true
         $ConvertBtn.ToolTip = "Start conversion process"
+        $ClearBtn.IsEnabled = $true
     }
 })
 


### PR DESCRIPTION
💡 What: Added screen reader live setting for the status message and fixed the initial/dynamic state of the Clear button.
🎯 Why: Status updates in TextBlocks are not read automatically by screen readers without `AutomationProperties.LiveSetting`. Also, the Clear button should be disabled when there's nothing to clear to prevent unnecessary actions.
♿ Accessibility: The addition of `LiveSetting="Polite"` enables assistive tech to read the "Ready" and subsequent statuses unobtrusively. Added an explicit `UrlBoxLabel` association for complete screen reader coverage.

---
*PR created automatically by Jules for task [17552568484437080324](https://jules.google.com/task/17552568484437080324) started by @badMade*