### PR TITLE
[Self-Heal] Implement automated self-healing CI workflow

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -1,0 +1,76 @@
+name: Self-heal (auto-fix & PR)
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  self-heal:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          # Install development dependencies typical for Python projects
+          pip install pytest black
+
+      - name: Run healthcheck (pre-repair)
+        continue-on-error: true
+        run: python scripts/healthcheck.py > selfheal-pre.txt
+
+      - name: Attempt self-heal repairs
+        run: python scripts/self-heal.py > selfheal-repair.txt
+
+      - name: Run healthcheck (post-repair)
+        id: post
+        continue-on-error: true
+        run: python scripts/healthcheck.py > selfheal-post.txt
+
+      - name: Collect logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfheal-logs
+          path: |
+            selfheal-pre.txt
+            selfheal-repair.txt
+            selfheal-post.txt
+
+      - name: Create PR with fixes
+        if: steps.post.outcome == 'success'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: self-healing automated fixes"
+          title: "[Self-Heal] Automated fixes"
+          body: |
+            **Automated PR** created by the self-heal workflow.
+            The `ci` workflow failed, and the repair scripts found fixes that result in a passing healthcheck.
+
+            Please review the attached logs if you need more details.
+          labels: "self-heal"
+          branch: "self-heal-patch"
+          base: main
+          assignees: "@jules"

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Minimal, opinionated healthcheck for a python project:
+   - root: typecheck (mypy - if available)? test (pytest)? lint (black --check)?
+"""
+import subprocess
+import sys
+import os
+
+def run(cmd, env=None):
+    return subprocess.run(cmd, shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+
+def has_tool(name):
+    from shutil import which
+    return which(name) is not None
+
+def try_run(name, cmd):
+    if not cmd:
+        return True
+    print(f"\n==> {name}")
+    print(f"$ {cmd}")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    result = run(cmd, env=env)
+    if result.returncode != 0:
+        print(result.stdout)
+        print(f"[{name}] failed with code {result.returncode}")
+        return False
+    print("OK")
+    return True
+
+def main():
+    success = True
+
+    # Root-level checks
+    if has_tool("black"):
+        success = success and try_run("Format Check (black)", "black --check src tests")
+
+    if has_tool("pytest"):
+        success = success and try_run("Unit tests (pytest)", "pytest -q")
+
+    if not success:
+        sys.exit(1)
+
+    print("\nHealthcheck passed!")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/self-heal.py
+++ b/scripts/self-heal.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Targeted, ordered repairs for a python project. Each step is idempotent and re-runs healthcheck.
+Exit 0 only if a repair produced a passing healthcheck and a non-empty diff.
+"""
+import subprocess
+import sys
+import os
+
+def run(cmd, env=None):
+    print(f"\n$ {cmd}")
+    return subprocess.run(cmd, shell=True, check=False, stdout=sys.stdout, stderr=sys.stderr, text=True, env=env)
+
+def try_run(cmd, env=None):
+    try:
+        result = subprocess.run(cmd, shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+        if result.returncode == 0:
+            print(f"\n$ {cmd} (OK)")
+            return True
+        else:
+            print(f"\n$ {cmd} (Failed with code {result.returncode})")
+            print(result.stdout)
+            return False
+    except Exception as e:
+        print(f"\n$ {cmd} (Error: {e})")
+        return False
+
+def changed():
+    try:
+        out = subprocess.check_output(["git", "status", "--porcelain"], text=True)
+        return len(out.strip()) > 0
+    except Exception:
+        return False
+
+def pass_health():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    try:
+        result = subprocess.run([sys.executable, "scripts/healthcheck.py"], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+        return result.returncode == 0
+    except Exception:
+        return False
+
+def main():
+    fixed = False
+
+    # 1) Format using black
+    print("Attempting to run black for formatting repairs...")
+    try_run("black src tests")
+    if pass_health():
+        fixed = fixed or changed()
+
+    if fixed and pass_health():
+        print("\nSelf-heal successful and healthcheck passes.")
+        sys.exit(0)
+
+    print("\nSelf-heal did not produce a passing healthcheck with diffs.")
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a self-healing automation workflow.

1.  **Added `scripts/healthcheck.py`**: A fast, opinionated python healthcheck that executes `black --check src tests` and `pytest -q` to verify the repository is clean.
2.  **Added `scripts/self-heal.py`**: An automated repair script that attempts to format the repository (`black src tests`). It verifies success by conditionally passing the healthcheck.
3.  **Added `.github/workflows/self-heal.yml`**: A GitHub Action triggered via `workflow_run` specifically when the main CI fails (or manually via `workflow_dispatch`). It runs the healthcheck, executes repairs, and, if successful, opens a PR applying the fixes using the `peter-evans/create-pull-request` action.

---
*PR created automatically by Jules for task [9166467347595154850](https://jules.google.com/task/9166467347595154850) started by @badMade*