### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-07-02 - Added HTTP Security Headers
+**Vulnerability:** Missing security headers on Flask endpoints exposing the app to potential Clickjacking, MIME-sniffing and cross-site scripting (XSS) risks.
+**Learning:** Even simple APIs and diagnostic endpoints like `/health` should implement defense-in-depth measures via standard HTTP response headers to limit exposure.
+**Prevention:** Always implement a global hook (e.g. `@app.after_request`) in Flask applications to inject standard security headers like `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, and `Content-Security-Policy`.

--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,20 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    # Prevent browsers from MIME-sniffing a response away from the declared content-type
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    # Prevent clickjacking by restricting framing
+    response.headers['X-Frame-Options'] = 'DENY'
+    # Require HTTPS connections
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    # Restrict where resources can be loaded from
+    response.headers['Content-Security-Policy'] = "default-src 'self'"
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,27 @@
+"""Tests for the Flask application."""
+import pytest
+
+pytest.importorskip("flask")
+
+from html2md.app import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the app."""
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_security_headers_present(client):
+    """Test that all required security headers are included in the response."""
+    response = client.get("/health")
+
+    assert response.status_code == 200
+
+    headers = response.headers
+    assert headers.get("X-Content-Type-Options") == "nosniff"
+    assert headers.get("X-Frame-Options") == "DENY"
+    assert headers.get("Strict-Transport-Security") == "max-age=31536000; includeSubDomains"
+    assert headers.get("Content-Security-Policy") == "default-src 'self'"


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The Flask application lacked standard HTTP security headers on its endpoints (like `/health`), which could expose it to potential Clickjacking, MIME-sniffing, and cross-site scripting (XSS) risks.
**🎯 Impact:** Without these headers, browsers might execute scripts they shouldn't, allow the app to be framed maliciously, or communicate insecurely, reducing the overall defense-in-depth posture.
**🔧 Fix:** Added a global `@app.after_request` hook that injects `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, and `Content-Security-Policy` headers into all responses.
**✅ Verification:** Added `tests/test_app.py` which verifies that all required security headers are correctly applied when hitting the `/health` endpoint. Run `PYTHONPATH=src pytest tests/test_app.py` to verify.

---
*PR created automatically by Jules for task [5205828692659837501](https://jules.google.com/task/5205828692659837501) started by @badMade*