### PR TITLE
🛡️ Sentinel: Add security headers to Flask app

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -11,6 +11,17 @@ DEFAULT_PORT = 10000
 app = Flask(__name__)
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['X-XSS-Protection'] = '1; mode=block'
+    response.headers['Content-Security-Policy'] = "default-src 'self'"
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    return response
+
+
 @app.route('/health')
 def health():
     """Return health status of the application."""

--- a/tests/test_app_security.py
+++ b/tests/test_app_security.py
@@ -1,0 +1,25 @@
+"""Security tests for the Flask application."""
+
+import pytest
+
+try:
+    from html2md.app import app
+except ImportError:
+    app = None
+
+@pytest.mark.skipif(app is None, reason="Flask is not installed")
+def test_security_headers_present():
+    """Test that all required security headers are present in the response."""
+    app.testing = True
+    client = app.test_client()
+
+    response = client.get('/health')
+
+    assert response.status_code == 200
+
+    headers = response.headers
+    assert headers.get('X-Content-Type-Options') == 'nosniff'
+    assert headers.get('X-Frame-Options') == 'DENY'
+    assert headers.get('X-XSS-Protection') == '1; mode=block'
+    assert headers.get('Content-Security-Policy') == "default-src 'self'"
+    assert headers.get('Strict-Transport-Security') == 'max-age=31536000; includeSubDomains'


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: Flask application `src/html2md/app.py` previously lacked security headers, leaving responses potentially susceptible to XSS, clickjacking, and MIME-type sniffing.
🎯 Impact: This change mitigates these common web vulnerabilities by adding strong, standard security headers to all responses.
🔧 Fix: Implemented an `@app.after_request` hook to inject headers such as `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security`, and a strict `Content-Security-Policy`.
✅ Verification: Added a new `pytest` test file (`tests/test_app_security.py`) that successfully verifies these headers are present on the `/health` endpoint.

---
*PR created automatically by Jules for task [15216733091792585400](https://jules.google.com/task/15216733091792585400) started by @badMade*