### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leakage in URL logging and error messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-18 - Prevented Credential Leakage in Logs and Error Messages
+**Vulnerability:** The CLI printed raw URLs to stdout during normal execution and to stderr upon network exceptions. URLs containing HTTP Basic Auth credentials (e.g., `http://user:pass@example.com`) leaked plain text passwords to the terminal output and potential CI/CD logs.
+**Learning:** Standard print statements and exception stringification do not automatically sanitize sensitive components of user input.
+**Prevention:** Always parse URLs (e.g., `urllib.parse.urlparse`) and explicitly redact passwords before logging or echoing URLs to standard output or error streams.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,12 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f':{parsed.password}@', ':***@')
+                safe_url = parsed._replace(netloc=safe_netloc).geturl()
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -147,7 +152,10 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                error_msg = str(e)
+                if parsed.password:
+                    error_msg = error_msg.replace(f':{parsed.password}@', ':***@')
+                print(f"Network error: {error_msg}", file=sys.stderr)
                 return 1
             except OSError as e:
                 print(f"File error: {e}", file=sys.stderr)

--- a/tests/test_cli_exceptions.py
+++ b/tests/test_cli_exceptions.py
@@ -26,6 +26,32 @@ class TestCliExceptions(unittest.TestCase):
                 self.assertIn("Network error", output)
                 self.assertIn("Network unreachable", output)
 
+    def test_password_redaction(self):
+        """Test that URLs containing passwords do not expose the password in logs or errors."""
+        captured_stderr = io.StringIO()
+        captured_stdout = io.StringIO()
+
+        with patch('sys.stderr', captured_stderr), patch('sys.stdout', captured_stdout):
+            with patch('requests.Session.get') as mock_get:
+                mock_get.side_effect = requests.RequestException("Failed fetching http://user:secret123@example.com")
+
+                try:
+                    main(['--url', 'http://user:secret123@example.com'])
+                except (SystemExit, RuntimeError, ValueError) as e:
+                    self.fail(f"main raised exception {e}")
+
+                stdout_output = captured_stdout.getvalue()
+                stderr_output = captured_stderr.getvalue()
+
+                # Verify stdout (Processing URL)
+                self.assertIn("Processing URL: http://user:***@example.com", stdout_output)
+                self.assertNotIn("secret123", stdout_output)
+
+                # Verify stderr (Network error)
+                self.assertIn("Network error", stderr_output)
+                self.assertIn("http://user:***@example.com", stderr_output)
+                self.assertNotIn("secret123", stderr_output)
+
     def test_file_error(self):
         """Test that file I/O errors are caught and printed."""
         captured_stderr = io.StringIO()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The CLI printed raw URLs containing HTTP Basic Auth credentials (e.g., `http://user:pass@example.com`) to `stdout` during normal execution and to `stderr` upon network exceptions, leading to plaintext password leakage in terminal output and potential CI/CD logs.
🎯 Impact: Attackers or unauthorized personnel could easily intercept or view credentials from logs or terminal outputs.
🔧 Fix: Parsed URLs using `urllib.parse` and explicitly redacted passwords before logging or echoing URLs to standard output or error streams.
✅ Verification: Ran unit tests using `pytest` ensuring `test_password_redaction` passes correctly.

---
*PR created automatically by Jules for task [15985653385946987283](https://jules.google.com/task/15985653385946987283) started by @badMade*