### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Flask app

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2026-06-24 - [MEDIUM] Add security headers to Flask app
+**Vulnerability:** The Flask application was missing standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, `Strict-Transport-Security`), leaving it vulnerable to attacks such as clickjacking and MIME-type sniffing.
+**Learning:** For a minimal API, basic headers provide defense in depth and should be added globally, especially to prevent browser-side exploitation.
+**Prevention:** Implement an `@app.after_request` hook that applies these standard security headers to all responses. Set CSP to `default-src 'none'` for pure API endpoints.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,16 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add standard security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Content-Security-Policy'] = "default-src 'none'"
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -1,0 +1,23 @@
+"""Tests for Flask app security headers."""
+
+import pytest
+pytest.importorskip("flask")
+from html2md.app import app
+
+@pytest.fixture
+def client():
+    """Create a test client for the app."""
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_security_headers(client):
+    """Test that security headers are present on responses."""
+    response = client.get('/health')
+    assert response.status_code == 200
+
+    headers = response.headers
+    assert headers.get('X-Content-Type-Options') == 'nosniff'
+    assert headers.get('X-Frame-Options') == 'DENY'
+    assert headers.get('Content-Security-Policy') == "default-src 'none'"
+    assert headers.get('Strict-Transport-Security') == 'max-age=31536000; includeSubDomains'


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Flask application was missing standard security headers like `X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, and `Strict-Transport-Security`. This makes the application potentially susceptible to MIME sniffing, clickjacking, and XSS if an endpoint inadvertently returns HTML.
🎯 Impact: Without these headers, an attacker could attempt to frame the API, sniff for MIME types, or bypass TLS connections.
🔧 Fix: Added an `@app.after_request` hook in `src/html2md/app.py` to append standard security headers to every response, providing defense-in-depth. Also created `tests/test_app_security.py` to verify their presence.
✅ Verification: Ran `PYTHONPATH=src python -m pytest tests/` to confirm that the health endpoint correctly returns the new security headers.

---
*PR created automatically by Jules for task [2138267030520499325](https://jules.google.com/task/2138267030520499325) started by @badMade*