### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in URL fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+.venv/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-06-22 - [Critical] SSRF Vulnerability in CLI Fetching Logic
+**Vulnerability:** The CLI fetched URLs using `requests.get()` without verifying if the resolved IP address was internal or private.
+**Learning:** URL fetchers that accept user input are highly susceptible to Server-Side Request Forgery (SSRF) if they don't validate the resolved IP. The `urllib.parse` does not provide IP context, so DNS resolution using `socket.getaddrinfo` paired with `ipaddress.ip_address` to check `is_private`, `is_loopback`, and `is_link_local` properties is required to protect against requests reaching internal services.
+**Prevention:** Implement an IP resolution check *before* passing the URL to the HTTP client (e.g. `requests.get()`).

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -6,6 +6,37 @@ import os
 import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
+import socket
+import ipaddress
+
+def is_safe_url(url: str) -> bool:
+    """Check if the URL resolves to a safe, non-internal IP address to prevent SSRF."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+
+    try:
+        # First try to parse as IP address directly to catch cases like http://127.0.0.1
+        ip_obj = ipaddress.ip_address(hostname.strip("[]"))
+        if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+            return False
+    except ValueError:
+        pass
+
+    try:
+        # Resolve hostname and check all IPs
+        addr_info = socket.getaddrinfo(hostname, None)
+        for res in addr_info:
+            ip = res[4][0]
+            ip_obj = ipaddress.ip_address(ip)
+            if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+                return False
+    except Exception:
+        # If we can't resolve it, it's safer to deny or it will fail anyway
+        return False
+
+    return True
 
 def main(argv=None):
     """Run the CLI."""
@@ -79,6 +110,10 @@ def main(argv=None):
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
+                return 1
+
+            if not is_safe_url(target_url):
+                print(f"Error: The URL resolves to an internal or invalid IP address, which is blocked for security reasons.", file=sys.stderr)
                 return 1
 
             print(f"Processing URL: {target_url}")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -66,6 +66,8 @@ def test_outdir_existing_file_returns_clear_error(capsys, tmp_path):
     assert str(outdir_file) in outerr.err
 
 
+import socket
+
 @patch("requests.Session.get")
 def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tmp_path):
     """Output directory creation failures are reported without a traceback."""
@@ -79,3 +81,41 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+@patch("requests.Session.get")
+def test_ssrf_blocked_urls(mock_get, capsys, tmp_path):
+    """Test that SSRF is prevented by blocking URLs resolving to internal/private IPs."""
+    # Test blocked URLs
+    blocked_urls = [
+        "http://127.0.0.1/",
+        "http://localhost:8080/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://[::1]/",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/"
+    ]
+
+    for url in blocked_urls:
+        ret = cli.main(["--url", url, "--outdir", str(tmp_path)])
+        outerr = capsys.readouterr()
+        assert ret == 1
+        assert "resolves to an internal or invalid IP address" in outerr.err
+        mock_get.assert_not_called()
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_ssrf_allowed_urls(mock_get, mock_getaddrinfo, capsys, tmp_path):
+    """Test that safe external URLs are allowed."""
+    # Mock DNS resolution for external domain to return a public IP
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))
+    ]
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    ret = cli.main(["--url", "http://example.com", "--outdir", str(tmp_path)])
+    assert ret == 0
+    mock_get.assert_called_once()


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `html2md` CLI accepted any arbitrary HTTP/HTTPS URL and resolved it using `requests.get()` without checking if the resolved IP address was internal or private.
🎯 **Impact:** An attacker could use this vulnerability to perform Server-Side Request Forgery (SSRF), probing the internal network, discovering internal services, or retrieving sensitive metadata from services (like AWS EC2 Instance Metadata at `169.254.169.254`).
🔧 **Fix:** Implemented an `is_safe_url` function to validate URLs *before* making the request. It uses `socket.getaddrinfo` to resolve the hostname and checks if any returned IP address matches `is_private`, `is_loopback`, or `is_link_local` via `ipaddress.ip_address`. If it does, the URL fetch is blocked. Tests were also added to ensure this logic works appropriately.
✅ **Verification:** Verified by checking against internal loopback IPs, common private network subnets, and standard link-local ranges, all of which are blocked by the updated tests.

---
*PR created automatically by Jules for task [2749231439878579989](https://jules.google.com/task/2749231439878579989) started by @badMade*