### PR TITLE
🛡️ Sentinel: [HIGH] Fix Slow-Read DoS risk in HTTP stream processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2025-02-18 - Prevent Slow-Read DoS in streaming responses
+**Vulnerability:** Slow-Read DoS (Denial of Service) when using requests.get(stream=True) because timeout only applies to connection, not total download.
+**Learning:** Malicious servers can trickle data 1 byte at a time to tie up resources indefinitely.
+**Prevention:** Always implement an absolute timeout check (e.g. comparing time.time() against a limit) inside the chunk reading loop when using stream=True.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
@@ -102,7 +103,11 @@ def main(argv=None):
 
                     chunks = []
                     total = 0
+                    start_time = time.monotonic()
                     for chunk in response.iter_content(chunk_size=8192):
+                        if time.monotonic() - start_time > 120:
+                            print("Error: Download timed out (exceeded 120s limit).", file=sys.stderr)
+                            return 1
                         total += len(chunk)
                         if total > max_size:
                             print(f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,26 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+@patch("time.monotonic")
+def test_slow_read_timeout_prevents_dos(mock_time, mock_get, capsys, tmp_path):
+    """An absolute timeout mitigates a slow-read DoS attack during download."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    # Simulate an infinite stream of 1-byte chunks
+    response.iter_content.return_value = [b"a", b"b", b"c"]
+    mock_get.return_value = response
+
+    # First call sets start_time, second call exceeds the 120s limit
+    mock_time.side_effect = [1000.0, 1121.0]
+
+    ret = cli.main(["--url", "http://example.com/slow", "--outdir", str(outdir)])
+
+    outerr = capsys.readouterr()
+    assert ret == 1
+    assert "Error: Download timed out (exceeded 120s limit)." in outerr.err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Slow-Read DoS (Denial of Service) when using `requests.get(stream=True)`. The timeout parameter in `requests` only applies to the initial connection and the time to first byte, but not the total download time.
🎯 Impact: A malicious server can trickle data 1 byte at a time to tie up resources indefinitely, causing a Denial of Service attack against this tool.
🔧 Fix: Add an absolute timeout check comparing `time.monotonic()` against a 120s limit inside the chunk reading loop when using `stream=True`.
✅ Verification: Ran `pytest tests/` after mocking `time.monotonic` in a new security test to verify the fix correctly aborts the download when exceeded.

Also updated `.jules/sentinel.md` with this critical learning.

---
*PR created automatically by Jules for task [13146379783741390253](https://jules.google.com/task/13146379783741390253) started by @badMade*