### PR TITLE
🎨 Palette: Make status text accessible for screen readers

### DIFF
--- a/gui-url-convert.ps1
+++ b/gui-url-convert.ps1
@@ -156,7 +156,7 @@ $xaml = @"
                  TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutomationProperties.Name="Log Output"/>
 
         <StatusBar Grid.Row="6" Margin="0,10,0,0">
-            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555"/>
+            <TextBlock Name="StatusText" Text="Ready" Foreground="#555555" AutomationProperties.LiveSetting="Polite"/>
         </StatusBar>
     </Grid>
 </Window>


### PR DESCRIPTION
💡 **What**: Added `AutomationProperties.LiveSetting="Polite"` to the `StatusText` TextBlock in `gui-url-convert.ps1`.
🎯 **Why**: Previously, status text updates (e.g., "Conversion started in a new console") were not announced to screen readers, causing non-sighted users to miss important operational feedback.
♿ **Accessibility**: This change ensures that screen readers dynamically announce these updates (akin to `aria-live="polite"` on the web) while keeping visual styling unchanged.

---
*PR created automatically by Jules for task [6665420161656664352](https://jules.google.com/task/6665420161656664352) started by @badMade*