### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via DNS resolution checks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2024-05-18 - Added Basic SSRF Protection for CLI URLs
+**Vulnerability:** The CLI fetched remote URLs directly, making it susceptible to Server-Side Request Forgery (SSRF) if deployed in a server environment where users could supply URLs like `http://169.254.169.254` or `http://localhost`.
+**Learning:** Checking the parsed hostname using `socket.gethostbyname` misses IPv6 addresses (e.g., `[::1]`) since it raises a `socket.gaierror`. Using `socket.getaddrinfo` ensures we correctly block IPv6 loopback and private addresses. Even so, this provides a defense-in-depth layer and remains vulnerable to DNS Rebinding TOCTOU since `requests` does its own resolution.
+**Prevention:** Always use `socket.getaddrinfo` instead of `socket.gethostbyname` for validating host IPs, and explicitly reject loopback, link-local, and private addresses.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,6 +81,24 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
+            # Security: SSRF protection on the initial URL
+            if parsed.hostname:
+                import socket
+                import ipaddress
+                try:
+                    # Handle IPv6 properly using getaddrinfo
+                    addr_infos = socket.getaddrinfo(parsed.hostname, None)
+                    for info in addr_infos:
+                        ip = info[4][0]
+                        addr = ipaddress.ip_address(ip)
+                        if addr.is_private or addr.is_loopback or addr.is_link_local:
+                            print(f"Error: Fetching from internal or private IP addresses ({ip}) is not allowed.", file=sys.stderr)
+                            return 1
+                except Exception:
+                    # If DNS resolution fails, let requests handle it (fail open)
+                    # Note: Vulnerable to DNS Rebinding TOCTOU, but adds basic defense-in-depth
+                    pass
+
             print(f"Processing URL: {target_url}")
 
             try:

--- a/test_ipv6.py
+++ b/test_ipv6.py
@@ -1,0 +1,12 @@
+import socket
+import ipaddress
+from urllib.parse import urlparse
+
+url = "http://[::1]/"
+parsed = urlparse(url)
+print(parsed.hostname)
+try:
+    ip = socket.gethostbyname(parsed.hostname)
+    print(ip)
+except Exception as e:
+    print(type(e), e)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -23,6 +23,29 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
     mock_get.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/admin",
+        "http://localhost:8080/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/",
+        "http://[::1]/",
+    ],
+)
+def test_process_url_ssrf_protection(capsys, tmp_path, url):
+    """Internal and private IP addresses are rejected before any network call."""
+    from unittest.mock import MagicMock
+    mock_requests = MagicMock()
+    mock_requests.RequestException = Exception
+
+    with patch.dict("sys.modules", {"requests": mock_requests, "markdownify": MagicMock()}):
+        cli.main(["--url", url, "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert "Error: Fetching from internal or private IP addresses" in outerr.err
+
+
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CLI application fetched URLs without any validation of the target IP address. If deployed in a containerized or server context (e.g. as part of `app.py`), an attacker could provide URLs like `http://169.254.169.254/latest/meta-data/` or `http://localhost:8080` to interact with internal services or metadata endpoints, leading to Server-Side Request Forgery (SSRF).
🎯 **Impact:** Exposes internal metadata, cloud credentials, or local services to attackers.
🔧 **Fix:** Added basic SSRF protection to `src/html2md/cli.py` using `socket.getaddrinfo` to resolve the provided hostname and blocking requests to private, loopback, or link-local IP addresses. This includes checks for both IPv4 and IPv6 to prevent bypasses. Note that this is a defense-in-depth measure and relies on a fail-open behavior on DNS resolution failure, meaning it is partially susceptible to DNS Rebinding TOCTOU.
✅ **Verification:** Added comprehensive tests to `tests/test_cli_security.py` to ensure internal metadata, loopback (IPv4/IPv6), and private network requests are rejected early.

---
*PR created automatically by Jules for task [9510162625200740492](https://jules.google.com/task/9510162625200740492) started by @badMade*