### PR TITLE
[AI-Assisted] 🛡️ Sentinel: Add security headers to Flask responses

### DIFF
--- a/src/html2md/app.py
+++ b/src/html2md/app.py
@@ -17,6 +17,16 @@ def health():
     return jsonify({'status': 'ok', 'service': 'html2md', 'version': __version__})
 
 
+@app.after_request
+def add_security_headers(response):
+    """Add security headers to all responses."""
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    response.headers['Content-Security-Policy'] = "default-src 'self'"
+    return response
+
+
 def get_host_port():
     """Get host and port from environment variables."""
     default_port = 10000

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,36 @@
+"""Tests for Flask app."""
+
+import pytest
+
+try:
+    import flask
+    from html2md.app import app
+except ImportError:
+    pytest.skip("flask is not installed", allow_module_level=True)
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the app."""
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_health_endpoint(client):
+    """Test health endpoint returns 200 OK and expected JSON."""
+    response = client.get('/health')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['status'] == 'ok'
+    assert data['service'] == 'html2md'
+    assert 'version' in data
+
+
+def test_security_headers(client):
+    """Test security headers are injected into the response."""
+    response = client.get('/health')
+    assert response.headers.get('X-Content-Type-Options') == 'nosniff'
+    assert response.headers.get('X-Frame-Options') == 'DENY'
+    assert response.headers.get('Strict-Transport-Security') == 'max-age=31536000; includeSubDomains'
+    assert response.headers.get('Content-Security-Policy') == "default-src 'self'"


### PR DESCRIPTION
## Summary
🛡️ Sentinel: Added standard security headers to Flask responses to provide defense-in-depth protection.

## AI Usage
AI agent Jules implemented this feature and corresponding tests. Tools used included bash sessions, git diffs, and file writes.

## Assumptions & Validation
Assumed standard security headers are appropriate for this app. Validated by adding tests for the `/health` endpoint to ensure the headers are present in the response.

## Design Rationale
Used Flask's `@app.after_request` decorator to inject standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`) into all responses globally. This is a standard and effective pattern for Flask applications.

## Testing
Added `tests/test_app.py` to test the `/health` endpoint and verify the injection of the headers.

## Risk & Rollback
Low risk. Applies standard security headers. Rollback plan is to revert this commit.

## Tech Debt (If any)
None.

---
*PR created automatically by Jules for task [15179687235395818818](https://jules.google.com/task/15179687235395818818) started by @badMade*