### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix URL credential leakage in logging and filenames

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-08 - Prevent URL Credentials Leakage in Output and Filenames
+**Vulnerability:** HTTP Basic Auth credentials embedded in URLs (e.g., `http://user:pass@example.com`) were leaked to stdout during logging ("Processing URL: ...") and to the local filesystem when the URL was used to construct a default fallback filename (e.g., `user:pass@example.com.md`).
+**Learning:** URL parsing (`urllib.parse`) correctly extracts credentials, but caution must be exercised when reconstructing or logging the URL. Reconstructing `parsed.netloc` while avoiding properties that strip formatting (like IPv6 brackets via `hostname`) or raise exceptions (like non-numeric ports via `port`) is necessary for a robust redaction implementation.
+**Prevention:** Mask sensitive parts of the URL (like passwords) early before they reach any logging, telemetry, or storage functions, ensuring formatting parity across edge cases like IPv6 or invalid ports.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -7,6 +7,32 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
+from urllib.parse import urlunparse
+
+def _redact_url(url: str) -> str:
+    """Redact password from URL if present."""
+    parsed = urlparse(url)
+    if not parsed.password:
+        return url
+
+    # Safely reconstruct netloc preserving formatting, avoiding parsed.port
+    # which can raise ValueError on non-numeric ports, and avoiding
+    # parsed.hostname which strips IPv6 brackets.
+    # Instead, we replace the password substring directly if we know username.
+    netloc = parsed.netloc
+
+    # urlparse puts credentials before '@' in netloc
+    if '@' in netloc:
+        credentials, rest = netloc.split('@', 1)
+        if ':' in credentials:
+            # Safely replace password part
+            username, _ = credentials.split(':', 1)
+            safe_netloc = f"{username}:***@{rest}"
+            parsed = parsed._replace(netloc=safe_netloc)
+
+    return urlunparse(parsed)
+
+
 def main(argv=None):
     """Run the CLI."""
     ap = argparse.ArgumentParser(
@@ -81,7 +107,8 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = _redact_url(target_url)
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -121,7 +148,7 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
+                    url_path = safe_url.split('?')[0].rstrip('/')
                     if url_path:
                         base = os.path.basename(unquote(url_path))
                         # Sanitize to prevent path traversal

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,33 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+def test_url_credentials_redacted_in_stdout_and_filename(capsys, tmp_path):
+    """Ensure passwords in URLs are redacted from stdout and not used in filenames."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    with patch("requests.Session.get") as mock_get:
+        response = MagicMock()
+        response.text = "<h1>dummy</h1>"
+        response.raise_for_status.return_value = None
+        mock_get.return_value = response
+
+        # A URL without a path means the domain is used for the filename,
+        # verifying the password isn't leaked into the filename either.
+        url = "http://user:supersecret@example.com"
+        cli.main(["--url", url, "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+
+    # The password should not be in the output
+    assert "supersecret" not in outerr.out
+    assert "supersecret" not in outerr.err
+
+    # The redacted string should be in the output
+    assert "user:***@example.com" in outerr.out
+
+    # The output filename should not contain the password
+    created_files = list(outdir.glob("*.md"))
+    assert len(created_files) == 1
+    assert "supersecret" not in created_files[0].name


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: HTTP Basic Auth credentials embedded in URLs (e.g., `http://user:pass@example.com`) were leaked to stdout when printing the "Processing URL:" line and potentially leaked to the filesystem as the default filename (e.g. `user:pass@example.com.md`) if a path was not present in the URL.

🎯 **Impact**: A user's plaintext credentials could end up recorded in logs (CI/CD environments, terminal history, etc) or in their local filesystem history.

🔧 **Fix**: Introduced `_redact_url` in the CLI core script to parse the target URL and substitute the password with `***` before printing it to standard output or deriving the markdown filename from it. Care was taken to split and reconstruct the `netloc` directly to avoid stripping IPv6 brackets (from `parsed.hostname`) or raising `ValueError` on malformed ports (from `parsed.port`).

✅ **Verification**: A new test was added in `tests/test_cli_security.py` using a URL with a password to ensure it gets masked as expected on stdout and does not leak into the constructed `.md` file name.

---
*PR created automatically by Jules for task [10469365774118449542](https://jules.google.com/task/10469365774118449542) started by @badMade*