### PR TITLE
🛡️ Sentinel: [HIGH] Fix Server-Side Request Forgery (SSRF) vulnerability in CLI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-08-11 - Fixed SSRF vulnerability in the URL processing CLI
+**Vulnerability:** The `html2md` CLI accepted URLs and fetched them using `requests.get` without checking if the resolved IP address belonged to a private, loopback, or link-local range. This creates a Server-Side Request Forgery (SSRF) vulnerability.
+**Learning:** Even simple CLI fetching tools are susceptible to SSRF if the inputs are not validated. Internal endpoints such as AWS Metadata (169.254.169.254) or localhost API servers could be queried.
+**Prevention:** Always extract the hostname from user-provided URLs and validate the resolved IP address against restricted IP ranges (like loopback, private, and link-local) before performing network requests.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -2,10 +2,36 @@
 
 from __future__ import annotations
 import argparse
+import ipaddress
 import os
+import socket
 import sys
 from pathlib import Path
 from urllib.parse import urlparse, unquote
+
+def _is_internal_url(url: str) -> bool:
+    """Check if the URL resolves to a local or private network address."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+        if ip.is_loopback or ip.is_private or ip.is_link_local:
+            return True
+    except ValueError:
+        pass
+
+    try:
+        ip_str = socket.gethostbyname(hostname)
+        ip = ipaddress.ip_address(ip_str)
+        if ip.is_loopback or ip.is_private or ip.is_link_local:
+            return True
+    except (socket.gaierror, ValueError):
+        pass
+
+    return False
 
 def main(argv=None):
     """Run the CLI."""
@@ -79,6 +105,10 @@ def main(argv=None):
             if parsed.scheme not in ('http', 'https'):
                 print(f"Error: Unsupported URL scheme '{parsed.scheme}'. "
                       "Only http and https are allowed.", file=sys.stderr)
+                return 1
+
+            if _is_internal_url(target_url):
+                print(f"Security Error: URL resolves to a local or private network address (SSRF protection).", file=sys.stderr)
                 return 1
 
             print(f"Processing URL: {target_url}")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -23,6 +23,25 @@ def test_process_url_unsupported_scheme(mock_get, capsys, tmp_path, url, scheme)
     mock_get.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "https://localhost/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/admin",
+        "http://192.168.1.1/",
+    ],
+)
+@patch("requests.Session.get")
+def test_process_url_blocks_ssrf(mock_get, capsys, tmp_path, url):
+    """Local and private IP addresses are rejected before any network call to prevent SSRF."""
+    cli.main(["--url", url, "--outdir", str(tmp_path)])
+    outerr = capsys.readouterr()
+    assert "Security Error: URL resolves to a local or private network address (SSRF protection)." in outerr.err
+    mock_get.assert_not_called()
+
+
 @patch("requests.Session.get")
 def test_traversal_like_paths_stay_within_outdir(mock_get, capsys, tmp_path):
     """Traversal-like URL paths must never write outside of --outdir."""


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CLI was fetching URLs using `requests.Session.get()` without checking if the domain resolved to an internal, private, or loopback network IP address. 
🎯 **Impact:** A malicious actor could provide a URL (like `http://127.0.0.1` or `http://169.254.169.254`) that resolves to an internal service or AWS metadata endpoint, allowing them to access restricted data through the server running the CLI.
🔧 **Fix:** Added a `_is_internal_url` verification check that extracts the hostname, resolves it using `socket`, and blocks the network request if the IP matches a loopback, link-local, or private address using the `ipaddress` library.
✅ **Verification:** Added `test_process_url_blocks_ssrf` to `tests/test_cli_security.py` verifying that known internal/private IP payloads are blocked before any network call happens. Tests are passing correctly.

---
*PR created automatically by Jules for task [393861878700111283](https://jules.google.com/task/393861878700111283) started by @badMade*