### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix basic auth password leak in URL logging and filename output

### DIFF
--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,11 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_url = target_url.replace(f":{parsed.password}@", ":***@")
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -123,7 +127,9 @@ def main(argv=None):
                     filename = "conversion_result.md"
                     url_path = target_url.split('?')[0].rstrip('/')
                     if url_path:
-                        base = os.path.basename(unquote(url_path))
+                        # use safe_url to prevent leaking passwords in filename
+                        safe_url_path = safe_url.split('?')[0].rstrip('/')
+                        base = os.path.basename(unquote(safe_url_path))
                         # Sanitize to prevent path traversal
                         base = base.replace('/', '_').replace('\\', '_')
                         base = base.strip('. ')

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -67,6 +67,25 @@ def test_outdir_existing_file_returns_clear_error(capsys, tmp_path):
 
 
 @patch("requests.Session.get")
+def test_cli_masks_passwords_in_url_output(mock_get, capsys, tmp_path):
+    """The CLI must not leak passwords from basic auth URLs in its console output."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://user:supersecretpass@example.com", "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+
+    assert "Processing URL: http://user:***@example.com" in outerr.out
+    assert "supersecretpass" not in outerr.out
+    assert "supersecretpass" not in outerr.err
+
+
+@patch("requests.Session.get")
 def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tmp_path):
     """Output directory creation failures are reported without a traceback."""
     outdir = tmp_path / "blocked"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When passing a URL with basic authentication (e.g. `http://user:password@example.com`), the plaintext password is leaked to stdout during the "Processing URL:" print statement, and could also be leaked in the generated markdown filename.
🎯 Impact: Credentials could be exposed in CI logs, console histories, or filesystem metadata, allowing unauthorized access.
🔧 Fix: Sanitized the URL before printing and filename generation. Used `urllib.parse.urlparse` to identify if a password is set, and masked it with `***` creating a `safe_url`.
✅ Verification: Added `test_cli_masks_passwords_in_url_output` in `tests/test_cli_security.py` to ensure passwords are not printed to `stdout` or `stderr`.

---
*PR created automatically by Jules for task [15248436458530951940](https://jules.google.com/task/15248436458530951940) started by @badMade*