### PR TITLE
🛡️ Sentinel: [HIGH] Fix URL password leakage in CLI output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,9 @@
 ## 2024-05-08 - Added Request Size Limits to Prevent Denial of Service
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
-**Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
-**Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+**Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since requests.get without stream=True buffers the entire response in memory.
+**Prevention:** Always use stream=True when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2026-07-01 - Prevent URL Password Leak in CLI Output
+**Vulnerability:** URLs containing basic auth credentials (e.g., http://user:password@example.com) leaked the password in plaintext when printed to stdout during processing and stderr during exceptions (requests.RequestException).
+**Learning:** External libraries like 'requests' often embed the target URL in their exception messages. Simply masking the URL in proactive logging is insufficient; all external exception strings that might contain the URL must also be sanitized before printing.
+**Prevention:** Always parse untrusted URLs using urlparse and mask the password property before logging. Catch exceptions from network/fetching libraries and sanitize the exception string if it might contain the credentialed URL.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,11 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_url = target_url.replace(f":{parsed.password}@", ":***@")
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -147,13 +151,19 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                error_msg = str(e)
+                if parsed.password:
+                    error_msg = error_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Network error: {error_msg}", file=sys.stderr)
                 return 1
             except OSError as e:
                 print(f"File error: {e}", file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                error_msg = str(e)
+                if parsed.password:
+                    error_msg = error_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Conversion failed: {error_msg}", file=sys.stderr)
                 return 1
 
             return 0

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,37 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+def test_url_password_is_masked_in_output(capsys):
+    """Ensure that passwords embedded in URLs are not printed to stdout or stderr."""
+    import sys
+
+    class FakeRequestException(Exception):
+        pass
+
+    # We patch requests via sys.modules and mock the session get method
+    mock_requests = MagicMock()
+    mock_requests.RequestException = FakeRequestException
+
+    mock_session = MagicMock()
+    mock_requests.Session.return_value = mock_session
+    mock_session.get.side_effect = FakeRequestException(
+        "Invalid URL 'http://user:supersecret123@example.com/': No schema supplied."
+    )
+
+    mock_markdownify = MagicMock()
+
+    with patch.dict(sys.modules, {'requests': mock_requests, 'markdownify': mock_markdownify}):
+        ret = cli.main(["--url", "http://user:supersecret123@example.com/"])
+
+    outerr = capsys.readouterr()
+    assert ret == 1
+
+    # Ensure stdout doesn't leak it in "Processing URL: ..."
+    assert "supersecret123" not in outerr.out
+    assert "http://user:***@example.com/" in outerr.out
+
+    # Ensure stderr doesn't leak it in exceptions
+    assert "supersecret123" not in outerr.err
+    assert "http://user:***@example.com/" in outerr.err


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix URL password leakage in CLI output

🚨 Severity: HIGH
💡 Vulnerability: Basic auth credentials embedded in URLs (e.g., http://user:secret@example.com) were printed in plaintext to stdout during the "Processing URL" log, and to stderr when network errors or conversion exceptions occurred because requests.RequestException embeds the URL in its message.
🎯 Impact: Passwords and sensitive authentication tokens could leak into console history, CI logs, or user bug reports.
🔧 Fix: Used `urlparse` to identify if the target URL has a password, and replaced the `:{password}@` section with `:***@` in both the standard "Processing URL" output and the string representation of any caught exceptions before printing.
✅ Verification: Added a test `test_url_password_is_masked_in_output` in `tests/test_cli_security.py` that verifies neither stdout nor stderr leaks the actual password. Run `pytest tests/test_cli_security.py` to verify.

---
*PR created automatically by Jules for task [3885815189735945774](https://jules.google.com/task/3885815189735945774) started by @badMade*