### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leak in URL logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2024-08-09 - Masked Passwords in Basic Auth URLs
+**Vulnerability:** The CLI leaked Basic Authentication credentials by logging the raw URL to stdout during execution and embedding the raw URL in stringified exceptions printed to stderr upon network/file failure.
+**Learning:** Python's standard `print()` combined with `urllib` representations don't automatically sanitize embedded credentials. Always manually sanitize input strings that reflect URLs if there is any possibility they contain credentials (e.g. `http://user:pass@example.com`).
+**Prevention:** Use `urllib.parse.urlparse` to identify if a password exists in a URL and manually obscure it via `url.replace(f":{parsed.password}@", ":***@")` before logging, storing, or returning it in error messages.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,11 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_url = target_url
+            if parsed.password:
+                safe_url = target_url.replace(f":{parsed.password}@", ":***@")
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")
@@ -121,9 +125,9 @@ def main(argv=None):
                 if args.outdir:
                     # Create a safe filename based on the URL
                     filename = "conversion_result.md"
-                    url_path = target_url.split('?')[0].rstrip('/')
-                    if url_path:
-                        base = os.path.basename(unquote(url_path))
+                    safe_url_path = safe_url.split('?')[0].rstrip('/')
+                    if safe_url_path:
+                        base = os.path.basename(unquote(safe_url_path))
                         # Sanitize to prevent path traversal
                         base = base.replace('/', '_').replace('\\', '_')
                         base = base.strip('. ')
@@ -147,13 +151,22 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                err_msg = str(e)
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Network error: {err_msg}", file=sys.stderr)
                 return 1
             except OSError as e:
-                print(f"File error: {e}", file=sys.stderr)
+                err_msg = str(e)
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"File error: {err_msg}", file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                err_msg = str(e)
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(f"Conversion failed: {err_msg}", file=sys.stderr)
                 return 1
 
             return 0

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -67,6 +67,43 @@ def test_outdir_existing_file_returns_clear_error(capsys, tmp_path):
 
 
 @patch("requests.Session.get")
+def test_cli_masks_passwords_in_url_output(mock_get, capsys, tmp_path):
+    """The CLI must not leak passwords from basic auth URLs in its console output."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    cli.main(["--url", "http://user:supersecretpass@example.com", "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+
+    assert "Processing URL: http://user:***@example.com" in outerr.out
+    assert "supersecretpass" not in outerr.out
+    assert "supersecretpass" not in outerr.err
+
+
+@patch("requests.Session.get")
+def test_cli_masks_passwords_in_network_error(mock_get, capsys):
+    """The CLI must not leak passwords in error messages when network requests fail."""
+    import requests
+    mock_get.side_effect = requests.RequestException(
+        "Max retries exceeded with url: http://user:supersecretpass@example.com/"
+    )
+
+    cli.main(["--url", "http://user:supersecretpass@example.com/"])
+    outerr = capsys.readouterr()
+
+    assert "Processing URL: http://user:***@example.com" in outerr.out
+    assert "Network error:" in outerr.err
+    assert "http://user:***@example.com/" in outerr.err
+    assert "supersecretpass" not in outerr.out
+    assert "supersecretpass" not in outerr.err
+
+
+@patch("requests.Session.get")
 def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tmp_path):
     """Output directory creation failures are reported without a traceback."""
     outdir = tmp_path / "blocked"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Basic Authentication credentials embedded in URLs (e.g., http://user:pass@host) were leaked to stdout in normal execution and stderr during network/OS exception handling.
🎯 Impact: Passwords could be persisted to CI/CD logs, terminal history, or system log files.
🔧 Fix: Utilized `urlparse` to identify if a password exists in the URL, and securely string replaced the password with `***` for safe stdout and stderr printing. Filename derivations also use the masked URL.
✅ Verification: Created unit tests `test_cli_masks_passwords_in_url_output` and `test_cli_masks_passwords_in_network_error` in `test_cli_security.py` verifying no password leakage.

---
*PR created automatically by Jules for task [8696492592437345433](https://jules.google.com/task/8696492592437345433) started by @badMade*