### PR TITLE
🎨 Palette: Add LiveSetting to StatusText for screen readers

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -156,7 +156,7 @@ $xaml = @"
                  TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
 
         <StatusBar Grid.Row="6" Margin="0,10,0,0">
-            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555"/>
+            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555" AutomationProperties.LiveSetting="Polite"/>
         </StatusBar>
     </Grid>
 </Window>


### PR DESCRIPTION
💡 **What:** Added `AutomationProperties.LiveSetting="Polite"` to the `StatusText` TextBlock in `gui-url-convert.ps1`.
🎯 **Why:** To ensure that important operational feedback from the GUI status bar is announced unobtrusively by screen readers, improving the accessibility for visually impaired users.
♿ **Accessibility:** This is the WPF/XAML equivalent of adding `aria-live="polite"` in HTML, enabling polite screen reader announcements when the text content updates.

---
*PR created automatically by Jules for task [10030152794754803082](https://jules.google.com/task/10030152794754803082) started by @badMade*