### PR TITLE
⚡ Bolt: Use hash map lookup to optimize duplicate field sanitization in log export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 4. **Fast type checks**: Using `type(rec) is dict` instead of `isinstance(rec, dict)` and `type(value) is str` instead of `isinstance(value, str)` skips subclass checks and is slightly faster in very tight loops.
 
 **Action:** When optimizing data-processing hot loops in Python, first eliminate string allocations (`strip`, `lstrip`), pre-compute list comprehenson iterables to avoid unpacking in the loop, and use `type() is X` for exact type checking instead of `isinstance` if subclassing isn't a concern.
+
+## 2024-11-21 - Optimize Duplicate Column Sanitization with Hash Map
+**Learning:** Found a performance bottleneck in `_unique_fieldnames` where duplicate field handling used an `O(N^2)` while loop `while candidate in used` over a set. For many duplicate fields, this was very slow. Replacing the `set` with a `dict` to store the next expected suffix (e.g., `used[base] = suffix + 1`) turned this into an `O(N)` hash map lookup, yielding a ~13x speedup on benchmarks with many duplicate elements (from ~3.2s to ~0.24s).
+**Action:** When deduplicating strings with numerical suffixes, use a dictionary to keep track of the current maximum suffix for each base string to avoid quadratic collisions, instead of linearly checking `base_1`, `base_2`, etc. against a set.

--- a/src/html2md/log_export.py
+++ b/src/html2md/log_export.py
@@ -1,4 +1,5 @@
 """Export html2md JSONL logs to CSV."""
+
 from __future__ import annotations
 
 import argparse
@@ -14,26 +15,34 @@ def _sanitize_formula(value: str) -> str:
     # Fast path checks before expensive lstrip()
     if not value or value[0] == "'":
         return value
-    if value[0] in _DANGEROUS_PREFIXES or value.lstrip().startswith(_DANGEROUS_PREFIXES):
+    if value[0] in _DANGEROUS_PREFIXES or value.lstrip().startswith(
+        _DANGEROUS_PREFIXES
+    ):
         return f"'{value}"
     return value
 
 
 def _unique_fieldnames(fields: list[str]) -> tuple[list[str], list[tuple[str, str]]]:
     """Return deduplicated/sanitized CSV headers and original->output mapping."""
-    used: set[str] = set()
+    # ⚡ Bolt: Use dict to track suffixes, replacing O(n^2) duplicate collision checks with O(n) hash map lookups
+    used: dict[str, int] = {}
     out_fields: list[str] = []
     mapping: list[tuple[str, str]] = []
 
     for field in fields:
         base = _sanitize_formula(field)
-        candidate = base
-        suffix = 1
-        while candidate in used:
+        if base in used:
+            suffix = used[base]
             candidate = f"{base}_{suffix}"
-            suffix += 1
+            while candidate in used:
+                suffix += 1
+                candidate = f"{base}_{suffix}"
+            used[base] = suffix + 1
+            used[candidate] = 1
+        else:
+            candidate = base
+            used[base] = 1
 
-        used.add(candidate)
         out_fields.append(candidate)
         mapping.append((field, candidate))
 
@@ -52,19 +61,21 @@ def _sanitize_value(value: object) -> object:
 def main(argv=None):
     """Run the log export CLI."""
     ap = argparse.ArgumentParser(
-        prog='html2md-log-export', description='Export html2md JSONL logs to CSV'
+        prog="html2md-log-export", description="Export html2md JSONL logs to CSV"
     )
-    ap.add_argument('--in', dest='inp', required=True)
-    ap.add_argument('--out', dest='out', required=True)
-    ap.add_argument('--fields', default='ts,input,output,status,reason')
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--out", dest="out", required=True)
+    ap.add_argument("--fields", default="ts,input,output,status,reason")
     args = ap.parse_args(argv)
 
-    fields = [f.strip() for f in args.fields.split(',') if f.strip()]
+    fields = [f.strip() for f in args.fields.split(",") if f.strip()]
     fieldnames, mapping = _unique_fieldnames(fields)
 
     inp = Path(args.inp)
     out = Path(args.out)
-    with inp.open('r', encoding='utf-8') as fi, out.open('w', newline='', encoding='utf-8') as fo:
+    with inp.open("r", encoding="utf-8") as fi, out.open(
+        "w", newline="", encoding="utf-8"
+    ) as fo:
         # Optimization: Use csv.writer instead of DictWriter to avoid per-row dictionary overhead
         w = csv.writer(fo)
         w.writerow(fieldnames)
@@ -88,13 +99,10 @@ def main(argv=None):
             if not isinstance(rec, dict):
                 continue
 
-            writerow([
-                sanitize(rec.get(name, ""))
-                for name in input_names
-            ])
+            writerow([sanitize(rec.get(name, "")) for name in input_names])
 
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
💡 **What:** Replaced the `set` used to track duplicate field names in `_unique_fieldnames` with a `dict` that stores the next suffix integer for a base name.
🎯 **Why:** The previous implementation used an inner `while` loop that linearly scanned for the next available suffix. For inputs with many repeating fields (e.g., `["a"] * 50`), this led to $O(N^2)$ quadratic slowdowns.
📊 **Impact:** Reduces time complexity for duplicate field sanitization from $O(N^2)$ to $O(N)$, resulting in a ~13x speedup measured in benchmarks.
🔬 **Measurement:** `python3 bench2.py` showed a decrease from ~3.2s to ~0.24s for 10000 iterations over 50 identical elements. Tests pass, verifying identical CSV formatting behavior.

---
*PR created automatically by Jules for task [4288915099710923221](https://jules.google.com/task/4288915099710923221) started by @badMade*