### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix credential leakage in console logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-08-02 - Sanitized URLs to Prevent Credential Leakage in Logs
+**Vulnerability:** The CLI was printing the raw target URL directly to the console (`print(f"Processing URL: {target_url}")`). If a user provided a URL containing basic authentication credentials (e.g., `http://user:pass@example.com`), those credentials would be leaked in standard output.
+**Learning:** URLs often contain sensitive information like basic auth credentials or tokens in the query string. Logging raw URLs without sanitization is a common vector for credential leakage.
+**Prevention:** Always parse untrusted or user-provided URLs and strip or mask sensitive components (like `username` and `password`) before printing or logging them to any output stream. Use `urlunparse` to rebuild a safe display string.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,21 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            # Security: Sanitize basic auth credentials from the printed URL
+            if parsed.username or parsed.password:
+                from urllib.parse import urlunparse
+                safe_netloc = parsed.hostname or ""
+                if parsed.port:
+                    safe_netloc = f"{safe_netloc}:{parsed.port}"
+                safe_netloc = f"***:***@{safe_netloc}"
+                display_url = urlunparse((
+                    parsed.scheme, safe_netloc, parsed.path,
+                    parsed.params, parsed.query, parsed.fragment
+                ))
+            else:
+                display_url = target_url
+
+            print(f"Processing URL: {display_url}")
 
             try:
                 print("Fetching content...")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,34 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_url_credentials_are_sanitized_in_output(mock_get, capsys, tmp_path):
+    """Test that URLs containing credentials do not leak them into stdout."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    # Provide dummy content bytes to avoid decode error in cli.py
+    response.iter_content.return_value = [b"<h1>dummy</h1>"]
+    response.encoding = "utf-8"
+    mock_get.return_value = response
+
+    # Provide a URL with basic auth
+    url = "http://sensitiveuser:supersecretpass@example.com/foo"
+
+    cli.main(["--url", url, "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+
+    # Assert that the sanitized URL is printed
+    assert "Processing URL: http://***:***@example.com/foo" in outerr.out
+
+    # Assert that the credentials are not leaked in stdout or stderr
+    assert "sensitiveuser" not in outerr.out
+    assert "supersecretpass" not in outerr.out
+    assert "sensitiveuser" not in outerr.err
+    assert "supersecretpass" not in outerr.err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The CLI was printing the raw target URL directly to the console during processing. If a user provided a URL containing basic authentication credentials (e.g., `http://user:pass@example.com`), those credentials would be leaked in standard output.
🎯 Impact: Leaked credentials in terminal history or CI/CD logs can be exploited by an attacker to gain unauthorized access to the target system.
🔧 Fix: Used `urlparse` and `urlunparse` to parse the target URL and reconstruct a safe display URL with `***:***` substituted for the username and password before logging.
✅ Verification: Ran the test suite to verify the new test case `test_url_credentials_are_sanitized_in_output` passes successfully and ensures the credentials are not leaked.

---
*PR created automatically by Jules for task [11308394040255846221](https://jules.google.com/task/11308394040255846221) started by @badMade*