### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize malicious URL schemes to prevent XSS in Markdown

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-18 - Prevented XSS in HTML-to-Markdown Conversion
+**Vulnerability:** Converting HTML to Markdown using `markdownify` does not automatically sanitize dangerous URL schemes in `href` and `src` attributes (e.g., `javascript:`, `vbscript:`, `data:text/html`). This allows XSS payloads to be passed through to the generated Markdown. If the resulting Markdown is rendered in an unsafe viewer, the payloads can execute.
+**Learning:** `markdownify` is a format converter, not an HTML sanitizer. Unsafe content in the HTML will often remain unsafe in the generated Markdown.
+**Prevention:** Pre-parse the HTML using a parser like `BeautifulSoup` and explicitly strip attributes containing dangerous schemes before converting to Markdown.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -28,9 +28,10 @@ def main(argv=None):
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
             from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from bs4 import BeautifulSoup  # type: ignore # pylint: disable=import-outside-toplevel
         except ImportError as e:
             print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+                  "Please run: pip install requests markdownify beautifulsoup4", file=sys.stderr)
             return 1
 
         session = requests.Session()
@@ -114,6 +115,17 @@ def main(argv=None):
 
                 encoding = response.encoding if isinstance(response.encoding, str) else "utf-8"
                 html_content = content_bytes.decode(encoding, errors="replace")
+
+                # Sanitize HTML to prevent XSS via malicious URL schemes in links/images
+                soup = BeautifulSoup(html_content, 'html.parser')
+                for tag in soup.find_all(True):
+                    for attr in ['href', 'src']:
+                        val = tag.get(attr)
+                        if val and isinstance(val, str):
+                            val_lower = val.lower().strip()
+                            if val_lower.startswith(('javascript:', 'vbscript:', 'data:text/html')):
+                                del tag[attr]
+                html_content = str(soup)
 
                 print("Converting to Markdown...")
                 md_content = md(html_content, heading_style="ATX")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,33 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_markdown_xss_sanitization(mock_get, capsys, tmp_path):
+    """Ensure dangerous URL schemes are stripped from links and images before Markdown conversion."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    html_bytes = b'<html><body><a href="javascript:alert(1)">Click</a><img src="vbscript:msgbox(1)"><a href="data:text/html,<script>alert(1)</script>">Data</a><a href="https://example.com">Safe</a></body></html>'
+    response.iter_content.return_value = [html_bytes]
+    response.encoding = 'utf-8'
+    response.headers = {'Content-Length': str(len(html_bytes))}
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://example.com/malicious", "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+    assert "Success!" in outerr.out
+
+    md_files = list(outdir.rglob("*.md"))
+    assert len(md_files) == 1
+    content = md_files[0].read_text(encoding="utf-8")
+
+    # Assert dangerous schemes are stripped
+    assert "javascript:" not in content.lower()
+    assert "vbscript:" not in content.lower()
+    assert "data:text/html" not in content.lower()
+    # Assert safe URLs are preserved
+    assert "https://example.com" in content


### PR DESCRIPTION
**🚨 Severity**: HIGH
**💡 Vulnerability**: The `html2md` CLI fetches remote URLs and directly passes raw HTML content to `markdownify` for conversion. `markdownify` does not sanitize URL schemes for `href` (links) and `src` (images) attributes. This allows a malicious webpage to embed XSS payloads like `javascript:alert(1)`, `vbscript:msgbox(1)`, or `data:text/html,...` which get translated into Markdown format.
**🎯 Impact**: If the resulting Markdown is rendered by a vulnerable Markdown viewer, it can lead to Cross-Site Scripting (XSS).
**🔧 Fix**: Added a pre-processing step using `BeautifulSoup` to find and strip these dangerous attributes from `href` and `src` before converting to Markdown. Added a test to verify the sanitization logic, and updated the `.jules/sentinel.md` journal to document the vulnerability.
**✅ Verification**: Run the tests using `PYTHONPATH=src pytest tests/test_cli_security.py::test_markdown_xss_sanitization`.

---
*PR created automatically by Jules for task [3953498296492708735](https://jules.google.com/task/3953498296492708735) started by @badMade*