### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Markdown generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2025-02-28 - Added XSS Mitigation for Rendered Markdown
+**Vulnerability:** The CLI fetched remote HTML pages and directly converted their content to Markdown using `markdownify`, preserving potentially malicious URL schemes like `javascript:`, `vbscript:`, and `data:` in `href` and `src` attributes. When the generated Markdown is rendered by standard Markdown viewers, these payloads could execute Cross-Site Scripting (XSS).
+**Learning:** Tools that convert external HTML to Markdown must sanitize the HTML before conversion, as Markdown renderers often trust the underlying schemes for links and images. An attacker controlling a page being converted could inject persistent XSS into the generated Markdown document.
+**Prevention:** Ensure that links and images with dangerous schemes (`javascript:`, `vbscript:`, `data:`) are sanitized out (replaced with safe fallbacks or removed) using a parser (e.g., `BeautifulSoup`) prior to Markdown conversion.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -28,9 +28,10 @@ def main(argv=None):
         try:
             import requests  # type: ignore  # pylint: disable=import-outside-toplevel
             from markdownify import markdownify as md  # pylint: disable=import-outside-toplevel
+            from bs4 import BeautifulSoup  # type: ignore  # pylint: disable=import-outside-toplevel
         except ImportError as e:
             print(f"Error: Missing dependency {e.name}."
-                  "Please run: pip install requests markdownify", file=sys.stderr)
+                  "Please run: pip install requests markdownify beautifulsoup4", file=sys.stderr)
             return 1
 
         session = requests.Session()
@@ -116,7 +117,19 @@ def main(argv=None):
                 html_content = content_bytes.decode(encoding, errors="replace")
 
                 print("Converting to Markdown...")
-                md_content = md(html_content, heading_style="ATX")
+                # Security: Sanitize dangerous schemes to prevent XSS in Markdown rendering
+                soup = BeautifulSoup(html_content, 'html.parser')
+                for tag in soup.find_all(['a', 'img']):
+                    if tag.name == 'a' and tag.has_attr('href'):
+                        href = tag['href'].strip().lower()
+                        if href.startswith(('javascript:', 'vbscript:', 'data:')):
+                            tag['href'] = '#'
+                    elif tag.name == 'img' and tag.has_attr('src'):
+                        src = tag['src'].strip().lower()
+                        if src.startswith(('javascript:', 'vbscript:', 'data:')):
+                            tag['src'] = ''
+
+                md_content = md(str(soup), heading_style="ATX")
 
                 if args.outdir:
                     # Create a safe filename based on the URL

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,46 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_xss_mitigation_sanitizes_dangerous_schemes(mock_get, capsys):
+    """Dangerous URL schemes in links and images should be sanitized to prevent XSS."""
+    html_content = '''
+        <html><body>
+            <a href="javascript:alert(1)">XSS Link</a>
+            <a href=" vbscript:msgbox(1)">VBScript Link</a>
+            <a href="DATA:text/html,<script>alert(1)</script>">Data Link</a>
+            <a href="https://example.com">Safe Link</a>
+            <img src="javascript:alert(1)" alt="XSS Image">
+            <img src="https://example.com/image.png" alt="Safe Image">
+        </body></html>
+    '''
+
+    response = MagicMock()
+    # Mocking iter_content and Content-Length to pass size checks
+    response.iter_content.return_value = [html_content.encode("utf-8")]
+    response.headers = {'Content-Length': str(len(html_content))}
+    response.encoding = "utf-8"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    ret = cli.main(["--url", "http://example.com"])
+
+    assert ret == 0
+    outerr = capsys.readouterr()
+    output = outerr.out
+
+    # Check that dangerous links are sanitized to '#'
+    assert "[XSS Link](#)" in output
+    assert "[VBScript Link](#)" in output
+    assert "[Data Link](#)" in output
+
+    # Check that safe link is preserved
+    assert "[Safe Link](https://example.com)" in output
+
+    # Check that dangerous image src is removed/empty
+    assert "![XSS Image]()" in output
+
+    # Check that safe image is preserved
+    assert "![Safe Image](https://example.com/image.png)" in output


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CLI fetches remote HTML pages and directly converts them to Markdown using `markdownify`. Malicious URL schemes such as `javascript:`, `vbscript:`, and `data:` in `href` and `src` attributes are preserved in the generated Markdown.
🎯 **Impact:** If a user renders the resulting Markdown in a standard Markdown viewer, the persistent payloads can be executed, leading to Cross-Site Scripting (XSS). An attacker can host a malicious webpage, convince a user to convert it, and achieve code execution when the output is viewed.
🔧 **Fix:** Added a pre-processing step using `BeautifulSoup` to sanitize dangerous URL schemes in `<a>` and `<img>` tags by replacing them with `#` or an empty string, before performing the Markdown conversion.
✅ **Verification:** Verified by a new suite of mock tests targeting uppercase schemes, padded schemes, and VBScript payloads. Added an entry to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [1454464254131119249](https://jules.google.com/task/1454464254131119249) started by @badMade*