### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [HIGH] Fix Server-Side Request Forgery (SSRF)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-08-21 - Added SSRF Protection
+**Vulnerability:** The CLI fetched remote URLs using `requests.Session().get()` which allows fetching from private network space (like localhost, AWS metadata endpoints, etc).
+**Learning:** `requests` will follow redirects, which can bypass simple upfront hostname checks. A malicious server can return a 302 redirect to a local or internal IP address, turning the CLI into a proxy for Server-Side Request Forgery (SSRF).
+**Prevention:** Always perform IP resolution (e.g. `socket.gethostbyname`) and check against restricted ranges (e.g. `ipaddress.is_private`) *before* every single request in a redirect chain by handling redirects manually with `allow_redirects=False`.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -5,7 +5,37 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from urllib.parse import urlparse, unquote
+from urllib.parse import urlparse, unquote, urljoin
+import socket
+import ipaddress
+
+def _is_internal_url(url: str) -> bool:
+    """Check if the URL resolves to an internal/private IP address."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            return True
+
+        # Use getaddrinfo to support both IPv4 and IPv6
+        addr_info = socket.getaddrinfo(hostname, None)
+
+        # Check all resolved IP addresses to prevent bypass
+        for res in addr_info:
+            ip_addr = res[4][0]
+            ip = ipaddress.ip_address(ip_addr)
+            if (ip.is_private or ip.is_loopback or
+                ip.is_link_local or ip.is_multicast or
+                ip.is_reserved or ip.is_unspecified):
+                return True
+
+        return False
+    except OSError:
+        # If DNS resolution fails or other OS error, it's safer to block
+        return True
+    except ValueError:
+        return True
+
 
 def main(argv=None):
     """Run the CLI."""
@@ -85,8 +115,35 @@ def main(argv=None):
 
             try:
                 print("Fetching content...")
+
+                # Security: Prevent SSRF by validating the URL and handling redirects manually
+                current_url = target_url
+                max_redirects = 5
+                response = None
+
+                for _ in range(max_redirects + 1):
+                    if _is_internal_url(current_url):
+                        print(f"Error: Refusing to fetch internal or unresolvable URL: {current_url}", file=sys.stderr)
+                        return 1
+
+                    response = session.get(current_url, timeout=30, stream=True, allow_redirects=False)
+
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get('Location')
+                        if not location:
+                            print("Error: Redirect without Location header.", file=sys.stderr)
+                            response.close()
+                            return 1
+                        current_url = urljoin(current_url, location)
+                        response.close()
+                        continue
+
+                    break
+                else:
+                    print(f"Error: Too many redirects (>{max_redirects}).", file=sys.stderr)
+                    return 1
+
                 # Security: Stream response and enforce 10MB limit to prevent DoS (OOM)
-                response = session.get(target_url, timeout=30, stream=True)
                 try:
                     response.raise_for_status()
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 import pytest
+import socket
 
 from html2md import cli
 
@@ -79,3 +80,54 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "url, mock_ip",
+    [
+        ("http://localhost:8080/admin", "127.0.0.1"),
+        ("http://127.0.0.1/admin", "127.0.0.1"),
+        ("http://169.254.169.254/latest/meta-data/", "169.254.169.254"),
+        ("http://internal.company.com/secret", "10.0.0.1"),
+    ],
+)
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_ssrf_direct_internal_url(mock_get, mock_getaddr, capsys, tmp_path, url, mock_ip):
+    """Direct requests to internal or loopback IP addresses are blocked."""
+    mock_getaddr.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (mock_ip, 0))]
+
+    ret = cli.main(["--url", url, "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert ret == 1
+    assert "Refusing to fetch internal or unresolvable URL" in outerr.err
+    mock_get.assert_not_called()
+
+
+@patch("socket.getaddrinfo")
+@patch("requests.Session.get")
+def test_ssrf_redirect_to_internal(mock_get, mock_getaddr, capsys, tmp_path):
+    """Redirects to internal or loopback IP addresses are blocked."""
+    import socket
+    # First host resolves to public IP, second to private IP
+    def getaddr_side_effect(hostname, *args, **kwargs):
+        if hostname == "public.example.com":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ("93.184.216.34", 0))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ("169.254.169.254", 0))]
+    mock_getaddr.side_effect = getaddr_side_effect
+
+    # Mock the redirect response
+    redirect_response = MagicMock()
+    redirect_response.status_code = 302
+    redirect_response.headers = {'Location': 'http://169.254.169.254/meta-data'}
+
+    # Since requests.Session.get is called with allow_redirects=False, it just returns the 302
+    mock_get.return_value = redirect_response
+
+    ret = cli.main(["--url", "http://public.example.com/redirect", "--outdir", str(tmp_path)])
+
+    outerr = capsys.readouterr()
+    assert ret == 1
+    assert "Refusing to fetch internal or unresolvable URL" in outerr.err
+    assert mock_get.call_count == 1


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF). The CLI fetched URLs using `requests.Session().get()`, which follows redirects by default. A malicious server could return a 302 redirect to an internal IP (like AWS metadata, localhost, etc.), bypassing basic URL checks.
🎯 Impact: An attacker could use this CLI tool as a proxy to access internal network resources or cloud metadata services that are otherwise unreachable.
🔧 Fix: Added a pre-fetch DNS resolution and IP validation check (`socket.getaddrinfo` and `ipaddress`). Prevented `requests` from following redirects automatically (`allow_redirects=False`) and manually handled redirects to ensure the IP check is enforced at every hop.
✅ Verification: Added unit tests in `tests/test_cli_security.py` that mock the `socket.getaddrinfo` resolution and verify both direct hits and redirects to internal addresses are blocked.

---
*PR created automatically by Jules for task [14923915489926720047](https://jules.google.com/task/14923915489926720047) started by @badMade*