### PR TITLE
🛡️ Sentinel: [CRITICAL] Mask basic auth passwords in logged URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-18 - Mask Basic Auth Passwords in Logs
+**Vulnerability:** The CLI prints the full, raw target URL to stdout when processing. If the URL contains basic authentication credentials (e.g., `https://user:password@example.com`), the password is leaked to terminal output or CI logs.
+**Learning:** Raw inputs containing connection strings, URLs, or other connection details often embed credentials. Directly logging these variables without sanitization is a common credential exposure vector.
+**Prevention:** Always parse URLs (e.g., using `urllib.parse.urlparse`) and replace sensitive components like `.password` with mask characters (e.g., `***`) before printing or logging them.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,16 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            from urllib.parse import urlunparse
+
+            # Security: Mask basic auth passwords to prevent credential leakage in logs
+            if parsed.password:
+                safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+                safe_url = urlunparse(parsed._replace(netloc=safe_netloc))
+            else:
+                safe_url = target_url
+
+            print(f"Processing URL: {safe_url}")
 
             try:
                 print("Fetching content...")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The CLI printed raw URLs containing basic auth passwords (e.g. `https://user:pass@example.com`) to stdout, potentially leaking credentials to terminal history or CI logs.
🎯 Impact: An attacker could harvest credentials from exposed logs if the tool is used to process protected internal resources.
🔧 Fix: Parsed the URL and explicitly masked the `.password` field with `***` before logging. Added security comments.
✅ Verification: Passwords are no longer visible in output. `pytest tests/` passes.

---
*PR created automatically by Jules for task [4414391551749971971](https://jules.google.com/task/4414391551749971971) started by @badMade*