### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize user input to prevent XSS in Markdown conversion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-06-27 - Added HTML Sanitization Before Markdown Conversion
+**Vulnerability:** The CLI converted fetched HTML into Markdown without first sanitizing malicious elements. Tags like `<script>` or `<style>`, and attributes like `href="javascript:..."` were carried over to the Markdown output. This exposed consumers of the Markdown (like Previewers) to XSS (Cross-Site Scripting) or malicious code execution vectors.
+**Learning:** Even when converting to a simpler format like Markdown, underlying conversion libraries (`markdownify`) may pass through malicious web elements unmodified. Markdown must be treated as a potential execution context if it is rendered later.
+**Prevention:** Always use an HTML parser (like `BeautifulSoup`) to decompose dangerous tags (`script`, `style`, `iframe`, `object`, `embed`) and sanitize dangerous URI schemes (`javascript:`, `vbscript:`, `data:`) *before* invoking format conversion libraries.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -27,10 +27,11 @@ def main(argv=None):
     if args.url or args.batch:
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
+            from bs4 import BeautifulSoup  # pylint: disable=import-outside-toplevel
             from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
         except ImportError as e:
             print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+                  "Please run: pip install requests beautifulsoup4 markdownify", file=sys.stderr)
             return 1
 
         session = requests.Session()
@@ -116,7 +117,18 @@ def main(argv=None):
                 html_content = content_bytes.decode(encoding, errors="replace")
 
                 print("Converting to Markdown...")
-                md_content = md(html_content, heading_style="ATX")
+                # Security: Sanitize HTML to prevent XSS and injection payloads in the Markdown output
+                soup = BeautifulSoup(html_content, "html.parser")
+                for tag in soup(["script", "style", "iframe", "object", "embed"]):
+                    tag.decompose()
+
+                for a in soup.find_all("a", href=True):
+                    href = a["href"].strip().lower()
+                    if href.startswith(("javascript:", "vbscript:", "data:")):
+                        a["href"] = "#"
+
+                clean_html = str(soup)
+                md_content = md(clean_html, heading_style="ATX")
 
                 if args.outdir:
                     # Create a safe filename based on the URL

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -67,6 +67,55 @@ def test_outdir_existing_file_returns_clear_error(capsys, tmp_path):
 
 
 @patch("requests.Session.get")
+def test_xss_sanitization_in_markdown(mock_get, capsys):
+    """Test that malicious HTML tags and hrefs are sanitized to prevent XSS."""
+    response = MagicMock()
+    # Provide HTML with malicious elements
+    response.text = '''
+    <html>
+    <body>
+        <h1>Title</h1>
+        <script>alert("xss1");</script>
+        <a href="javascript:alert('xss2')">Bad Link</a>
+        <a href="  vBscRipT: msgbox('xss3') ">Bad Link 2</a>
+        <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgneHNzNCcpPC9zY3JpcHQ+">Bad Link 3</a>
+        <iframe src="http://evil.com"></iframe>
+        <style>body { background: url('javascript:alert("xss5")'); }</style>
+    </body>
+    </html>
+    '''
+    # We must mock iter_content to return the response text encoded as bytes
+    # because the CLI now streams the response
+    response.iter_content.return_value = [response.text.encode('utf-8')]
+    response.encoding = 'utf-8'
+    response.headers = {'Content-Length': str(len(response.text.encode('utf-8')))}
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    # Call main with a URL, no --outdir to print to stdout
+    ret = cli.main(["--url", "http://example.com"])
+
+    outerr = capsys.readouterr()
+    assert ret == 0
+
+    stdout = outerr.out
+
+    # Assert that malicious payloads are NOT present
+    assert "alert(\"xss1\")" not in stdout
+    assert "javascript:alert('xss2')" not in stdout
+    assert "vBscRipT:" not in stdout
+    assert "data:text" not in stdout
+    assert "evil.com" not in stdout
+    assert "xss5" not in stdout
+
+    # Assert that safe content IS present, and links are neutralized
+    assert "Title" in stdout
+    assert "[Bad Link](#)" in stdout
+    assert "[Bad Link 2](#)" in stdout
+    assert "[Bad Link 3](#)" in stdout
+
+
+@patch("requests.Session.get")
 def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tmp_path):
     """Output directory creation failures are reported without a traceback."""
     outdir = tmp_path / "blocked"


### PR DESCRIPTION
This PR introduces a high-priority security fix to mitigate XSS (Cross-Site Scripting) vulnerabilities when converting arbitrary HTML to Markdown using `markdownify`. Since `markdownify` does not sanitize tags like `<script>`, they could be carried over to the generated Markdown, potentially leading to code execution if the Markdown is rendered later. The fix parses the downloaded HTML with `BeautifulSoup` to explicitly decompose dangerous tags and neutralize malicious links (`javascript:`, `vbscript:`, `data:`) before the Markdown conversion step.

---
*PR created automatically by Jules for task [14763669774085787509](https://jules.google.com/task/14763669774085787509) started by @badMade*