### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix shell=True usage in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+.venv

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2024-05-08 - Added Request Size Limits to Prevent Denial of Service
-**Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
-**Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
-**Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+## 2024-05-18 - CLI Subprocess Injection Risk
+**Vulnerability:** Smoke test uses `shell=True` with `subprocess.run` to execute command. Although current inputs are static, this is a dangerous pattern that can lead to command injection if test parameters change or if the pattern is copied to production code.
+**Learning:** Python PR rules explicitly forbid `subprocess` calls with `shell=True` and unsanitized user input. Tests should be held to the same standard to prevent bad copy-pasting.
+**Prevention:** Avoid `shell=True` when running commands via `subprocess`, even in tests.

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -4,8 +4,8 @@ import os
 import subprocess
 import sys
 
-def run(cmd):
-    """Run a shell command."""
+def run(cmd_list):
+    """Run a shell command safely without shell=True."""
     env = os.environ.copy()
     # Ensure src is in PYTHONPATH if not already set or installed
     src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))
@@ -14,13 +14,15 @@ def run(cmd):
     else:
         env["PYTHONPATH"] = src_path
 
+    # Security: shell=True is removed to prevent command injection.
+    # Commands must be passed as a list of arguments.
     return subprocess.run(
-        cmd, capture_output=True, text=True, shell=True, check=False, env=env
+        cmd_list, capture_output=True, text=True, check=False, env=env
     )
 
 
 def test_help_runs():
     """Test that help command runs successfully."""
     # Use python -m html2md to ensure tests pass even if package is not installed globally
-    r = run(f"{sys.executable} -m html2md --help")
+    r = run([sys.executable, "-m", "html2md", "--help"])
     assert r.returncode == 0, r.stderr


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The test `tests/test_cli_smoke.py` used `subprocess.run` with `shell=True`. While inputs were hardcoded, this establishes a dangerous pattern that can lead to command injection if the test is modified to accept dynamic inputs.
🎯 Impact: Prevents potential command injection if test parameters change and ensures tests follow the same security standards as production code.
🔧 Fix: Removed `shell=True` and changed the command execution to use a list of arguments rather than a single formatted string.
✅ Verification: Ran `pytest` locally and ensured the smoke test still passes.

---
*PR created automatically by Jules for task [14507579973787055960](https://jules.google.com/task/14507579973787055960) started by @badMade*