### PR TITLE
🛡️ Sentinel: [HIGH] Fix Slowloris DoS vulnerability in file downloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-09 - Added Request Duration Limits to Prevent Slowloris DoS
+**Vulnerability:** The CLI fetched remote URLs directly into memory in chunks, enforcing a total size limit, but without capping the duration of the entire download loop. A malicious or misconfigured server returning data at an extremely slow rate (e.g., 1 byte every 29 seconds) would keep the connection open indefinitely, creating a Denial of Service (DoS) vulnerability via a "Slow Read" or Slowloris attack.
+**Learning:** Limiting response size is insufficient to prevent resource exhaustion. If the response streams indefinitely but very slowly, the connection and associated resources stay occupied. A global timeout on the streaming block is required.
+**Prevention:** Always enforce a strict upper limit on the overall duration of the download, in addition to tracking total byte size limit.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
@@ -102,7 +103,11 @@ def main(argv=None):
 
                     chunks = []
                     total = 0
+                    start_time = time.time()
                     for chunk in response.iter_content(chunk_size=8192):
+                        if time.time() - start_time > 60:
+                            print("Error: Download timeout.", file=sys.stderr)
+                            return 1
                         total += len(chunk)
                         if total > max_size:
                             print(f"Error: Downloaded content exceeds maximum allowed size ({max_size} bytes).", file=sys.stderr)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CLI fetched remote URLs directly into memory in chunks, enforcing a total size limit, but without capping the overall duration of the download loop. A malicious or misconfigured server returning data at an extremely slow rate (e.g., 1 byte every 29 seconds) would keep the connection open indefinitely, creating a Denial of Service (DoS) vulnerability via a "Slow Read" or Slowloris attack.
🎯 **Impact:** An attacker could exhaust local resources or cause the process to hang indefinitely by serving extremely slow responses, blocking further conversions or automated jobs.
🔧 **Fix:** Introduced a strict 60-second limit around the chunked download loop in `src/html2md/cli.py`. If the total streaming duration exceeds this limit, the process correctly bails out and prevents hanging. (Note: The original `session.get` already had a 30-second initial timeout, but this did not cover the overall chunk streaming phase.)
✅ **Verification:** Run `python -m pytest tests/` to confirm no regressions are introduced.
📝 **Sentinel Learning:** Added journal entry detailing the necessity of enforcing duration limits in addition to byte size constraints during streaming data processing to prevent Slowloris resource exhaustion attacks.

---
*PR created automatically by Jules for task [11867848069257325173](https://jules.google.com/task/11867848069257325173) started by @badMade*