### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix credential leakage in CLI output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-08 - Prevent Cleartext Credentials in CLI Output
+**Vulnerability:** The CLI printed URLs directly using `target_url`, exposing embedded basic authentication passwords to standard output (CWE-312 / CWE-532).
+**Learning:** Even benign logging can be an exposure vector for sensitive data.
+**Prevention:** Mask any credentials in URLs before passing them to `print()` or logging functions, e.g. using `urllib.parse`.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,11 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+                safe_url = parsed._replace(netloc=safe_netloc).geturl()
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,19 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_cli_masks_passwords_in_output(mock_get, capsys):
+    """Ensure that passwords in URLs are masked in CLI output."""
+    mock_response = MagicMock()
+    mock_response.text = "<h1>Hello</h1>"
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    cli.main(["--url", "http://admin:supersecret@example.com"])
+
+    outerr = capsys.readouterr()
+    assert "http://admin:***@example.com" in outerr.out
+    assert "supersecret" not in outerr.out
+    assert "supersecret" not in outerr.err


### PR DESCRIPTION
Identified and fixed a security vulnerability where HTTP basic authentication credentials embedded in URLs were printed in plaintext to the console during URL processing. Masking is now applied via `urllib.parse` before logging. A security test was added to prevent regressions.

**Severity:** MEDIUM
**Vulnerability:** Cleartext Storage of Sensitive Information (CWE-312) in console output.
**Impact:** Passwords embedded in URLs could be leaked to standard output or CI/CD logs if output is captured.
**Fix:** Mask passwords with `***` using `urllib.parse` before printing the URL in `cli.py`.
**Verification:** Added `test_cli_masks_passwords_in_output` to `tests/test_cli_security.py` and ran it to confirm the plaintext password is no longer output.

---
*PR created automatically by Jules for task [12287737062408448529](https://jules.google.com/task/12287737062408448529) started by @badMade*