### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leakage in URL logging and filename generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-06-16 - Prevent Credential Leakage in URL Logging and File Generation
+**Vulnerability:** The CLI accepted URLs containing Basic Auth credentials (e.g., `http://admin:secret@example.com/`) and directly echoed the raw URL to stdout during processing. Furthermore, when generating an output filename, it split the raw URL by `?`, leaving the credentials intact in the generated filename (e.g., `admin:secret@example.com.md`), writing credentials to the filesystem and potentially exposing them.
+**Learning:** Raw URLs should never be used directly for logging or filename generation, as they may contain embedded sensitive data like credentials.
+**Prevention:** Always parse URLs (e.g., with `urllib.parse.urlparse`) and explicitly extract/sanitize components. Mask `parsed.password` in logs and use `parsed.path` or `parsed.hostname` for generating local resource names.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,15 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            # Security: Prevent credential leakage in logs
+            safe_log_url = target_url
+            if parsed.password:
+                safe_netloc = f"{parsed.username}:***@{parsed.hostname}"
+                if parsed.port:
+                    safe_netloc += f":{parsed.port}"
+                safe_log_url = parsed._replace(netloc=safe_netloc).geturl()
+
+            print(f"Processing URL: {safe_log_url}")
 
             try:
                 print("Fetching content...")
@@ -121,14 +129,19 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
-                    if url_path:
-                        base = os.path.basename(unquote(url_path))
-                        # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
-                        base = base.strip('. ')
-                        if base:
-                            filename = f"{base}.md"
+
+                    # Security: Use parsed components to avoid exposing credentials in filename
+                    path_str = parsed.path.rstrip('/')
+                    if path_str:
+                        base = os.path.basename(unquote(path_str))
+                    else:
+                        base = parsed.hostname or "index"
+
+                    # Sanitize to prevent path traversal
+                    base = base.replace('/', '_').replace('\\', '_')
+                    base = base.strip('. ')
+                    if base:
+                        filename = f"{base}.md"
 
                     out_path = (outdir_path or Path(args.outdir)) / filename
                     # Final safety check: ensure output stays within outdir


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix credential leakage in URL logging and filename generation

🚨 Severity: HIGH
💡 Vulnerability: Basic Auth credentials in URLs (e.g., http://admin:secret@example.com/) were exposed in stdout logs and written to the filesystem as part of the output `.md` filename.
🎯 Impact: Exposed credentials in CI/CD logs, terminal outputs, and local filesystem filenames could allow unauthorized access to authenticated endpoints.
🔧 Fix: Parsed the URL to mask `parsed.password` for logging and extracted the `parsed.path` or `parsed.hostname` for filename generation, preventing raw URL usage.
✅ Verification: Ran `pytest` suite ensuring all tests pass, including CLI security tests. Verified visually that generated filenames use path/host instead of the full credential-bearing URL.

---
*PR created automatically by Jules for task [7550706092379766605](https://jules.google.com/task/7550706092379766605) started by @badMade*