### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [HIGH] Fix URL credential leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-07-25 - Prevent URL Password Leaks in CLI output
+**Vulnerability:** The CLI fetched remote URLs and printed them directly to standard output and exception tracebacks (e.g., standard error). Since it accepted basic auth credentials within the URL (e.g., `http://user:password@example.com`), it leaked sensitive data.
+**Learning:** Never assume URLs are safe to print as-is. They may contain credentials, tokens, or PII. `requests.RequestException` strings and stdout both need sanitization.
+**Prevention:** Use `urllib.parse.urlparse` to identify if `parsed.password` exists, and mask it by replacing the password component before displaying it or logging it.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,11 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_url = safe_url.replace(f":{parsed.password}@", ":***@")
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -147,13 +151,19 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                err_msg = str(e)
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Network error: {err_msg}", file=sys.stderr)
                 return 1
             except OSError as e:
                 print(f"File error: {e}", file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                err_msg = str(e)
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Conversion failed: {err_msg}", file=sys.stderr)
                 return 1
 
             return 0

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,22 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+@patch("requests.Session.get")
+def test_cli_masks_credentials_in_output_and_errors(mock_get, capsys, tmp_path):
+    """Ensure passwords in URLs are masked in standard output and error messages."""
+    import requests
+    mock_get.side_effect = requests.RequestException("Failed to connect to http://user:secret123@example.com/")
+
+    ret = cli.main(["--url", "http://user:secret123@example.com/", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert ret == 1
+
+    # Check that stdout doesn't contain the secret
+    assert "secret123" not in outerr.out
+    assert "http://user:***@example.com/" in outerr.out
+
+    # Check that stderr doesn't contain the secret
+    assert "secret123" not in outerr.err
+    assert "http://user:***@example.com/" in outerr.err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The CLI tool printed raw URLs directly to stdout during normal operation and to stderr during exception handling. When a user provided a URL containing basic authentication credentials (e.g., `http://user:secret123@example.com/`), the password was leaked in plaintext.
🎯 Impact: Attackers or unauthorized users could harvest credentials from shell history, CI logs, or application crash reports.
🔧 Fix: Used `urllib.parse.urlparse` to identify passwords embedded in URLs and mask them (`:***@`) before displaying the "Processing URL:" message or reporting network/conversion exceptions.
✅ Verification: Added an automated test in `tests/test_cli_security.py` to ensure credentials are masked in both standard output and standard error streams.

---
*PR created automatically by Jules for task [5190282075719803099](https://jules.google.com/task/5190282075719803099) started by @badMade*