### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix credential leakage in URL logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2024-03-22 - Credential Leak in URL Logging
+**Vulnerability:** The CLI was printing the target URL directly using `print(f"Processing URL: {target_url}")` before fetching it. If a user provided a URL with embedded credentials (e.g., `http://user:pass@example.com`), those credentials would be printed in plain text to the console, risking exposure in logs or terminal history.
+**Learning:** Always treat user-provided URLs as potentially containing sensitive data. Logging or printing raw URLs without sanitization can inadvertently leak credentials.
+**Prevention:** Use URL parsing libraries (like `urllib.parse.urlparse`) to inspect and sanitize URLs, stripping out `username` and `password` components before logging or displaying them.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,13 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            # Prevent credential leakage in logs
+            safe_url = target_url
+            if parsed.username or parsed.password:
+                safe_netloc = parsed.netloc.split('@')[-1]
+                safe_url = parsed._replace(netloc=safe_netloc).geturl()
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")


### PR DESCRIPTION
Addresses a potential security issue where URLs with embedded authentication credentials were printed in plain text, causing a risk of credentials leaking into logs or terminal histories. The URL parsing library is now used to properly mask credentials prior to printing the URL in the CLI.

---
*PR created automatically by Jules for task [12139552321072783986](https://jules.google.com/task/12139552321072783986) started by @badMade*