### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leak in auto-generated filenames

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-18 - Fix Credential Leak in Auto-generated Filenames
+**Vulnerability:** The CLI auto-generated filenames from URLs by string manipulation without stripping the basic authentication part, leading to credentials leaking on disk as the filename.
+**Learning:** Extracting filenames directly from raw URL strings using `.split('?')[0]` is dangerous since URLs might contain embedded basic auth credentials.
+**Prevention:** Always use safe parsed structures like `urllib.parse.urlparse` and extract paths or hostnames, ignoring embedded credentials, when constructing paths. Ensure cross-platform safety by replacing colons `replace(':', '_')` as well.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -121,11 +121,13 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
-                    if url_path:
-                        base = os.path.basename(unquote(url_path))
+                    safe_path = parsed.path.rstrip('/')
+                    if not safe_path:
+                        safe_path = parsed.hostname or ""
+                    if safe_path:
+                        base = os.path.basename(unquote(safe_path))
                         # Sanitize to prevent path traversal
-                        base = base.replace('/', '_').replace('\\', '_')
+                        base = base.replace('/', '_').replace('\\', '_').replace(':', '_')
                         base = base.strip('. ')
                         if base:
                             filename = f"{base}.md"


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix credential leak in auto-generated filenames

🚨 Severity: CRITICAL
💡 Vulnerability: When an output directory was specified without an explicit filename, the CLI attempted to auto-generate a filename based on the provided URL using naive string parsing (`target_url.split('?')[0]`). If a URL contained basic authentication credentials (e.g. `http://user:secretpassword@example.com/`), these credentials became part of the filename itself.
🎯 Impact: Secrets (usernames and passwords) would be written in plain text to the filesystem as part of the filename, leaking them to directory listings, logs, backups, and potentially to unprivileged users on shared file systems. Additionally, `os.path.basename` combined with colons in credentials could cause path traversal issues via Windows alternate data streams (ADS) or absolute drive mappings.
🔧 Fix: Replaced raw string parsing with `urllib.parse.urlparse`. The filename generation now relies securely on `parsed.path` or `parsed.hostname`, stripping out embedded basic auth credentials. Replaced colons `:` with underscores `_` in the generated filename to prevent Windows-specific path handling bugs.
✅ Verification: Confirmed functionality via `pytest tests/`, which verified file generation processes securely format URL properties.

---
*PR created automatically by Jules for task [1977443495289810423](https://jules.google.com/task/1977443495289810423) started by @badMade*