### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix credential leakage in CLI output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-07-24 - Prevent Credential Leakage in CLI Output
+**Vulnerability:** The CLI printed the target URL directly to stdout during processing, and also logged full exception string representations to stderr. If a user provided a URL with embedded Basic Auth credentials (e.g., `http://user:pass@example.com`), these credentials would be leaked to the terminal and any error logs.
+**Learning:** CLI tools often echo user input or raw exception messages to the console. When handling URLs, this can inadvertently expose embedded secrets. It's critical to sanitize URLs before displaying them or their associated error messages.
+**Prevention:** Apply a robust sanitization function (e.g., using regex to replace `user:pass` in `http://user:pass@...` with `***:***`) to all URLs printed to output and to all exception messages converted to strings before printing.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import re
 from pathlib import Path
 from urllib.parse import urlparse, unquote
+
+
+def _sanitize_text(text: str) -> str:
+    """Mask credentials in URLs to prevent leakage in output."""
+    return re.sub(r"(https?://)[^@/]+@", r"\1***:***@", text)
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -81,7 +88,7 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            print(f"Processing URL: {_sanitize_text(target_url)}")
 
             try:
                 print("Fetching content...")
@@ -147,13 +154,13 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                print(f"Network error: {_sanitize_text(str(e))}", file=sys.stderr)
                 return 1
             except OSError as e:
-                print(f"File error: {e}", file=sys.stderr)
+                print(f"File error: {_sanitize_text(str(e))}", file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                print(f"Conversion failed: {_sanitize_text(str(e))}", file=sys.stderr)
                 return 1
 
             return 0


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The CLI output printed URLs and exception strings directly to stdout/stderr. If a user provided a URL with embedded Basic Auth credentials (e.g., `http://user:pass@example.com`), these credentials would be leaked to the terminal and any error logs.
🎯 Impact: This leakage can lead to unauthorized access and security breaches if logs or console output are exposed.
🔧 Fix: Added a regex-based `_sanitize_text` helper to `src/html2md/cli.py` to mask credentials in URLs before they are printed. Exception strings are also sanitized before being printed in error handlers.
✅ Verification: Ensure the test suite passes using `pytest`. Attempting to convert a URL like `http://user:pass@example.com/` will print `Processing URL: http://***:***@example.com/` instead.

---
*PR created automatically by Jules for task [8301749461668405356](https://jules.google.com/task/8301749461668405356) started by @badMade*