### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [MEDIUM] Fix URL password leak in CLI outputs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2025-02-27 - Prevent URL Password Leakage in CLI Tools
+**Vulnerability:** The CLI printed out raw input URLs in its logging and exception messages, exposing basic authentication passwords when URLs like `https://user:password123@example.com` were processed.
+**Learning:** URL components (particularly credentials like `username:password`) are often overlooked when logging or printing raw input strings, causing sensitive data to be exposed in CI/CD logs, terminals, or exception traces.
+**Prevention:** Always parse and sanitize URLs (e.g., using `urllib.parse`) to mask or remove password fields before displaying or logging them, even in error handling logic.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from urllib.parse import urlparse, unquote
+from urllib.parse import urlparse, unquote, urlunparse
 
 def main(argv=None):
     """Run the CLI."""
@@ -81,7 +81,12 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            safe_target_url = target_url
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+                safe_target_url = urlunparse(parsed._replace(netloc=safe_netloc))
+
+            print(f"Processing URL: {safe_target_url}")
 
             try:
                 print("Fetching content...")
@@ -147,13 +152,22 @@ def main(argv=None):
                     print(md_content)
 
             except requests.RequestException as e:
-                print(f"Network error: {e}", file=sys.stderr)
+                err_msg = f"Network error: {e}"
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(err_msg, file=sys.stderr)
                 return 1
             except OSError as e:
-                print(f"File error: {e}", file=sys.stderr)
+                err_msg = f"File error: {e}"
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(err_msg, file=sys.stderr)
                 return 1
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Conversion failed: {e}", file=sys.stderr)
+                err_msg = f"Conversion failed: {e}"
+                if parsed.password:
+                    err_msg = err_msg.replace(f":{parsed.password}@", ":***@")
+                print(err_msg, file=sys.stderr)
                 return 1
 
             return 0


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The CLI prints the raw input URL during processing and exception handling. If the URL contains basic authentication credentials (e.g., `https://user:password123@example.com`), the password is leaked in plaintext to standard output or standard error (which may end up in logs or CI/CD pipelines).
🎯 **Impact:** Sensitive credentials could be exposed to unauthorized parties who have access to the CLI output or logs.
🔧 **Fix:** Added safe URL handling in `src/html2md/cli.py`. Before printing the target URL or error messages, the code now checks if `parsed.password` is present and replaces `:{password}@` with `:***@`.
✅ **Verification:** Run the CLI against a URL with a password, and observe that it prints `***` instead of the password. Also tested by forcing an exception and verifying the error message masks the password.

Original Claude Chat URL: <CLAUDE_CHAT_URL>

---
*PR created automatically by Jules for task [5162594193287390327](https://jules.google.com/task/5162594193287390327) started by @badMade*