### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix URL credential leakage in CLI logs and filenames

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2024-05-09 - Prevent URL Credentials from Leaking in Logs and Filenames
+**Vulnerability:** The CLI application processed URLs that could contain basic authentication credentials (e.g., `http://user:password@example.com`). The application printed `print(f"Processing URL: {target_url}")` directly, exposing plaintext passwords to console logs. Furthermore, the auto-generated filename could inadvertently extract the credentials into the `.md` output filename.
+**Learning:** URL manipulation functions like `urllib.parse.urlparse` correctly extract passwords, but the original URL structure may still be used inadvertently for console output and logging.
+**Prevention:** Mask passwords explicitly in logged URLs, and safely reconstruct target URLs for output paths so that credentials are omitted entirely from artifacts.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -7,16 +7,16 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
-        prog='html2md',
-        description='Convert HTML URL to Markdown.'
+        prog="html2md", description="Convert HTML URL to Markdown."
     )
-    ap.add_argument('--help-only', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--url', help='Input URL to convert')
-    ap.add_argument('--batch', help='File containing URLs to process (one per line)')
-    ap.add_argument('--outdir', help='Output directory to save the file')
+    ap.add_argument("--help-only", action="store_true", help=argparse.SUPPRESS)
+    ap.add_argument("--url", help="Input URL to convert")
+    ap.add_argument("--batch", help="File containing URLs to process (one per line)")
+    ap.add_argument("--outdir", help="Output directory to save the file")
 
     args = ap.parse_args(argv)
 
@@ -27,33 +27,40 @@ def main(argv=None):
     if args.url or args.batch:
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
-            from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from markdownify import (
+                markdownify as md,
+            )  # pylint: disable=import-outside-toplevel
         except ImportError as e:
-            print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+            print(
+                f"Error: Missing dependency {e.name}."
+                "Please run: pip install requests markdownify",
+                file=sys.stderr,
+            )
             return 1
 
         session = requests.Session()
-        session.headers.update({
-            'User-Agent': (
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/120.0.0.0 Safari/537.36'
-            ),
-            'Accept': (
-                'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                'image/avif,image/webp,image/apng,*/*;q=0.8'
-            ),
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Referer': 'https://www.google.com/',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'cross-site',
-            'Sec-Fetch-User': '?1',
-        })
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,image/apng,*/*;q=0.8"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Referer": "https://www.google.com/",
+                "Connection": "keep-alive",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "cross-site",
+                "Sec-Fetch-User": "?1",
+            }
+        )
 
         outdir_path = None
         real_outdir = None
@@ -61,27 +68,48 @@ def main(argv=None):
             outdir_path = Path(args.outdir)
             try:
                 if outdir_path.exists() and not outdir_path.is_dir():
-                    print(f"Error: --outdir must be a directory: {args.outdir}", file=sys.stderr)
+                    print(
+                        f"Error: --outdir must be a directory: {args.outdir}",
+                        file=sys.stderr,
+                    )
                     return 1
                 outdir_path.mkdir(parents=True, exist_ok=True)
                 real_outdir = outdir_path.resolve()
             except OSError as e:
-                print(f"Error creating output directory '{args.outdir}': {e}", file=sys.stderr)
+                print(
+                    f"Error creating output directory '{args.outdir}': {e}",
+                    file=sys.stderr,
+                )
                 return 1
 
         def process_url(target_url: str) -> int:
             """Process a single URL. Returns 0 on success, 1 on error."""
             # Fix common URL typo: trailing slash before query parameters
-            if '/?' in target_url:
-                target_url = target_url.replace('/?', '?')
+            if "/?" in target_url:
+                target_url = target_url.replace("/?", "?")
 
             parsed = urlparse(target_url)
-            if parsed.scheme not in ('http', 'https'):
-                print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
-                      "Only http and https are allowed.", file=sys.stderr)
+            if parsed.scheme not in ("http", "https"):
+                print(
+                    f"Error: Unsupported URL scheme '{parsed.scheme}'. "
+                    "Only http and https are allowed.",
+                    file=sys.stderr,
+                )
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            filename_safe_url = target_url
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+                safe_url = parsed._replace(netloc=safe_netloc).geturl()
+
+                # For filename generation, completely remove credentials to avoid '***' in filenames
+                # and to avoid any user info
+                if "@" in parsed.netloc:
+                    clean_netloc = parsed.netloc.split("@", 1)[-1]
+                    filename_safe_url = parsed._replace(netloc=clean_netloc).geturl()
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -92,8 +120,11 @@ def main(argv=None):
 
                     max_size = 10 * 1024 * 1024
                     try:
-                        if int(response.headers.get('Content-Length', 0)) > max_size:
-                            print(f"Error: Content-Length exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)
+                        if int(response.headers.get("Content-Length", 0)) > max_size:
+                            print(
+                                f"Error: Content-Length exceeds maximum allowed size ({max_size} bytes).",
+                                file=sys.stderr,
+                            )
                             return 1
                     except ValueError:
                         # Invalid or non-numeric Content-Length: treat as unknown size.
@@ -105,14 +136,19 @@ def main(argv=None):
                     for chunk in response.iter_content(chunk_size=8192):
                         total += len(chunk)
                         if total > max_size:
-                            print(f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)
+                            print(
+                                f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).",
+                                file=sys.stderr,
+                            )
                             return 1
                         chunks.append(chunk)
                     content_bytes = b"".join(chunks)
                 finally:
                     response.close()
 
-                encoding = response.encoding if isinstance(response.encoding, str) else "utf-8"
+                encoding = (
+                    response.encoding if isinstance(response.encoding, str) else "utf-8"
+                )
                 html_content = content_bytes.decode(encoding, errors="replace")
 
                 print("Converting to Markdown...")
@@ -121,12 +157,23 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
+
+                    # Use filename_safe_url which has credentials completely removed
+                    url_path = filename_safe_url.split("?")[0].rstrip("/")
+
                     if url_path:
-                        base = os.path.basename(unquote(url_path))
+                        # Extract the hostname and path without scheme
+                        try:
+                            safe_parsed = urlparse(url_path)
+                            # Create a clean string from netloc and path, skipping the scheme
+                            clean_path = safe_parsed.netloc + safe_parsed.path
+                        except Exception:
+                            clean_path = url_path
+
+                        base = os.path.basename(unquote(clean_path))
                         # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
-                        base = base.strip('. ')
+                        base = base.replace("/", "_").replace("\\", "_")
+                        base = base.strip(". ")
                         if base:
                             filename = f"{base}.md"
 
@@ -137,10 +184,12 @@ def main(argv=None):
                         if real_outdir:
                             real_out_path.relative_to(real_outdir)
                     except ValueError:
-                        print("Error: Output path escapes output directory.",
-                              file=sys.stderr)
+                        print(
+                            "Error: Output path escapes output directory.",
+                            file=sys.stderr,
+                        )
                         return 1
-                    with out_path.open('w', encoding='utf-8') as f:
+                    with out_path.open("w", encoding="utf-8") as f:
                         f.write(md_content)
                     print(f"Success! Saved to: {out_path}")
                 else:
@@ -169,7 +218,7 @@ def main(argv=None):
             if not os.path.exists(args.batch):
                 print(f"Error: Batch file not found: {args.batch}", file=sys.stderr)
                 return 1
-            with open(args.batch, 'r', encoding='utf-8') as f:
+            with open(args.batch, "r", encoding="utf-8") as f:
                 for line in f:
                     u = line.strip()
                     if u:

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -48,7 +48,9 @@ def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
         assert "Success!" in outerr.out
 
     # Ensure any output files are contained under --outdir.
-    assert list(outdir.rglob("*.md")), "No markdown files were created in the output directory."
+    assert list(
+        outdir.rglob("*.md")
+    ), "No markdown files were created in the output directory."
     assert secret_file.read_text(encoding="utf-8") == "secret content"
     assert not (tmp_path / "secret.txt.md").exists()
 
@@ -79,3 +81,47 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_url_credentials_are_not_leaked(mock_get, capsys, tmp_path):
+    """URLs containing basic auth credentials do not leak them in logs or filenames."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.content = b"<h1>dummy</h1>"
+    response.encoding = "utf-8"
+    response.headers = {"Content-Length": "14"}
+
+    # Mock iter_content to yield chunks correctly
+    response.iter_content = MagicMock(return_value=[b"<h1>dummy</h1>"])
+
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    url = "https://sensitiveuser:supersecretpassword@example.com/sensitive_path"
+    ret = cli.main(["--url", url, "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+
+    assert ret == 0
+
+    # Output should show masked credentials
+    assert (
+        "Processing URL: https://sensitiveuser:***@example.com/sensitive_path"
+        in outerr.out
+    )
+
+    # Ensure credentials are not leaked in standard output except for the masked username
+    # the username 'sensitiveuser' WILL be in the output as 'sensitiveuser:***'
+    assert "supersecretpassword" not in outerr.out
+    assert "supersecretpassword" not in outerr.err
+    assert "sensitiveuser" not in outerr.err
+
+    # Ensure no file contains the credentials in its name
+    for file_path in outdir.rglob("*.md"):
+        assert "sensitiveuser" not in file_path.name
+        assert "supersecretpassword" not in file_path.name
+        assert "example.com" in file_path.name or "sensitive_path" in file_path.name


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Basic authentication credentials (such as passwords) embedded in URLs (e.g. `http://user:pass@example.com`) were printed directly to standard output, leaking plaintext passwords to the console logs. Additionally, auto-generated output filenames based on URLs with credentials could inherit the plaintext passwords.
🎯 Impact: Exposed credentials in CI/CD pipeline logs or user consoles, as well as saved files named with the credentials. This is a severe credential leakage vulnerability.
🔧 Fix: Used `urllib.parse.urlparse` to safely extract and redact credentials from the URL used in the log statements (replaced with `***`). The filename generation logic was completely rewritten to drop the user credentials entirely when deriving output file names.
✅ Verification: Added comprehensive unit test `test_url_credentials_are_not_leaked` in `tests/test_cli_security.py` to assert that standard output, standard error, and created file names do not leak credentials. Tested manually successfully.

---
*PR created automatically by Jules for task [17297789389291275800](https://jules.google.com/task/17297789389291275800) started by @badMade*