### PR TITLE
[AI-Assisted] 🛡️ Sentinel: [HIGH] Fix credential leakage in CLI URL output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The CLI fetched remote URLs directly into memory without any size constraints. A malicious or misconfigured server returning a multi-gigabyte HTML response would cause an Out of Memory (OOM) error, creating a Denial of Service (DoS) vulnerability.
 **Learning:** Even simple CLI fetch tools are susceptible to resource exhaustion attacks if response sizes are unbounded, especially since `requests.get` without `stream=True` buffers the entire response in memory.
 **Prevention:** Always use `stream=True` when downloading untrusted resources, and enforce a strict upper limit on downloaded bytes.
+
+## 2024-05-24 - Prevent Credential Leakage in CLI Tool Output
+**Vulnerability:** The CLI tool logged the full requested URL, which can inadvertently contain inline HTTP basic authentication credentials (e.g. `http://user:password@example.com/`). This would leak passwords directly into standard output, terminal histories, and CI run logs.
+**Learning:** Any tool that handles user-provided or config-provided URLs must sanitize or mask those URLs before printing them to the console or log files. Simple string replacement or ignoring the issue relies on user perfection, which is fragile.
+**Prevention:** Use standard URL parsing libraries (like `urllib.parse`) to detect password components in URLs and proactively mask them (e.g. `user:***@example.com`) before any diagnostic printing or logging occurs.

--- a/src/html2md/cli.py
+++ b/src/html2md/cli.py
@@ -81,7 +81,14 @@ def main(argv=None):
                       "Only http and https are allowed.", file=sys.stderr)
                 return 1
 
-            print(f"Processing URL: {target_url}")
+            display_url = target_url
+            if parsed.password:
+                host_info = parsed.netloc.rsplit('@', 1)[-1]
+                user_info = parsed.username or ''
+                masked_netloc = f"{user_info}:***@{host_info}"
+                display_url = parsed._replace(netloc=masked_netloc).geturl()
+
+            print(f"Processing URL: {display_url}")
 
             try:
                 print("Fetching content...")

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -79,3 +79,31 @@ def test_outdir_creation_failure_returns_error_before_fetch(mock_get, capsys, tm
     assert "Error creating output directory" in outerr.err
     assert "Permission denied" in outerr.err
     mock_get.assert_not_called()
+
+
+@patch("requests.Session.get")
+def test_url_password_is_masked_in_output(mock_get, capsys, tmp_path):
+    """Passwords in URLs must be masked in standard output to prevent credential leakage."""
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    response = MagicMock()
+    response.text = "<h1>dummy</h1>"
+    response.raise_for_status.return_value = None
+    mock_get.return_value = response
+
+    url_with_password = "http://user:secretp%40ssword@example.com/foo"
+
+    cli.main(["--url", url_with_password, "--outdir", str(outdir)])
+    outerr = capsys.readouterr()
+
+    # Assert output has masked password
+    assert "Processing URL: http://user:***@example.com/foo" in outerr.out
+
+    # Assert password is NOT leaked in output
+    assert "secretp%40ssword" not in outerr.out
+    assert "secretp%40ssword" not in outerr.err
+
+    # Assert the actual request still used the unmasked URL
+    mock_get.assert_called_once()
+    assert mock_get.call_args[0][0] == url_with_password


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The CLI tool logged the full requested URL, inadvertently leaking HTTP basic auth passwords to stdout and logs.
🎯 Impact: Attackers could harvest credentials from terminal history or CI logs.
🔧 Fix: Sanitize URLs using `urllib.parse` before printing, masking passwords (e.g., `user:***@host`).
✅ Verification: Ran unit tests.

---
*PR created automatically by Jules for task [1244201715722053703](https://jules.google.com/task/1244201715722053703) started by @badMade*