### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leakage in URL logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2025-02-25 - Credential Leakage in URL Logging
+**Vulnerability:** Passwords embedded in standard URLs (e.g., `https://user:password@example.com/`) were printed to standard output during the fetching initialization phase in the CLI.
+**Learning:** Raw URLs processed from command line inputs or files should be explicitly parsed and sanitized before being outputted, logged, or included in error messages, as users might pass connection strings containing credentials directly.
+**Prevention:** Use standard parsing libraries (like `urllib.parse.urlparse`) to inspect the components of a URL and redact `password` if present (e.g., using `urlparse` and replacing the `netloc` component) before passing the string to any logging or print function.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,12 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+                safe_url = parsed._replace(netloc=safe_netloc).geturl()
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,23 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_process_url_redacts_credentials_in_logs(mock_get, capsys, tmp_path):
+    """Ensure that passwords in URLs are redacted before being printed to stdout."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    url_with_creds = "https://admin:supersecret@example.com/sensitive-data"
+
+    cli.main(["--url", url_with_creds, "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+    assert "admin:***@example.com" in outerr.out
+    assert "supersecret" not in outerr.out


### PR DESCRIPTION
This PR addresses a credential leakage issue where the `html2md` CLI logs input URLs to standard output. If the provided URL contains embedded credentials (e.g., `https://user:password@example.com`), those credentials were included in the CLI's output.

The fix safely identifies and redacts the password from the output log message without affecting the target URL used for the actual web request. A unit test `test_process_url_redacts_credentials_in_logs` is included to prevent regressions.

---
*PR created automatically by Jules for task [17486916941222603560](https://jules.google.com/task/17486916941222603560) started by @badMade*